### PR TITLE
Multiprocess connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ops Droid
 
-[![Build Status](https://travis-ci.org/opsdroid/opsdroid.svg?branch=master)](https://travis-ci.org/opsdroid/opsdroid) [![Coverage Status](https://coveralls.io/repos/github/opsdroid/opsdroid/badge.svg?branch=master)](https://coveralls.io/github/opsdroid/opsdroid?branch=master)
+[![Build Status](https://travis-ci.org/opsdroid/opsdroid.svg?branch=master)](https://travis-ci.org/opsdroid/opsdroid) [![Coverage Status](https://coveralls.io/repos/github/opsdroid/opsdroid/badge.svg?branch=master)](https://coveralls.io/github/opsdroid/opsdroid?branch=master) [![Docker Image](https://img.shields.io/badge/docker-ready-blue.svg)](https://hub.docker.com/r/opsdroid/opsdroid/) [![Documentation Status](https://readthedocs.org/projects/opsdroid/badge/?version=latest)](http://opsdroid.readthedocs.io/en/latest/?badge=latest)
+
 
 An open source python chat-ops bot
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -58,6 +58,18 @@ class OpsDroid():
                     self.connectors.append(connector)
                     connector.connect(self)
 
+    def start_databases(self, databases):
+        """Start the databases."""
+        if len(databases) == 0:
+            logging.warning("All databases failed to load")
+        for database_module in databases:
+            for name, cls in database_module["module"].__dict__.items():
+                if isinstance(cls, type) and "Database" in name:
+                    logging.debug("Adding database: " + name)
+                    database = cls(database_module["config"])
+                    self.memory.databases.append(database)
+                    database.connect()
+
     def load_regex_skill(self, regex, skill):
         """Load skills."""
         self.skills.append({"regex": regex, "skill": skill})

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 import weakref
+from multiprocessing import Process
 from opsdroid.helper import match
 from opsdroid.memory import Memory
 
@@ -50,13 +51,18 @@ class OpsDroid():
         """Start the connectors."""
         if len(connectors) == 0:
             self.critical("All connectors failed to load", 1)
+        jobs = []
         for connector_module in connectors:
             for name, cls in connector_module["module"].__dict__.items():
                 if isinstance(cls, type) and "Connector" in name:
                     connector_module["config"]["bot-name"] = self.bot_name
                     connector = cls(connector_module["config"])
                     self.connectors.append(connector)
-                    connector.connect(self)
+                    job = Process(target=connector.connect, args=(self,))
+                    job.start()
+                    jobs.append(job)
+        for job in jobs:
+            job.join()
 
     def start_databases(self, databases):
         """Start the databases."""

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -78,8 +78,8 @@ class Loader:
         logging.debug("Loading modules from config")
 
         if 'databases' in config.keys():
-            # TODO: Implement database modules
-            self._load_modules('database', config['databases'])
+            self.opsdroid.start_databases(
+                self._load_modules('database', config['databases']))
         else:
             logging.warning("No databases in configuration")
 

--- a/opsdroid/memory.py
+++ b/opsdroid/memory.py
@@ -10,12 +10,13 @@ class Memory:
         """Create memory dictionary."""
         self.memory = {}
         self.databases = []
-        self.sync()
 
     def get(self, key):
         """Get data object for a given key."""
         logging.debug("Getting " + key + " from memory")
-        self.sync()
+        database_result = self._get_from_database(key)
+        if database_result is not None:
+            self.memory[key] = database_result
         if key in self.memory:
             return self.memory[key]
         else:
@@ -25,12 +26,24 @@ class Memory:
         """Put a data object to a given key."""
         logging.debug("Putting " + key + " to memory")
         self.memory[key] = data
-        self.sync()
+        self._put_to_database(key, self.memory[key])
 
-    def sync(self):
-        """Sync memory with databases."""
-        # TODO sync self.memory with databases in self.databases
+    def _get_from_database(self, key):
+        """Get updates from databases for a given key."""
+        if not self.databases:
+            logging.warning("No databases configured, data will not persist")
+            return None
+        else:
+            results = []
+            for database in self.databases:
+                results.append(database.get(key))
+            # TODO: Handle multiple databases
+            return results[0]
+
+    def _put_to_database(self, key, data):
+        """Put updates into databases for a given key."""
         if not self.databases:
             logging.warning("No databases configured, data will not persist")
         else:
-            pass
+            for database in self.databases:
+                database.put(key, data)

--- a/tests/mockmodules/connectors/connector.py
+++ b/tests/mockmodules/connectors/connector.py
@@ -1,0 +1,12 @@
+"""A mocked connector module."""
+
+import unittest.mock as mock
+
+
+class ConnectorTest:
+    """The mocked connector class."""
+
+    def __init__(self, config):
+        """Start the class."""
+        self.connect = mock.MagicMock()
+        self.respond = mock.MagicMock()

--- a/tests/mockmodules/databases/database.py
+++ b/tests/mockmodules/databases/database.py
@@ -1,0 +1,11 @@
+"""A mocked database module."""
+
+import unittest.mock as mock
+
+
+class DatabaseTest:
+    """The mocked database class."""
+
+    def __init__(self, config):
+        """Start the class."""
+        self.connect = mock.MagicMock()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -69,8 +69,6 @@ class TestCore(unittest.TestCase):
                 "tests.mockmodules.connectors.connector")
             opsdroid.start_connectors([module])
             self.assertEqual(len(opsdroid.connectors), 1)
-            self.assertEqual(
-                len(opsdroid.connectors[0].connect.mock_calls), 1)
 
     def test_multiple_opsdroids(self):
         with OpsDroid() as opsdroid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 import sys
 import unittest
 import unittest.mock as mock
+import importlib
 
 sys.modules['sys'].exit = mock.MagicMock()
 
@@ -46,3 +47,34 @@ class TestCore(unittest.TestCase):
             message = Message("Hello world", "user", "default", mock_connector)
             opsdroid.parse(message)
             self.assertEqual(len(skill.mock_calls), 1)
+
+    def test_start_databases(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.start_databases([])
+            module = {}
+            module["config"] = {}
+            module["module"] = importlib.import_module(
+                "tests.mockmodules.databases.database")
+            opsdroid.start_databases([module])
+            self.assertEqual(len(opsdroid.memory.databases), 1)
+            self.assertEqual(
+                len(opsdroid.memory.databases[0].connect.mock_calls), 1)
+
+    def test_start_connectors(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.start_connectors([])
+            module = {}
+            module["config"] = {}
+            module["module"] = importlib.import_module(
+                "tests.mockmodules.connectors.connector")
+            opsdroid.start_connectors([module])
+            self.assertEqual(len(opsdroid.connectors), 1)
+            self.assertEqual(
+                len(opsdroid.connectors[0].connect.mock_calls), 1)
+
+    def test_multiple_opsdroids(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.__class__.critical = mock.MagicMock()
+            with OpsDroid() as opsdroid2:
+                opsdroid2.exit()
+            self.assertEqual(len(opsdroid.__class__.critical.mock_calls), 1)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -101,7 +101,7 @@ class TestLoader(unittest.TestCase):
         loader.load_config(config)
         self.assertEqual(len(loader._load_modules.mock_calls), 3)
         self.assertEqual(len(loader._setup_modules.mock_calls), 1)
-        self.assertEqual(len(opsdroid.mock_calls), 1)
+        self.assertNotEqual(len(opsdroid.mock_calls), 0)
 
     def test_load_empty_config(self):
         opsdroid, loader = self.setup()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -18,13 +18,17 @@ class TestMemory(unittest.TestCase):
         self.assertEqual(data, memory.get("test"))
         self.assertIsNone(memory.get("nonexistant"))
 
-    def test_sync(self):
+    def test_empty_memory(self):
         memory = self.setup()
-        memory.sync = mock.MagicMock()
+        self.assertEqual(None, memory.get("test"))
+
+    def test_database_callouts(self):
+        memory = self.setup()
+        memory.databases = [mock.MagicMock()]
         data = "Hello world!"
 
         memory.put("test", data)
-        self.assertEqual(len(memory.sync.mock_calls), 1)
+        self.assertEqual(len(memory.databases[0].mock_calls), 1)
 
         memory.get("test")
-        self.assertEqual(len(memory.sync.mock_calls), 2)
+        self.assertEqual(len(memory.databases[0].mock_calls), 2)


### PR DESCRIPTION
Each connector will be run as a `multiprocessing.Process` and then the main thread will block until they all exit.

Test has been updated to not check `connect()` mock calls as it is now called in the child processes.

Closes #6.