### PR TITLE
Run each connector in a child fork

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -18,6 +18,7 @@ class OpsDroid():
         self.bot_name = 'opsdroid'
         self.sys_status = 0
         self.connectors = []
+        self.connector_jobs = []
         self.skills = []
         self.memory = Memory()
         logging.info("Created main opsdroid object")
@@ -51,7 +52,6 @@ class OpsDroid():
         """Start the connectors."""
         if len(connectors) == 0:
             self.critical("All connectors failed to load", 1)
-        jobs = []
         for connector_module in connectors:
             for name, cls in connector_module["module"].__dict__.items():
                 if isinstance(cls, type) and "Connector" in name:
@@ -60,8 +60,8 @@ class OpsDroid():
                     self.connectors.append(connector)
                     job = Process(target=connector.connect, args=(self,))
                     job.start()
-                    jobs.append(job)
-        for job in jobs:
+                    self.connector_jobs.append(job)
+        for job in self.connector_jobs:
             job.join()
 
     def start_databases(self, databases):

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 import weakref
+from multiprocessing import Process
 from opsdroid.helper import match
 from opsdroid.memory import Memory
 
@@ -50,13 +51,18 @@ class OpsDroid():
         """Start the connectors."""
         if len(connectors) == 0:
             self.critical("All connectors failed to load", 1)
+        jobs = []
         for connector_module in connectors:
             for name, cls in connector_module["module"].__dict__.items():
                 if isinstance(cls, type) and "Connector" in name:
                     connector_module["config"]["bot-name"] = self.bot_name
                     connector = cls(connector_module["config"])
                     self.connectors.append(connector)
-                    connector.connect(self)
+                    job = Process(target=connector.connect, args=(self,))
+                    job.start()
+                    jobs.append(job)
+        for job in jobs:
+            job.join()
 
     def start_databases(self, databases):
         """Start the databases."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -69,8 +69,6 @@ class TestCore(unittest.TestCase):
                 "tests.mockmodules.connectors.connector")
             opsdroid.start_connectors([module])
             self.assertEqual(len(opsdroid.connectors), 1)
-            self.assertEqual(
-                len(opsdroid.connectors[0].connect.mock_calls), 1)
 
     def test_multiple_opsdroids(self):
         with OpsDroid() as opsdroid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -69,6 +69,7 @@ class TestCore(unittest.TestCase):
                 "tests.mockmodules.connectors.connector")
             opsdroid.start_connectors([module])
             self.assertEqual(len(opsdroid.connectors), 1)
+            self.assertEqual(len(opsdroid.connector_jobs), 1)
 
     def test_multiple_opsdroids(self):
         with OpsDroid() as opsdroid:


### PR DESCRIPTION
Each connector will be run as a `multiprocessing.Process` and then the main thread will block until they all exit.

Test has been updated to not check `connect()` mock calls as it is now called in the child processes.

Closes #6.