### PR TITLE
Shell out to pip instead of using the pip module

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import subprocess
 import importlib
-import pip
 import yaml
 from opsdroid.const import (
     DEFAULT_GIT_URL, MODULES_DIRECTORY, DEFAULT_MODULE_BRANCH)
@@ -48,6 +47,19 @@ def git_clone(git_url, install_path, branch):
                                 git_url, install_path], shell=False,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
+    process.wait()
+
+
+def pip_install_deps(requirements_path):
+    """Pip install a requirements.txt file and wait for finish."""
+    process = subprocess.Popen(["pip", "install", "-r", requirements_path],
+                               shell=False,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    for output in process.communicate():
+        if output != "":
+            for line in output.splitlines():
+                logging.debug(str(line).strip())
     process.wait()
 
 
@@ -174,5 +186,4 @@ class Loader:
 
             # Install module dependancies
             if os.path.isfile(config["install_path"] + "/requirements.txt"):
-                pip.main(["install", "-r", config["install_path"] +
-                          "/requirements.txt"])
+                pip_install_deps(config["install_path"] + "/requirements.txt")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -20,6 +20,9 @@ class TestLoader(unittest.TestCase):
         loader = ld.Loader(opsdroid)
         return opsdroid, loader
 
+    def reset_subprocess_mocks(self):
+        sys.modules['subprocess'].mock_calls = []
+
     def test_load_config_file(self):
         opsdroid, loader = self.setup()
         config = loader.load_config_file("tests/configs/minimal.yaml")
@@ -43,8 +46,14 @@ class TestLoader(unittest.TestCase):
         self.assertEqual(len(example_modules[0]["module"].mock_calls), 1)
 
     def test_git_clone(self):
+        self.reset_subprocess_mocks()
         ld.git_clone("https://github.com/rmccue/test-repository.git",
                      "/tmp/test", "master")
+        self.assertNotEqual(len(sys.modules['subprocess'].mock_calls), 0)
+
+    def test_pip_install_deps(self):
+        self.reset_subprocess_mocks()
+        ld.pip_install_deps("/path/to/some/file.txt")
         self.assertNotEqual(len(sys.modules['subprocess'].mock_calls), 0)
 
     def test_build_module_path(self):


### PR DESCRIPTION
The logging does seem to be fine. The problem is actually in the pip module where it is messing with the root logger (pypa/pip#3043).

This PR stops using the `pip` module and instead uses `subprocess` to shell out to pip.

Closes #7 