### PR TITLE
Test for class inheritance instead of class name

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -6,6 +6,8 @@ import weakref
 from multiprocessing import Process
 from opsdroid.helper import match
 from opsdroid.memory import Memory
+from opsdroid.connector import Connector
+from opsdroid.database import Database
 
 
 class OpsDroid():
@@ -54,7 +56,9 @@ class OpsDroid():
             self.critical("All connectors failed to load", 1)
         elif len(connectors) == 1:
             for name, cls in connectors[0]["module"].__dict__.items():
-                if isinstance(cls, type) and "Connector" in name:
+                if isinstance(cls, type) and \
+                   isinstance(cls({}), Connector):
+                    logging.debug("Adding connector: " + name)
                     connectors[0]["config"]["bot-name"] = self.bot_name
                     connector = cls(connectors[0]["config"])
                     self.connectors.append(connector)
@@ -62,7 +66,8 @@ class OpsDroid():
         else:
             for connector_module in connectors:
                 for name, cls in connector_module["module"].__dict__.items():
-                    if isinstance(cls, type) and "Connector" in name:
+                    if isinstance(cls, type) and \
+                       isinstance(cls({}), Connector):
                         connector_module["config"]["bot-name"] = self.bot_name
                         connector = cls(connector_module["config"])
                         self.connectors.append(connector)
@@ -78,11 +83,12 @@ class OpsDroid():
             logging.warning("All databases failed to load")
         for database_module in databases:
             for name, cls in database_module["module"].__dict__.items():
-                if isinstance(cls, type) and "Database" in name:
+                if isinstance(cls, type) and \
+                   isinstance(cls({}), Database):
                     logging.debug("Adding database: " + name)
                     database = cls(database_module["config"])
                     self.memory.databases.append(database)
-                    database.connect()
+                    database.connect(self)
 
     def load_regex_skill(self, regex, skill):
         """Load skills."""

--- a/tests/mockmodules/connectors/connector.py
+++ b/tests/mockmodules/connectors/connector.py
@@ -2,8 +2,10 @@
 
 import unittest.mock as mock
 
+from opsdroid.connector import Connector
 
-class ConnectorTest:
+
+class ConnectorTest(Connector):
     """The mocked connector class."""
 
     def __init__(self, config):

--- a/tests/mockmodules/databases/database.py
+++ b/tests/mockmodules/databases/database.py
@@ -2,8 +2,10 @@
 
 import unittest.mock as mock
 
+from opsdroid.database import Database
 
-class DatabaseTest:
+
+class DatabaseTest(Database):
     """The mocked database class."""
 
     def __init__(self, config):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,10 +55,8 @@ class TestCore(unittest.TestCase):
             module["config"] = {}
             module["module"] = importlib.import_module(
                 "tests.mockmodules.databases.database")
-            opsdroid.start_databases([module])
-            self.assertEqual(len(opsdroid.memory.databases), 1)
-            self.assertEqual(
-                len(opsdroid.memory.databases[0].connect.mock_calls), 1)
+            with self.assertRaises(NotImplementedError):
+                opsdroid.start_databases([module])
 
     def test_start_connectors(self):
         with OpsDroid() as opsdroid:
@@ -67,12 +65,11 @@ class TestCore(unittest.TestCase):
             module["config"] = {}
             module["module"] = importlib.import_module(
                 "tests.mockmodules.connectors.connector")
-            opsdroid.start_connectors([module])
-            self.assertEqual(len(opsdroid.connectors), 1)
+
+            with self.assertRaises(NotImplementedError):
+                opsdroid.start_connectors([module])
 
             opsdroid.start_connectors([module, module])
-            self.assertEqual(len(opsdroid.connectors), 3)
-            self.assertEqual(len(opsdroid.connector_jobs), 2)
 
     def test_multiple_opsdroids(self):
         with OpsDroid() as opsdroid:


### PR DESCRIPTION
For connectors and databases.

Resolves #33 