### PR TITLE
Add default connector and default room

### DIFF
--- a/docs/extending/connectors.md
+++ b/docs/extending/connectors.md
@@ -1,6 +1,6 @@
 # Creating a connector
 
-Connectors are a class which extends the base opsdroid Connector. The class has three mandatory methods, `connect`, `listen` and `respond`.
+Connectors are a class which extends the base opsdroid Connector. The class has three mandatory methods, `connect`, `listen` and `respond`. There are also some default values you can override with the `__init__` function, just be sure you are setting everything that the default init sets.
 
 #### connect
 *connect* is a method which connects to a specific chat service
@@ -25,6 +25,12 @@ from opsdroid.message import Message
 
 
 class MyConnector(Connector):
+
+  def __init__(self, config):
+    # Init the config for the connector
+    self.name = "MyConnector" # The name of your connector
+    self.config = config # The config dictionary to be accessed later
+    self.default_room = "MyDefaultRoom" # The default room for messages to go
 
   async def connect(self, opsdroid):
     # Create connection object with chat library

--- a/opsdroid/connector.py
+++ b/opsdroid/connector.py
@@ -24,6 +24,7 @@ class Connector():
         """
         self.name = ""
         self.config = config
+        self.default_room = None
 
     async def connect(self, opsdroid):
         """Connect to chat service.

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -45,6 +45,18 @@ class OpsDroid():
         """Remove self from existing instances."""
         self.__class__.instances = []
 
+    @property
+    def default_connector(self):
+        """Return the default connector."""
+        default_connector = None
+        for connector in self.connectors:
+            if connector.config["default"]:
+                default_connector = connector
+                break
+        if default_connector is None:
+            default_connector = self.connectors[0]
+        return default_connector
+
     def exit(self):
         """Exit application."""
         logging.info("Exiting application with return code " +

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -51,7 +51,7 @@ class OpsDroid():
         """Return the default connector."""
         default_connector = None
         for connector in self.connectors:
-            if connector.config["default"]:
+            if "default" in connector.config and connector.config["default"]:
                 default_connector = connector
                 break
         if default_connector is None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -14,6 +14,7 @@ class TestConnectorBaseClass(unittest.TestCase):
     def test_init(self):
         config = {"example_item": "test"}
         connector = Connector(config)
+        self.assertEqual(None, connector.default_room)
         self.assertEqual("", connector.name)
         self.assertEqual("test", connector.config["example_item"])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -104,6 +104,21 @@ class TestCore(unittest.TestCase):
             opsdroid.setup_skills(example_modules)
             self.assertEqual(len(example_modules[0]["module"].mock_calls), 1)
 
+    def test_default_connector(self):
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({})
+            opsdroid.connectors.append(mock_connector)
+            self.assertEqual(opsdroid.default_connector, mock_connector)
+
+            mock_default_connector = Connector({"default": True})
+            opsdroid.connectors.append(mock_default_connector)
+            self.assertEqual(opsdroid.default_connector,
+                             mock_default_connector)
+
+    def test_default_room(self):
+        mock_connector = Connector({})
+        self.assertEqual(None, mock_connector.default_room)
+
 
 class TestCoreAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid core class."""


### PR DESCRIPTION
From a skill it should be possible to retrieve a default connector and for that connector a default room. This will allow broadcast messages to be sent from a connector which isn't designed to be triggered by a human, e.g cron or a RESTful API.

- [x] Add `opsdroid.default_connector` property
- [x] Add `connector.default_room` property

Closes #48 