### PR TITLE
Add api.ai support

### DIFF
--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -18,7 +18,9 @@ async def hello(opsdroid, message):
 
 In this example we are importing the `match_regex` decorator from the opsdroid skills library. We are then using it to decorate a simple hello world function.
 
-The decorator takes a regular expression to match against the message received from the connector. In this case we are checking to see if the message from the user is "hi".
+This decorator takes a regular expression to match against the message received from the connector. In this case we are checking to see if the message from the user is "hi".
+
+For more information about the different decorators available in opsdroid see the [parsers documentation](parsers/overview).
 
 If the message matches the regular expression then the decorated function is called. As arguments opsdroid will pass a pointer to itself along with a Message object containing information about the message from the user.
 
@@ -27,6 +29,8 @@ To ensure the bot is responsive the concurrency controls introduced in Python 3.
 ## Message object
 
 The message object passed to the skill function is an instance of the opsdroid Message class which has the following properties and methods.
+
+Also depending on the parser it may have parser specific properties too. See the [parsers documentation](parsers/overview) for more details.
 
 ### `text`
 
@@ -39,10 +43,6 @@ A _string_ containing the username of the user who wrote the message.
 ### `room`
 
 A _string_ containing the name of the room or chat channel the message was sent in.
-
-### `regex`
-
-A _[re match object](https://docs.python.org/2/library/re.html#re.MatchObject)_ for the regular expression the message was matched against.
 
 ### `connector`
 

--- a/docs/parsers/api.ai.md
+++ b/docs/parsers/api.ai.md
@@ -1,0 +1,90 @@
+# api.ai Parser
+
+[api.ai](https://api.ai) is an NLP API for matching strings to [intents](https://docs.api.ai/docs/concept-intents) or [actions](https://docs.api.ai/docs/concept-actions). Intents are created on the api.ai website.
+
+## Example 1
+
+```python
+from opsdroid.skills import match_apiai_action
+
+@match_apiai_action('mydomain.myaction')
+async def mySkill(opsdroid, message):
+    await message.respond('An appropriate response!')
+```
+
+The above skill would be called on any intent which has an action of `'mydomain.myaction'`.
+
+## Example 2
+
+```python
+from opsdroid.skills import match_apiai_intent
+
+@match_apiai_intent('myIntent')
+async def mySkill(opsdroid, message):
+    await message.respond('An appropriate response!')
+```
+
+The above skill would be called on any intent which has a name of `'myIntent'`.
+
+## Creating an api.ai bot
+
+You can find a quick getting started with api.ai guide [here](https://docs.api.ai/docs/get-started).
+
+## Configuring opsdroid
+
+In order to enable api.ai skills you must specify an `access-key` for your bot (referred to as an agent in api.ai) in the parsers section of the opsdroid configuration file. You can find this `access-key` in your agent settings. Currently you may only register one agent per opsdroid instance to avoid making multiple API calls for every message.
+
+You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
+
+```yaml
+
+parsers:
+  apiai:
+    access-token: "exampleaccesstoken123"
+    min-score: 0.6
+```
+
+## Message object additional parameters
+
+### `message.apiai`
+
+An http response object which has been returned by the api.ai API. This allows you to access any information from the matched intent including the action, intent name, suggested speech response, context, parameters, score, error status, etc.
+
+```python
+import json
+
+from opsdroid.skills import match_apiai_action
+
+@match_apiai_action('smalltalk.greetings')
+async def dumpResponse(opsdroid, message):
+    print json.dumps(message.apiai)
+```
+
+This example skill will print the following on the message "whats up?".
+
+```json
+{
+  "sessionId": "abc123",
+  "result": {
+    "parameters": {
+      "simplified": "what is up"
+    },
+    "metadata": {
+      "contexts": [],
+      "outputContexts": [],
+      "inputContexts": []
+    },
+    "speech": "Living the dream.",
+    "action": "smalltalk.greetings",
+    "resolvedQuery": "whats up?",
+    "source": "domains",
+    "score": 1.0
+  },
+  "timestamp": "2016-12-19T12:10:20.462Z",
+  "id": "9835915f-72a8-4292-8365-3067b9af0a80",
+  "status": {
+    "errorType": "success",
+    "code": 200
+  }
+}
+```

--- a/docs/parsers/api.ai.md
+++ b/docs/parsers/api.ai.md
@@ -57,7 +57,7 @@ from opsdroid.skills import match_apiai_action
 
 @match_apiai_action('smalltalk.greetings')
 async def dumpResponse(opsdroid, message):
-    print json.dumps(message.apiai)
+    print(json.dumps(message.apiai))
 ```
 
 This example skill will print the following on the message "whats up?".

--- a/docs/parsers/overview.md
+++ b/docs/parsers/overview.md
@@ -1,0 +1,9 @@
+# Parsers
+
+When writing skills for opsdroid there are multiple parsers you can use for matching messages to your functions.
+
+ * [Regular Expression](parsers/regex)
+  * `opsdroid.skills.match_regex`
+ * [API.AI](parsers/api.ai)
+  * `opsdroid.skills.match_apiai_action`
+  * `opsdroid.skills.match_apiai_intent` 

--- a/docs/parsers/regex.md
+++ b/docs/parsers/regex.md
@@ -1,0 +1,31 @@
+# Regular Expression Parser
+
+This is the simplest parser available in opsdroid. It matches the message from the user against a regular expression. If the regex matches the function is called.
+
+## Example
+
+```python
+from opsdroid.skills import match_regex
+
+@match_regex('hi')
+async def hello(opsdroid, message):
+    await message.respond('Hey')
+```
+
+The above skill would be called on any message which matches the regex `'hi'`.
+
+## Message object additional parameters
+
+### `message.regex`
+
+A _[re match object](https://docs.python.org/3/library/re.html#re.MatchObject)_ for the regular expression the message was matched against. This allows you to access any wildcard matches in the regex from within your skill.
+
+```python
+from opsdroid.skills import match_regex
+
+@match_regex(r'remember (.*)')
+async def remember(opsdroid, message):
+    remember = message.regex.group(1)
+    await opsdroid.memory.put("remember", remember)
+    await message.respond("OK I'll remember that")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,4 +10,8 @@ pages:
     - Adding skills: 'extending/skills.md'
     - Adding connectors: 'extending/connectors.md'
     - Adding databases: 'extending/databases.md'
+  - Parsers:
+    - Overview: 'parsers/overview.md'
+    - Regular Expressions: 'parsers/regex.md'
+    - API.AI: 'parsers/api.ai.md'
   - Contributing: 'contributing.md'

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -133,5 +133,5 @@ class OpsDroid():
 
             await parse_regex(self, message)
 
-            if self.config['parsers']['apiai']:
+            if "parsers" in self.config and "apiai" in self.config["parsers"]:
                 await parse_apiai(self, message)

--- a/opsdroid/helper.py
+++ b/opsdroid/helper.py
@@ -1,7 +1,6 @@
 """Helper functions to use within OpsDroid."""
 
 import logging
-import re
 
 
 def set_logging_level(logging_level):
@@ -23,8 +22,3 @@ def set_logging_level(logging_level):
         logger.setLevel(logging.INFO)
         logging.warning("Log level '" + logging_level +
                         "' unknown, defaulting to 'info'")
-
-
-def match(regex, message):
-    """Regex match a string."""
-    return re.match(regex, message)

--- a/opsdroid/parsers/__init__.py
+++ b/opsdroid/parsers/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for opsdroid parsers."""

--- a/opsdroid/parsers/apiai.py
+++ b/opsdroid/parsers/apiai.py
@@ -53,9 +53,13 @@ async def parse_apiai(opsdroid, message):
         if result:
             for skill in opsdroid.skills:
 
-                if "apiai" in skill:
-                    if "action" in result["result"] and \
-                            skill["apiai"] in result["result"]["action"]:
+                if "apiai_action" in skill or "apiai_intent" in skill:
+                    if ("action" in result["result"] and
+                            skill["apiai_action"] in
+                            result["result"]["action"]) \
+                            or ("intentName" in result["result"] and
+                                skill["apiai_intent"] in
+                                result["result"]["intentName"]):
                         message.apiai = result
                         try:
                             await skill["skill"](opsdroid, message)
@@ -67,4 +71,4 @@ async def parse_apiai(opsdroid, message):
                             logging.exception("Exception when parsing '" +
                                               message.text +
                                               "' against skill '" +
-                                              skill["apiai"] + "'")
+                                              result["result"]["action"] + "'")

--- a/opsdroid/parsers/apiai.py
+++ b/opsdroid/parsers/apiai.py
@@ -1,0 +1,61 @@
+"""A helper function for parsing and executing api.ai skills."""
+
+import logging
+import json
+
+import aiohttp
+
+
+async def parse_apiai(opsdroid, message):
+    """Parse a message against all apiai skills."""
+    # pylint: disable=broad-except
+    # We want to catch all exceptions coming from a skill module and not
+    # halt the application. If a skill throws an exception it just doesn't
+    # give a response to the user, so an error response should be given.
+    config = opsdroid.config['parsers']['apiai']
+    if 'access-token' in config:
+        async with aiohttp.ClientSession() as session:
+            payload = {
+                "v": "20150910",
+                "lang": "en",
+                "sessionId": message.connector.name,
+                "query": message.text
+            }
+            headers = {
+                "Authorization": "Bearer " + config['access-token'],
+                "Content-Type": "application/json"
+            }
+            async with session.post("https://api.api.ai/v1/query",
+                                    data=json.dumps(payload),
+                                    headers=headers) as resp:
+                result = await resp.json()
+                logging.debug("api.ai response - " + json.dumps(result))
+
+                if result["status"]["code"] >= 300:
+                    logging.error("api.ai error - " +
+                                  str(result["status"]["code"]) + " " +
+                                  result["status"]["errorType"])
+                    return
+
+                if "min-score" in config and \
+                    result["score"] < config["min-score"]:
+                    logging.debug("api.ai score lower than min-score")
+                    return
+
+                for skill in opsdroid.skills:
+
+                    if "apiai" in skill:
+                        if "action" in result["result"] and \
+                                skill["apiai"] in result["result"]["action"]:
+                            message.apiai = result
+                            try:
+                                await skill["skill"](opsdroid, message)
+                            except Exception:
+                                await message.respond(
+                                    "Whoops there has been an error")
+                                await message.respond(
+                                    "Check the log for details")
+                                logging.exception("Exception when parsing '" +
+                                                  message.text +
+                                                  "' against skill '" +
+                                                  skill["apiai"] + "'")

--- a/opsdroid/parsers/apiai.py
+++ b/opsdroid/parsers/apiai.py
@@ -38,7 +38,7 @@ async def parse_apiai(opsdroid, message):
                     return
 
                 if "min-score" in config and \
-                    result["score"] < config["min-score"]:
+                        result["score"] < config["min-score"]:
                     logging.debug("api.ai score lower than min-score")
                     return
 

--- a/opsdroid/parsers/apiai.py
+++ b/opsdroid/parsers/apiai.py
@@ -25,17 +25,6 @@ async def call_apiai(message, config):
         result = await resp.json()
         logging.debug("api.ai response - " + json.dumps(result))
 
-        if result["status"]["code"] >= 300:
-            logging.error("api.ai error - " +
-                          str(result["status"]["code"]) + " " +
-                          result["status"]["errorType"])
-            return False
-
-        if "min-score" in config and \
-                result["result"]["score"] < config["min-score"]:
-            logging.debug("api.ai score lower than min-score")
-            return False
-
         return result
 
 
@@ -49,6 +38,18 @@ async def parse_apiai(opsdroid, message):
     if 'access-token' in config:
 
         result = await call_apiai(message, config)
+
+        if result["status"]["code"] >= 300:
+            logging.error("api.ai error - " +
+                          str(result["status"]["code"]) + " " +
+                          result["status"]["errorType"])
+            return
+
+        if "min-score" in config and \
+                result["result"]["score"] < config["min-score"]:
+            logging.debug("api.ai score lower than min-score")
+            return
+
         if result:
             for skill in opsdroid.skills:
 

--- a/opsdroid/parsers/apiai.py
+++ b/opsdroid/parsers/apiai.py
@@ -6,6 +6,39 @@ import json
 import aiohttp
 
 
+async def call_apiai(message, config):
+    """Call the api.ai api and return the response."""
+    async with aiohttp.ClientSession() as session:
+        payload = {
+            "v": "20150910",
+            "lang": "en",
+            "sessionId": message.connector.name,
+            "query": message.text
+        }
+        headers = {
+            "Authorization": "Bearer " + config['access-token'],
+            "Content-Type": "application/json"
+        }
+        resp = await session.post("https://api.api.ai/v1/query",
+                                  data=json.dumps(payload),
+                                  headers=headers)
+        result = await resp.json()
+        logging.debug("api.ai response - " + json.dumps(result))
+
+        if result["status"]["code"] >= 300:
+            logging.error("api.ai error - " +
+                          str(result["status"]["code"]) + " " +
+                          result["status"]["errorType"])
+            return False
+
+        if "min-score" in config and \
+                result["result"]["score"] < config["min-score"]:
+            logging.debug("api.ai score lower than min-score")
+            return False
+
+        return result
+
+
 async def parse_apiai(opsdroid, message):
     """Parse a message against all apiai skills."""
     # pylint: disable=broad-except
@@ -14,48 +47,23 @@ async def parse_apiai(opsdroid, message):
     # give a response to the user, so an error response should be given.
     config = opsdroid.config['parsers']['apiai']
     if 'access-token' in config:
-        async with aiohttp.ClientSession() as session:
-            payload = {
-                "v": "20150910",
-                "lang": "en",
-                "sessionId": message.connector.name,
-                "query": message.text
-            }
-            headers = {
-                "Authorization": "Bearer " + config['access-token'],
-                "Content-Type": "application/json"
-            }
-            async with session.post("https://api.api.ai/v1/query",
-                                    data=json.dumps(payload),
-                                    headers=headers) as resp:
-                result = await resp.json()
-                logging.debug("api.ai response - " + json.dumps(result))
 
-                if result["status"]["code"] >= 300:
-                    logging.error("api.ai error - " +
-                                  str(result["status"]["code"]) + " " +
-                                  result["status"]["errorType"])
-                    return
+        result = await call_apiai(message, config)
+        if result:
+            for skill in opsdroid.skills:
 
-                if "min-score" in config and \
-                        result["score"] < config["min-score"]:
-                    logging.debug("api.ai score lower than min-score")
-                    return
-
-                for skill in opsdroid.skills:
-
-                    if "apiai" in skill:
-                        if "action" in result["result"] and \
-                                skill["apiai"] in result["result"]["action"]:
-                            message.apiai = result
-                            try:
-                                await skill["skill"](opsdroid, message)
-                            except Exception:
-                                await message.respond(
-                                    "Whoops there has been an error")
-                                await message.respond(
-                                    "Check the log for details")
-                                logging.exception("Exception when parsing '" +
-                                                  message.text +
-                                                  "' against skill '" +
-                                                  skill["apiai"] + "'")
+                if "apiai" in skill:
+                    if "action" in result["result"] and \
+                            skill["apiai"] in result["result"]["action"]:
+                        message.apiai = result
+                        try:
+                            await skill["skill"](opsdroid, message)
+                        except Exception:
+                            await message.respond(
+                                "Whoops there has been an error")
+                            await message.respond(
+                                "Check the log for details")
+                            logging.exception("Exception when parsing '" +
+                                              message.text +
+                                              "' against skill '" +
+                                              skill["apiai"] + "'")

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -1,0 +1,28 @@
+"""A helper function for parsing and executing regex skills."""
+
+import logging
+import re
+
+
+async def parse_regex(opsdroid, message):
+    """Parse a message against all regex skills."""
+    # pylint: disable=broad-except
+    # We want to catch all exceptions coming from a skill module and not
+    # halt the application. If a skill throws an exception it just doesn't
+    # give a response to the user, so an error response should be given.
+    for skill in opsdroid.skills:
+        if "regex" in skill:
+            regex = re.match(skill["regex"], message.text)
+            if regex:
+                message.regex = regex
+                try:
+                    await skill["skill"](opsdroid, message)
+                except Exception:
+                    await message.respond(
+                        "Whoops there has been an error")
+                    await message.respond(
+                        "Check the log for details")
+                    logging.exception("Exception when parsing '" +
+                                      message.text +
+                                      "' against skill '" +
+                                      skill["regex"] + "'")

--- a/opsdroid/skills.py
+++ b/opsdroid/skills.py
@@ -13,11 +13,21 @@ def match_regex(regex):
     return matcher
 
 
-def match_apiai(action):
-    """Return apiai match decorator."""
+def match_apiai_action(action):
+    """Return apiai action match decorator."""
     def matcher(func):
         """Add decorated function to skills list for apiai matching."""
         for opsdroid in OpsDroid.instances:
-            opsdroid.skills.append({"apiai": action, "skill": func})
+            opsdroid.skills.append({"apiai_action": action, "skill": func})
+        return func
+    return matcher
+
+
+def match_apiai_intent(intent):
+    """Return apiai intent match decorator."""
+    def matcher(func):
+        """Add decorated function to skills list for apiai matching."""
+        for opsdroid in OpsDroid.instances:
+            opsdroid.skills.append({"apiai_intent": intent, "skill": func})
         return func
     return matcher

--- a/opsdroid/skills.py
+++ b/opsdroid/skills.py
@@ -12,6 +12,7 @@ def match_regex(regex):
         return func
     return matcher
 
+
 def match_apiai(action):
     """Return apiai match decorator."""
     def matcher(func):

--- a/opsdroid/skills.py
+++ b/opsdroid/skills.py
@@ -8,6 +8,15 @@ def match_regex(regex):
     def matcher(func):
         """Add decorated function to skills list for regex matching."""
         for opsdroid in OpsDroid.instances:
-            opsdroid.load_regex_skill(regex, func)
+            opsdroid.skills.append({"regex": regex, "skill": func})
+        return func
+    return matcher
+
+def match_apiai(action):
+    """Return apiai match decorator."""
+    def matcher(func):
+        """Add decorated function to skills list for apiai matching."""
+        for opsdroid in OpsDroid.instances:
+            opsdroid.skills.append({"apiai": action, "skill": func})
         return func
     return matcher

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml
+aiohttp

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ import importlib
 from opsdroid.core import OpsDroid
 from opsdroid.message import Message
 from opsdroid.connector import Connector
+from opsdroid.skills import match_regex
 
 
 class TestCore(unittest.TestCase):
@@ -55,7 +56,8 @@ class TestCore(unittest.TestCase):
         with OpsDroid() as opsdroid:
             regex = r".*"
             skill = mock.MagicMock()
-            opsdroid.load_regex_skill(regex, skill)
+            decorator = match_regex(regex)
+            decorator(skill)
             self.assertEqual(len(opsdroid.skills), 1)
             self.assertEqual(opsdroid.skills[0]["regex"], regex)
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
@@ -111,7 +113,8 @@ class TestCoreAsync(asynctest.TestCase):
             regex = r".*"
             skill = amock.CoroutineMock()
             mock_connector = Connector({})
-            opsdroid.load_regex_skill(regex, skill)
+            decorator = match_regex(regex)
+            decorator(skill)
             message = Message("Hello world", "user", "default", mock_connector)
             await opsdroid.parse(message)
             self.assertTrue(skill.called)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -26,18 +26,3 @@ class TestHelper(unittest.TestCase):
 
         helper.set_logging_level('an unkown level')
         self.assertEqual(20, logging.getLogger().getEffectiveLevel())
-
-    def test_match(self):
-        match = helper.match(r".*", "test")
-        self.assertEqual(match.group(0), "test")
-
-        match = helper.match(r"hello (.*)", "hello world")
-        self.assertEqual(match.group(1), "world")
-
-    def test_sensitive_match(self):
-        """Matches should be case sensitive"""
-        match = helper.match(r"hello", "hello")
-        self.assertTrue(match)
-
-        match = helper.match(r"hello", "HELLO")
-        self.assertFalse(match)

--- a/tests/test_parser_apiai.py
+++ b/tests/test_parser_apiai.py
@@ -5,7 +5,7 @@ import asynctest.mock as amock
 from aiohttp import helpers
 
 from opsdroid.core import OpsDroid
-from opsdroid.skills import match_apiai
+from opsdroid.skills import match_apiai_action
 from opsdroid.message import Message
 from opsdroid.parsers import apiai
 from opsdroid.connector import Connector
@@ -42,7 +42,7 @@ class TestParserApiai(asynctest.TestCase):
                     'apiai': {'access-token': "test"}
                 }
             mock_skill = amock.CoroutineMock()
-            match_apiai('myaction')(mock_skill)
+            match_apiai_action('myaction')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
             message = Message("Hello world", "user", "default", mock_connector)
@@ -69,7 +69,7 @@ class TestParserApiai(asynctest.TestCase):
                 }
             mock_skill = amock.CoroutineMock()
             mock_skill.side_effect = Exception()
-            match_apiai('myaction')(mock_skill)
+            match_apiai_action('myaction')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
             message = Message("Hello world", "user", "default", mock_connector)
@@ -95,7 +95,7 @@ class TestParserApiai(asynctest.TestCase):
                     'apiai': {'access-token': "test"}
                 }
             mock_skill = amock.CoroutineMock()
-            match_apiai('myaction')(mock_skill)
+            match_apiai_action('myaction')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
             message = Message("Hello world", "user", "default", mock_connector)
@@ -121,7 +121,7 @@ class TestParserApiai(asynctest.TestCase):
                     'apiai': {'access-token': "test", "min-score": 0.8}
                 }
             mock_skill = amock.CoroutineMock()
-            match_apiai('myaction')(mock_skill)
+            match_apiai_action('myaction')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
             message = Message("Hello world", "user", "default", mock_connector)

--- a/tests/test_parser_apiai.py
+++ b/tests/test_parser_apiai.py
@@ -24,7 +24,14 @@ class TestParserApiai(asynctest.TestCase):
 
             with amock.patch.object(apiai, 'call_apiai') as mocked_call_apiai:
                 mocked_call_apiai.return_value = {
-                        "result": {"action": "myaction"}
+                        "result": {
+                            "action": "myaction",
+                            "score": 0.7
+                        },
+                        "status": {
+                            "code": 200,
+                            "errorType": "success"
+                        }
                     }
                 await apiai.parse_apiai(opsdroid, message)
 

--- a/tests/test_parser_apiai.py
+++ b/tests/test_parser_apiai.py
@@ -1,0 +1,31 @@
+
+import asynctest
+import asynctest.mock as amock
+
+from opsdroid.core import OpsDroid
+from opsdroid.skills import match_apiai
+from opsdroid.message import Message
+from opsdroid.parsers import apiai
+
+
+class TestParserApiai(asynctest.TestCase):
+    """Test the opsdroid api.ai parser."""
+
+    async def test_parse_apiai(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = {
+                    'apiai': {'access-token': "test"}
+                }
+            mock_skill = amock.CoroutineMock()
+            match_apiai('myaction')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            with amock.patch.object(apiai, 'call_apiai') as mocked_call_apiai:
+                mocked_call_apiai.return_value = {
+                        "result": {"action": "myaction"}
+                    }
+                await apiai.parse_apiai(opsdroid, message)
+
+            self.assertTrue(mock_skill.called)

--- a/tests/test_parser_apiai.py
+++ b/tests/test_parser_apiai.py
@@ -36,3 +36,55 @@ class TestParserApiai(asynctest.TestCase):
                 await apiai.parse_apiai(opsdroid, message)
 
             self.assertTrue(mock_skill.called)
+
+    async def test_parse_apiai_failure(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = {
+                    'apiai': {'access-token': "test"}
+                }
+            mock_skill = amock.CoroutineMock()
+            match_apiai('myaction')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            with amock.patch.object(apiai, 'call_apiai') as mocked_call_apiai:
+                mocked_call_apiai.return_value = {
+                        "result": {
+                            "action": "myaction",
+                            "score": 0.7
+                        },
+                        "status": {
+                            "code": 404,
+                            "errorType": "not found"
+                        }
+                    }
+                await apiai.parse_apiai(opsdroid, message)
+
+            self.assertFalse(mock_skill.called)
+
+    async def test_parse_apiai_low_score(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = {
+                    'apiai': {'access-token': "test", "min-score": 0.8}
+                }
+            mock_skill = amock.CoroutineMock()
+            match_apiai('myaction')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            with amock.patch.object(apiai, 'call_apiai') as mocked_call_apiai:
+                mocked_call_apiai.return_value = {
+                        "result": {
+                            "action": "myaction",
+                            "score": 0.7
+                        },
+                        "status": {
+                            "code": 200,
+                            "errorType": "success"
+                        }
+                    }
+                await apiai.parse_apiai(opsdroid, message)
+
+            self.assertFalse(mock_skill.called)

--- a/tests/test_parser_apiai.py
+++ b/tests/test_parser_apiai.py
@@ -37,6 +37,33 @@ class TestParserApiai(asynctest.TestCase):
 
             self.assertTrue(mock_skill.called)
 
+    async def test_parse_apiai_raises(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = {
+                    'apiai': {'access-token': "test"}
+                }
+            mock_skill = amock.CoroutineMock()
+            mock_skill.side_effect = Exception()
+            match_apiai('myaction')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            with amock.patch.object(apiai, 'call_apiai') as mocked_call_apiai:
+                mocked_call_apiai.return_value = {
+                        "result": {
+                            "action": "myaction",
+                            "score": 0.7
+                        },
+                        "status": {
+                            "code": 200,
+                            "errorType": "success"
+                        }
+                    }
+                await apiai.parse_apiai(opsdroid, message)
+
+            self.assertTrue(mock_skill.called)
+
     async def test_parse_apiai_failure(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = {

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -23,26 +23,17 @@ class TestParserRegex(asynctest.TestCase):
 
             self.assertTrue(mock_skill.called)
 
-    # async def test_parse_regex_raises(self):
-    #     with OpsDroid() as opsdroid:
-    #         mock_skill = amock.CoroutineMock()
-    #         mock_skill.side_effect = Exception()
-    #         match_regex(r"(.*)")(mock_skill)
-    #         self.assertEqual(len(opsdroid.skills), 1)
-    #
-    #         mock_connector = amock.CoroutineMock()
-    #         message = Message("Hello world", "user",
-    #                           "default", mock_connector)
-    #
-    #         with self.assertRaises(Exception):
-    #             await parse_regex(opsdroid, message)
+    async def test_parse_regex_raises(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = amock.CoroutineMock()
+            mock_skill.side_effect = Exception()
+            match_regex(r"(.*)")(mock_skill)
+            self.assertEqual(len(opsdroid.skills), 1)
 
-    async def test_raises(self):
-        mock_obj = amock.CoroutineMock()
-        mock_obj.side_effect = Exception()
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user",
+                              "default", mock_connector)
 
-        async def wrapper(wrapped_object):
-            await wrapped_object()
+            await parse_regex(opsdroid, message)
 
-        with self.assertRaises(Exception):
-            await wrapper(mock_obj())
+            self.assertTrue(mock_skill.called)

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -1,0 +1,48 @@
+
+import asynctest
+import asynctest.mock as amock
+
+from opsdroid.core import OpsDroid
+from opsdroid.skills import match_regex
+from opsdroid.message import Message
+from opsdroid.parsers.regex import parse_regex
+
+
+class TestParserRegex(asynctest.TestCase):
+    """Test the opsdroid regex parser."""
+
+    async def test_parse_regex(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = amock.CoroutineMock()
+            match_regex(r"(.*)")(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            await parse_regex(opsdroid, message)
+
+            self.assertTrue(mock_skill.called)
+
+    # async def test_parse_regex_raises(self):
+    #     with OpsDroid() as opsdroid:
+    #         mock_skill = amock.CoroutineMock()
+    #         mock_skill.side_effect = Exception()
+    #         match_regex(r"(.*)")(mock_skill)
+    #         self.assertEqual(len(opsdroid.skills), 1)
+    #
+    #         mock_connector = amock.CoroutineMock()
+    #         message = Message("Hello world", "user",
+    #                           "default", mock_connector)
+    #
+    #         with self.assertRaises(Exception):
+    #             await parse_regex(opsdroid, message)
+
+    async def test_raises(self):
+        mock_obj = amock.CoroutineMock()
+        mock_obj.side_effect = Exception()
+
+        async def wrapper(wrapped_object):
+            await wrapped_object()
+
+        with self.assertRaises(Exception):
+            await wrapper(mock_obj())

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -12,9 +12,19 @@ class TestSkillDecorators(unittest.TestCase):
     def test_match_regex(self):
         with OpsDroid() as opsdroid:
             regex = r"(.*)"
-            decorator = skills.match_regex(regex)
             mockedskill = mock.MagicMock()
+            decorator = skills.match_regex(regex)
             decorator(mockedskill)
             self.assertEqual(len(opsdroid.skills), 1)
             self.assertEqual(opsdroid.skills[0]["regex"], regex)
+            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+
+    def test_match_apiai(self):
+        with OpsDroid() as opsdroid:
+            action = "myaction"
+            mockedskill = mock.MagicMock()
+            decorator = skills.match_apiai(action)
+            decorator(mockedskill)
+            self.assertEqual(len(opsdroid.skills), 1)
+            self.assertEqual(opsdroid.skills[0]["apiai"], action)
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,22 +1,20 @@
 
-import sys
 import unittest
 import unittest.mock as mock
 
-sys.modules['opsdroid.core'] = mock.MagicMock()
-
-from opsdroid import skills  # noqa: E402
+from opsdroid.core import OpsDroid
+from opsdroid import skills
 
 
 class TestSkillDecorators(unittest.TestCase):
     """Test the opsdroid skills decorators."""
 
     def test_match_regex(self):
-        sys.modules['opsdroid.core'].OpsDroid.instances = [mock.MagicMock()]
-        self.assertEqual(
-            len(sys.modules['opsdroid.core'].OpsDroid.instances), 1)
-        matcher = skills.match_regex(r"(.*)")
-        matcher(mock.MagicMock())
-        self.assertEqual(
-            len(sys.modules['opsdroid.core'].OpsDroid.instances[0].mock_calls),
-            1)
+        with OpsDroid() as opsdroid:
+            regex = r"(.*)"
+            decorator = skills.match_regex(regex)
+            mockedskill = mock.MagicMock()
+            decorator(mockedskill)
+            self.assertEqual(len(opsdroid.skills), 1)
+            self.assertEqual(opsdroid.skills[0]["regex"], regex)
+            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -28,3 +28,9 @@ class TestSkillDecorators(unittest.TestCase):
             self.assertEqual(len(opsdroid.skills), 1)
             self.assertEqual(opsdroid.skills[0]["apiai_action"], action)
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            intent = "myIntent"
+            decorator = skills.match_apiai_intent(intent)
+            decorator(mockedskill)
+            self.assertEqual(len(opsdroid.skills), 2)
+            self.assertEqual(opsdroid.skills[1]["apiai_intent"], intent)
+            self.assertIsInstance(opsdroid.skills[1]["skill"], mock.MagicMock)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -23,8 +23,8 @@ class TestSkillDecorators(unittest.TestCase):
         with OpsDroid() as opsdroid:
             action = "myaction"
             mockedskill = mock.MagicMock()
-            decorator = skills.match_apiai(action)
+            decorator = skills.match_apiai_action(action)
             decorator(mockedskill)
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["apiai"], action)
+            self.assertEqual(opsdroid.skills[0]["apiai_action"], action)
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)


### PR DESCRIPTION
This PR adds a parser for [api.ai](https://api.ai) which allows the creation of intents on api.ai and matching skills in opsdroid. It also moves the regex parser into it's own file and formalises the addition of new parsers.

- [x] Code
- [x] Tests/Coverage
- [x] Documentation