### PR TITLE
Change config syntax and pass config to skills

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -23,11 +23,11 @@ _Config options of the connectors themselves differ between connectors, see the 
 ```yaml
 connectors:
 
-  slack:
+  - name: slack
     token: "mysecretslacktoken"
 
   # conceptual connector
-  twitter:
+  - name: twitter
     oauth_key: "myoauthkey"
     secret_key: "myoauthsecret"
 ```
@@ -44,7 +44,7 @@ _Config options of the databases themselves differ between databases, see the da
 
 ```yaml
 databases:
-  mongo:
+  - name: mongo
     host: "mymongohost.mycompany.com"
     port: "27017"
     database: "opsdroid"
@@ -62,11 +62,11 @@ All python logging levels are available in opsdroid. `logging` can be set to `de
 logging: debug
 
 connectors:
-  shell:
+  - name: shell
 
 skills:
-  hello:
-  seen:
+  - name: hello
+  - name: seen
 ```
 
 ### `module-path`
@@ -77,11 +77,11 @@ Set the path for opsdroid to use when installing skills. Defaults to the current
 module-path: "/etc/opsdroid/modules"
 
 connectors:
-  shell:
+  - name: shell
 
 skills:
-  hello:
-  seen:
+  - name: hello
+  - name: seen
 ```
 
 ### `skills`
@@ -92,8 +92,8 @@ _Config options of the skills themselves differ between skills, see the skill do
 
 ```yaml
 skills:
-  hello:
-  seen:
+  - name: hello
+  - name: seen
 ```
 
 See [module options](#module-options) for installing custom skills.
@@ -110,9 +110,9 @@ A git url to install the module from.
 
 ```yaml
 connectors:
-  slack:
+  - name: slack
     token: "mysecretslacktoken"
-  mynewconnector:
+  - name: mynewconnector
     repo: https://github.com/username/myconnector.git
 ```
 
@@ -122,7 +122,7 @@ A local path to install the module from.
 
 ```yaml
 skills:
-  myawesomeskill:
+  - name: myawesomeskill
     path: /home/me/src/opsdroid-skills/myawesomeskill
 ```
 
@@ -130,7 +130,7 @@ Or you can specify a single file.
 
 ```yaml
 skills:
-  myawesomeskill:
+  - name: myawesomeskill
     path: /home/me/src/opsdroid-skills/myawesomeskill/myskill.py
 ```
 
@@ -140,7 +140,7 @@ Set this to do a fresh git clone of the module whenever you start opsdroid.
 
 ```yaml
 databases:
-  mongodb:
+  - name: mongodb
     repo: https://github.com/username/mymongofork.git
     no-cache: true
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,10 +30,10 @@ For example a simple barebones configuration would look like:
 
 ```yaml
 connectors:
-  shell:
+  - name: shell
 
 skills:
-  hello:
+  - name: hello
 ```
 
 This tells opsdroid to use the [shell connector](https://github.com/opsdroid/connector-shell) and [hello skill](https://github.com/opsdroid/skill-hello) from the official module library.
@@ -46,19 +46,19 @@ A more advanced config would like similar to the following:
 
 ```yaml
 connectors:
-  slack:
+  - name: slack
     token: "mysecretslacktoken"
 
 databases:
-  mongo:
+  - name: mongo
     host: "mymongohost.mycompany.com"
     port: "27017"
     database: "opsdroid"
 
 skills:
-  hello:
-  seen:
-  myawesomeskill:
+  - name: hello
+  - name: seen
+  - name: myawesomeskill
     repo: "https://github.com/username/myawesomeskill.git"
 ```
 

--- a/docs/parsers/api.ai.md
+++ b/docs/parsers/api.ai.md
@@ -39,7 +39,7 @@ You can also set a `min-score` option to tell opsdroid to ignore any matches whi
 ```yaml
 
 parsers:
-  apiai:
+  - name: apiai
     access-token: "exampleaccesstoken123"
     min-score: 0.6
 ```

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -1,42 +1,54 @@
-#                      _           _     _
-#   ___  _ __  ___  __| |_ __ ___ (_) __| |
-#  / _ \| '_ \/ __|/ _` | '__/ _ \| |/ _` |
-# | (_) | |_) \__ \ (_| | | | (_) | | (_| |
-#  \___/| .__/|___/\__,_|_|  \___/|_|\__,_|
-#       |_|
-#                   __ _
-#   ___ ___  _ __  / _(_) __ _
-#  / __/ _ \| '_ \| |_| |/ _` |
-# | (_| (_) | | | |  _| | (_| |
-#  \___\___/|_| |_|_| |_|\__, |
-#                        |___/
-#
-# A default config file to use with opsdroid
+##                      _           _     _
+##   ___  _ __  ___  __| |_ __ ___ (_) __| |
+##  / _ \| '_ \/ __|/ _` | '__/ _ \| |/ _` |
+## | (_) | |_) \__ \ (_| | | | (_) | | (_| |
+##  \___/| .__/|___/\__,_|_|  \___/|_|\__,_|
+##       |_|
+##                   __ _
+##   ___ ___  _ __  / _(_) __ _
+##  / __/ _ \| '_ \| |_| |/ _` |
+## | (_| (_) | | | |  _| | (_| |
+##  \___\___/|_| |_|_| |_|\__, |
+##                        |___/
+##
+## A default config file to use with opsdroid
 
-# Set the logging level
+## Set the logging level
 # logging: info
 
-# Set the location for opsdroid to install modules
+## Set the location for opsdroid to install modules
 # module-path: "."
 
-# Connector modules
-connectors:
-  shell:
+## Parsers
+# parsers:
+#   - name: regex
+#     enabled: true
+#
+#   - name: crontab
+#     enabled: true
+#
+#   - name: apiai
+#     access-token: "youraccesstoken"
+#     min-score: 0.6
 
-# Database modules (optional)
+## Connector modules
+connectors:
+  - name: shell
+
+## Database modules (optional)
 # databases:
 
-# Skill modules
+## Skill modules
 skills:
 
-  # Hello world (https://github.com/opsdroid/skill-hello)
-  hello:
+  ## Hello world (https://github.com/opsdroid/skill-hello)
+  - name: hello
 
-  # Last seen (https://github.com/opsdroid/skill-seen)
-  seen:
+  ## Last seen (https://github.com/opsdroid/skill-seen)
+  - name: seen
 
-  # Dance (https://github.com/opsdroid/skill-dance)
-  dance:
+  ## Dance (https://github.com/opsdroid/skill-dance)
+  - name: dance
 
-  # Loud noises (https://github.com/opsdroid/skill-loudnoises)
-  loudnoises:
+  ## Loud noises (https://github.com/opsdroid/skill-loudnoises)
+  - name: loudnoises

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -151,11 +151,16 @@ class OpsDroid():
                 self.eventloop.create_task(parse_regex(self, message)))
 
             if "parsers" in self.config:
+                logging.debug("Processing parsers")
                 parsers = self.config["parsers"]
 
                 apiai = [p for p in parsers if p["name"] == "apiai"]
-                if len(apiai) == 1 and apiai[0]["enabled"] is not False:
+                logging.debug("Checking apiai")
+                if len(apiai) == 1 and \
+                        ("enabled" not in apiai[0] or
+                         apiai[0]["enabled"] is not False):
                     logging.debug("Parsing with apiai")
                     tasks.append(
-                        self.eventloop.create_task(parse_apiai(self, message, apiai[0])))
+                        self.eventloop.create_task(
+                            parse_apiai(self, message, apiai[0])))
         return tasks

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -150,7 +150,12 @@ class OpsDroid():
             tasks.append(
                 self.eventloop.create_task(parse_regex(self, message)))
 
-            if "parsers" in self.config and "apiai" in self.config["parsers"]:
-                tasks.append(
-                    self.eventloop.create_task(parse_apiai(self, message)))
+            if "parsers" in self.config:
+                parsers = self.config["parsers"]
+
+                apiai = [p for p in parsers if p["name"] == "apiai"]
+                if len(apiai) == 1 and apiai[0]["enabled"] is not False:
+                    logging.debug("Parsing with apiai")
+                    tasks.append(
+                        self.eventloop.create_task(parse_apiai(self, message, apiai[0])))
         return tasks

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -154,12 +154,12 @@ class Loader:
         if not os.path.isdir(self.modules_directory):
             os.makedirs(self.modules_directory)
 
-        for module_name in modules.keys():
+        for module in modules:
 
             # Set up module config
-            config = modules[module_name]
+            config = module
             config = {} if config is None else config
-            config["name"] = module_name
+            config["name"] = module["name"]
             config["type"] = modules_type
             config["module_path"] = self.build_module_path("import", config)
             config["install_path"] = self.build_module_path("install", config)

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -18,6 +18,7 @@ class Loader:
         """Setup object with opsdroid instance."""
         self.opsdroid = opsdroid
         self.modules_directory = MODULES_DIRECTORY
+        self.current_import_config = None
         logging.debug("Loaded loader")
 
     @staticmethod
@@ -173,6 +174,7 @@ class Loader:
             self._install_module(config)
 
             # Import module
+            self.current_import_config = config
             module = self.import_module(config)
             if module is not None:
                 loaded_modules.append({

--- a/opsdroid/parsers/apiai.py
+++ b/opsdroid/parsers/apiai.py
@@ -28,13 +28,12 @@ async def call_apiai(message, config):
         return result
 
 
-async def parse_apiai(opsdroid, message):
+async def parse_apiai(opsdroid, message, config):
     """Parse a message against all apiai skills."""
     # pylint: disable=broad-except
     # We want to catch all exceptions coming from a skill module and not
     # halt the application. If a skill throws an exception it just doesn't
     # give a response to the user, so an error response should be given.
-    config = opsdroid.config['parsers']['apiai']
     if 'access-token' in config:
 
         result = await call_apiai(message, config)

--- a/opsdroid/parsers/apiai.py
+++ b/opsdroid/parsers/apiai.py
@@ -61,7 +61,8 @@ async def parse_apiai(opsdroid, message, config):
                                 result["result"]["intentName"]):
                         message.apiai = result
                         try:
-                            await skill["skill"](opsdroid, message)
+                            await skill["skill"](opsdroid, skill["config"],
+                                                 message)
                         except Exception:
                             await message.respond(
                                 "Whoops there has been an error")

--- a/opsdroid/parsers/crontab.py
+++ b/opsdroid/parsers/crontab.py
@@ -19,6 +19,6 @@ async def parse_crontab(opsdroid):
         for skill in opsdroid.skills:
             if "crontab" in skill and pycron.is_now(skill["crontab"]):
                 try:
-                    await skill["skill"](opsdroid, None)
+                    await skill["skill"](opsdroid, skill["config"], None)
                 except Exception:
                     logging.exception("Exception when executing cron skill.")

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -16,7 +16,7 @@ async def parse_regex(opsdroid, message):
             if regex:
                 message.regex = regex
                 try:
-                    await skill["skill"](opsdroid, message)
+                    await skill["skill"](opsdroid, skill["config"], message)
                 except Exception:
                     await message.respond(
                         "Whoops there has been an error")

--- a/opsdroid/skills.py
+++ b/opsdroid/skills.py
@@ -8,7 +8,9 @@ def match_regex(regex):
     def matcher(func):
         """Add decorated function to skills list for regex matching."""
         for opsdroid in OpsDroid.instances:
-            opsdroid.skills.append({"regex": regex, "skill": func})
+            opsdroid.skills.append({"regex": regex, "skill": func,
+                                    "config":
+                                    opsdroid.loader.current_import_config})
         return func
     return matcher
 
@@ -18,7 +20,9 @@ def match_apiai_action(action):
     def matcher(func):
         """Add decorated function to skills list for apiai matching."""
         for opsdroid in OpsDroid.instances:
-            opsdroid.skills.append({"apiai_action": action, "skill": func})
+            opsdroid.skills.append({"apiai_action": action, "skill": func,
+                                    "config":
+                                    opsdroid.loader.current_import_config})
         return func
     return matcher
 
@@ -28,7 +32,9 @@ def match_apiai_intent(intent):
     def matcher(func):
         """Add decorated function to skills list for apiai matching."""
         for opsdroid in OpsDroid.instances:
-            opsdroid.skills.append({"apiai_intent": intent, "skill": func})
+            opsdroid.skills.append({"apiai_intent": intent, "skill": func,
+                                    "config":
+                                    opsdroid.loader.current_import_config})
         return func
     return matcher
 
@@ -38,6 +44,8 @@ def match_crontab(crontab):
     def matcher(func):
         """Add decorated function to skills list for crontab matching."""
         for opsdroid in OpsDroid.instances:
-            opsdroid.skills.append({"crontab": crontab, "skill": func})
+            opsdroid.skills.append({"crontab": crontab, "skill": func,
+                                    "config":
+                                    opsdroid.loader.current_import_config})
         return func
     return matcher

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import importlib
 from opsdroid.core import OpsDroid
 from opsdroid.message import Message
 from opsdroid.connector import Connector
-from opsdroid.skills import match_regex
+from opsdroid.skills import match_regex, match_apiai_action
 
 
 class TestCore(unittest.TestCase):
@@ -124,7 +124,7 @@ class TestCore(unittest.TestCase):
 class TestCoreAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid core class."""
 
-    async def test_parse(self):
+    async def test_parse_regex(self):
         with OpsDroid() as opsdroid:
             regex = r".*"
             skill = amock.CoroutineMock()
@@ -136,3 +136,18 @@ class TestCoreAsync(asynctest.TestCase):
             for task in tasks:
                 await task
             self.assertTrue(skill.called)
+
+    async def test_parse_apiai(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [{"name": "apiai"}]
+            apiai_action = ""
+            skill = amock.CoroutineMock()
+            mock_connector = Connector({})
+            decorator = match_apiai_action(apiai_action)
+            decorator(skill)
+            message = Message("Hello world", "user", "default", mock_connector)
+            with amock.patch('opsdroid.parsers.apiai.parse_apiai'):
+                tasks = await opsdroid.parse(message)
+                self.assertEqual(len(tasks), 2)  # apiai and regex
+                for task in tasks:
+                    await task

--- a/tests/test_parser_apiai.py
+++ b/tests/test_parser_apiai.py
@@ -17,7 +17,7 @@ class TestParserApiai(asynctest.TestCase):
     async def test_call_apiai(self):
         mock_connector = Connector({})
         message = Message("Hello world", "user", "default", mock_connector)
-        config = {'access-token': 'test'}
+        config = {'name': 'apiai', 'access-token': 'test'}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
         result.json.return_value = {
@@ -38,9 +38,9 @@ class TestParserApiai(asynctest.TestCase):
 
     async def test_parse_apiai(self):
         with OpsDroid() as opsdroid:
-            opsdroid.config['parsers'] = {
-                    'apiai': {'access-token': "test"}
-                }
+            opsdroid.config['parsers'] = [
+                    {'name': 'apiai', 'access-token': "test"}
+                ]
             mock_skill = amock.CoroutineMock()
             match_apiai_action('myaction')(mock_skill)
 
@@ -58,15 +58,16 @@ class TestParserApiai(asynctest.TestCase):
                             "errorType": "success"
                         }
                     }
-                await apiai.parse_apiai(opsdroid, message)
+                await apiai.parse_apiai(opsdroid, message,
+                                        opsdroid.config['parsers'][0])
 
             self.assertTrue(mock_skill.called)
 
     async def test_parse_apiai_raises(self):
         with OpsDroid() as opsdroid:
-            opsdroid.config['parsers'] = {
-                    'apiai': {'access-token': "test"}
-                }
+            opsdroid.config['parsers'] = [
+                    {'name': 'apiai', 'access-token': "test"}
+                ]
             mock_skill = amock.CoroutineMock()
             mock_skill.side_effect = Exception()
             match_apiai_action('myaction')(mock_skill)
@@ -85,15 +86,16 @@ class TestParserApiai(asynctest.TestCase):
                             "errorType": "success"
                         }
                     }
-                await apiai.parse_apiai(opsdroid, message)
+                await apiai.parse_apiai(opsdroid, message,
+                                        opsdroid.config['parsers'][0])
 
             self.assertTrue(mock_skill.called)
 
     async def test_parse_apiai_failure(self):
         with OpsDroid() as opsdroid:
-            opsdroid.config['parsers'] = {
-                    'apiai': {'access-token': "test"}
-                }
+            opsdroid.config['parsers'] = [
+                    {'name': 'apiai', 'access-token': "test"}
+                ]
             mock_skill = amock.CoroutineMock()
             match_apiai_action('myaction')(mock_skill)
 
@@ -111,15 +113,16 @@ class TestParserApiai(asynctest.TestCase):
                             "errorType": "not found"
                         }
                     }
-                await apiai.parse_apiai(opsdroid, message)
+                await apiai.parse_apiai(opsdroid, message,
+                                        opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
 
     async def test_parse_apiai_low_score(self):
         with OpsDroid() as opsdroid:
-            opsdroid.config['parsers'] = {
-                    'apiai': {'access-token': "test", "min-score": 0.8}
-                }
+            opsdroid.config['parsers'] = [
+                    {'name': 'apiai', 'access-token': "test", "min-score": 0.8}
+                ]
             mock_skill = amock.CoroutineMock()
             match_apiai_action('myaction')(mock_skill)
 
@@ -137,6 +140,7 @@ class TestParserApiai(asynctest.TestCase):
                             "errorType": "success"
                         }
                     }
-                await apiai.parse_apiai(opsdroid, message)
+                await apiai.parse_apiai(opsdroid, message,
+                                        opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)


### PR DESCRIPTION
### Change config syntax

Configs of connectors, databases, skills and parsers are now lists instead of dictionaries. Fixes #77.

Before

```yaml
connectors:
  slack:
    api-token: "mytoken"

skills:
  hello:
  seen:
  dance:
```

After

```yaml
connectors:
  - name: slack
    api-token: "mytoken"

skills:
  - name: hello
  - name: seen
  - name: dance
```

### Pass config to skills

Previously a skill would access its config from the opsdroid object passed to the skill. However the skill creator cannot be sure what name the user will give the skill. Therefore the config specific to that skill should be passed as a separate argument.

Before
```python
@match_regex(r"myregex") 
async def myskill(opsdroid, message):
    pass
```

After
```python
@match_regex(r"myregex") 
async def myskill(opsdroid, config, message):
    pass
```

- [x] Code
- [x] Tests
- [x] Documentation