### PR TITLE
Fix home dir config and missing config warnings

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import weakref
 import asyncio
+import os.path
 
 from opsdroid.memory import Memory
 from opsdroid.connector import Connector
@@ -78,7 +79,8 @@ class OpsDroid():
         """Load configuration."""
         self.config = self.loader.load_config_file([
             "./configuration.yaml",
-            "~/.opsdroid/configuration.yaml",
+            os.path.join(os.path.expanduser("~"),
+                         ".opsdroid/configuration.yaml"),
             "/etc/opsdroid/configuration.yaml"
             ])
 

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -97,8 +97,8 @@ class Loader:
         config_path = ""
         for possible_path in config_paths:
             if not os.path.isfile(possible_path):
-                logging.warning("Config file " + possible_path +
-                                " not found", 1)
+                logging.debug("Config file " + possible_path +
+                                " not found")
             else:
                 config_path = possible_path
                 break
@@ -108,6 +108,7 @@ class Loader:
 
         try:
             with open(config_path, 'r') as stream:
+                logging.info("Loaded config from {}".format(config_path))
                 return yaml.load(stream)
         except yaml.YAMLError as error:
             self.opsdroid.critical(error, 1)

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -108,7 +108,7 @@ class Loader:
 
         try:
             with open(config_path, 'r') as stream:
-                logging.info("Loaded config from {}".format(config_path))
+                logging.info("Loaded config from %s", config_path)
                 return yaml.load(stream)
         except yaml.YAMLError as error:
             self.opsdroid.critical(error, 1)

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -98,7 +98,7 @@ class Loader:
         for possible_path in config_paths:
             if not os.path.isfile(possible_path):
                 logging.debug("Config file " + possible_path +
-                                " not found")
+                              " not found")
             else:
                 config_path = possible_path
                 break


### PR DESCRIPTION
This fixes the ability to load config from `~/.opsdroid/configuration.yaml` (#75) and the long errors given when trying to load a missing config file (#76).