### PR TITLE
Add RESTful web server and webhook parser

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -105,6 +105,18 @@ skills:
 
 See [module options](#module-options) for installing custom skills.
 
+### `web`
+
+Configure the REST API in opsdroid.
+
+By default opsdroid will start a web server on port `8080` accessible only to localhost. For more information see the [REST API docs](rest-api).
+
+```yaml
+web:
+  host: '127.0.0.1'  # set to '0.0.0.0' to allow all traffic
+  port: 8080
+```
+
 ## Module options
 
 All modules are installed from git repositories. By default if no additional options are specified opsdroid will look for the repository at `https://github.com/opsdroid/<moduletype>-<modulename>.git`.

--- a/docs/parsers/crontab.md
+++ b/docs/parsers/crontab.md
@@ -6,6 +6,7 @@ The crontab parser is a bit different to other parsers. This parser doesn't take
 
 ```python
 from opsdroid.matchers import match_crontab
+from opsdroid.message import Message
 
 @match_crontab('* * * * *')
 async def mycrontabskill(opsdroid, config, message):

--- a/docs/parsers/overview.md
+++ b/docs/parsers/overview.md
@@ -3,9 +3,11 @@
 When writing skills for opsdroid there are multiple parsers you can use for matching messages to your functions.
 
  * [Regular Expression](parsers/regex)
-  * `opsdroid.skills.match_regex`
+    * `opsdroid.skills.match_regex`
  * [API.AI](parsers/api.ai)
-  * `opsdroid.skills.match_apiai_action`
-  * `opsdroid.skills.match_apiai_intent`
+    * `opsdroid.skills.match_apiai_action`
+    * `opsdroid.skills.match_apiai_intent`
  * [Crontab](parsers/crontab)
-  * `opsdroid.skills.match_crontab`
+    * `opsdroid.skills.match_crontab`
+ * [Webhook](parsers/webhook)
+    * `opsdroid.skills.match_webhook`

--- a/docs/parsers/webhook.md
+++ b/docs/parsers/webhook.md
@@ -1,0 +1,33 @@
+# Webhook Parser
+
+Similar to the crontab parser this parser doesn't take a message as an input, it takes a webhook instead. It allows you to trigger the skill by calling a specific URL endpoint.
+
+## Example
+
+```python
+from aiohttp.web import Request
+
+from opsdroid.matchers import match_webhook
+from opsdroid.message import Message
+
+@match_webhook('examplewebhook')
+async def mycrontabskill(opsdroid, config, message):
+
+    if type(message) is not Message and type(message) is Request:
+      # Capture the request POST data and set message to a default message
+      request = await message.post()
+      message = Message("", None, connector.default_room,
+                        opsdroid.default_connector)
+
+    # Respond
+    await message.respond('Hey')
+```
+
+**Config**
+
+```yaml
+skills:
+  - name: "exampleskill"
+```
+
+The above skill would be called if you send a POST to `http://localhost:8080/skill/exampleskill/examplewebhook`. As the skill is being triggered by a webhook the `message` argument being passed in will be set to the [aiohttp Request](http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.BaseRequest), this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_room` properties to get some sensible defaults.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,0 +1,64 @@
+# REST API
+
+There is a RESTful API for opsdroid which by default is only accessible to `localhost` on port `8080`. See the [configuration reference](configuration-reference#web) for config options.
+
+## Methods
+
+### `/` _[GET]_
+
+A test url you can use to check whether the API is running.
+
+**Example response**
+
+```json
+{
+  "timestamp": "2017-02-05T10:12:51.622981",
+  "status": 200,
+  "result": {
+    "message": "Welcome to the opsdroid API"
+  }
+}
+```
+
+### `/stats/` _[GET]_
+
+This method returns runtime statistics which could be useful in monitoring.
+
+**Example response**
+
+```json
+{
+  "timestamp": "2017-02-05T10:14:37.494541",
+  "status": 200,
+  "result": {
+    "version": "0.6.0",
+    "messages": {
+      "total_parsed": 164,
+      "webhooks_called": 28
+    },
+    "modules": {
+      "skills": 13,
+      "connectors": 1,
+      "databases": 0
+    }
+  }
+}
+```
+
+### `/skill/{skillname}/{webhookname}` _[POST]_
+
+This method family will call skills which have been decorated with the [webhook matcher](parsers/webhook). The URI format includes the name of the skill from the `configuration.yaml` and the name of the webhook set in the decorator.
+
+The response includes information on whether a skill was successfully triggered or not.
+
+**Example response**
+
+```json
+{
+  "timestamp": "2017-02-04T16:25:01.956323",
+  "status": 200,
+  "result": {
+    "called_skill": "examplewebhookskill"
+  }
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ pages:
   - Home: 'index.md'
   - Getting Started: 'getting-started.md'
   - Configuration Reference: 'configuration-reference.md'
+  - REST API: 'rest-api.md'
   - Extending opsdroid:
     - Adding skills: 'extending/skills.md'
     - Adding connectors: 'extending/connectors.md'
@@ -14,4 +15,6 @@ pages:
     - Overview: 'parsers/overview.md'
     - Regular Expressions: 'parsers/regex.md'
     - API.AI: 'parsers/api.ai.md'
+    - Crontab: 'parsers/crontab.md'
+    - Webhook: 'parsers/webhook.md'
   - Contributing: 'contributing.md'

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -7,6 +7,7 @@ import argparse
 
 from opsdroid.core import OpsDroid
 from opsdroid.const import LOG_FILENAME
+from opsdroid.web import Web
 
 
 _LOGGER = logging.getLogger("opsdroid")
@@ -99,6 +100,7 @@ def main():
     with OpsDroid() as opsdroid:
         opsdroid.load()
         configure_logging(opsdroid.config)
+        opsdroid.web_server = Web(opsdroid)
         opsdroid.start_loop()
         opsdroid.exit()
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -37,6 +37,11 @@ class OpsDroid():
         self.memory = Memory()
         self.loader = Loader(self)
         self.config = {}
+        self.stats = {
+            "messages_parsed": 0,
+            "webhooks_called": 0
+        }
+        self.web_server = None
         _LOGGER.info("Created main opsdroid object")
 
     def __enter__(self):
@@ -95,6 +100,7 @@ class OpsDroid():
         self.setup_skills(skills)
         self.start_connector_tasks(connectors)
         self.eventloop.create_task(parse_crontab(self))
+        self.web_server.start()
         try:
             self.eventloop.run_forever()
         except (KeyboardInterrupt, EOFError):
@@ -147,6 +153,7 @@ class OpsDroid():
 
     async def parse(self, message):
         """Parse a string against all skills."""
+        self.stats["messages_parsed"] = self.stats["messages_parsed"] + 1
         tasks = []
         if message.text.strip() != "":
             _LOGGER.debug("Parsing input: " + message.text)

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -55,7 +55,7 @@ class Web:
                     port=self.get_port, print=_LOGGER.info)
 
     @staticmethod
-    def build_response(status, result, task=None):
+    def build_response(status, result):
         """Build a json response object."""
         return web.Response(text=json.dumps({
             "timestamp": datetime.now().isoformat(),

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -1,0 +1,84 @@
+"""Submodule to handle web requests in opsdroid."""
+
+import json
+import logging
+from datetime import datetime
+
+from aiohttp import web
+
+from opsdroid.const import __version__
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Web:
+    """Web server for opsdroid."""
+
+    def __init__(self, opsdroid):
+        """Setup web object."""
+        self.opsdroid = opsdroid
+        try:
+            self.config = self.opsdroid.config["web"]
+        except KeyError:
+            self.config = {}
+        self.web_app = web.Application(loop=self.opsdroid.eventloop)
+        self.web_app.router.add_get('/', self.web_index_handler)
+        self.web_app.router.add_get('', self.web_index_handler)
+        self.web_app.router.add_get('/stats', self.web_stats_handler)
+        self.web_app.router.add_get('/stats/', self.web_stats_handler)
+
+    @property
+    def get_port(self):
+        """Return port from config or the default."""
+        try:
+            port = self.config["port"]
+        except KeyError:
+            port = 8080
+        return port
+
+    @property
+    def get_host(self):
+        """Return host from config or the default."""
+        try:
+            host = self.config["host"]
+        except KeyError:
+            host = '127.0.0.1'
+        return host
+
+    def start(self):
+        """Start web servers."""
+        _LOGGER.debug(
+            "Starting web server with host %s and port %s",
+            self.get_host, self.get_port)
+        web.run_app(self.web_app, host=self.get_host,
+                    port=self.get_port, print=_LOGGER.info)
+
+    @staticmethod
+    def build_response(status, result, task=None):
+        """Build a json response object."""
+        return web.Response(text=json.dumps({
+            "timestamp": datetime.now().isoformat(),
+            "status": status,
+            "result": result
+        }))
+
+    def web_index_handler(self, request):
+        """Handle root web request."""
+        return self.build_response(200, {
+            "message": "Welcome to the opsdroid API"})
+
+    def web_stats_handler(self, request):
+        """Handle stats request."""
+        return self.build_response(200, {
+            "version": __version__,
+            "messages": {
+                "total_parsed": self.opsdroid.stats["messages_parsed"],
+                "webhooks_called": self.opsdroid.stats["webhooks_called"]
+            },
+            "modules": {
+                "skills": len(self.opsdroid.skills),
+                "connectors": len(self.opsdroid.connectors),
+                "databases": len(self.opsdroid.memory.databases)
+            }
+        })

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,6 +38,7 @@ class TestCore(unittest.TestCase):
     def test_start_loop(self):
         with OpsDroid() as opsdroid:
             mockconfig = {}, {}, {}
+            opsdroid.web_server = mock.Mock()
             opsdroid.loader = mock.Mock()
             opsdroid.loader.load_config = mock.Mock(return_value=mockconfig)
             opsdroid.start_databases = mock.Mock()

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -3,11 +3,12 @@ import unittest
 import unittest.mock as mock
 
 from opsdroid.core import OpsDroid
+from opsdroid.web import Web
 from opsdroid import matchers
 
 
-class TestSkillDecorators(unittest.TestCase):
-    """Test the opsdroid skills decorators."""
+class TestMatchers(unittest.TestCase):
+    """Test the opsdroid matcher decorators."""
 
     def test_match_regex(self):
         with OpsDroid() as opsdroid:
@@ -44,3 +45,18 @@ class TestSkillDecorators(unittest.TestCase):
             self.assertEqual(len(opsdroid.skills), 1)
             self.assertEqual(opsdroid.skills[0]["crontab"], crontab)
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+
+    def test_match_webhook(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.loader.current_import_config = {"name": "testhook"}
+            opsdroid.web_server = Web(opsdroid)
+            opsdroid.web_server.web_app = mock.Mock()
+            webhook = "test"
+            mockedskill = mock.MagicMock()
+            decorator = matchers.match_webhook(webhook)
+            decorator(mockedskill)
+            self.assertEqual(len(opsdroid.skills), 1)
+            self.assertEqual(opsdroid.skills[0]["webhook"], webhook)
+            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(
+                opsdroid.web_server.web_app.router.add_post.call_count, 2)

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -1,16 +1,18 @@
 
-import unittest
-import unittest.mock as mock
+import asynctest
+import asynctest.mock as mock
+
+import aiohttp.web
 
 from opsdroid.core import OpsDroid
 from opsdroid.web import Web
 from opsdroid import matchers
 
 
-class TestMatchers(unittest.TestCase):
+class TestMatchers(asynctest.TestCase):
     """Test the opsdroid matcher decorators."""
 
-    def test_match_regex(self):
+    async def test_match_regex(self):
         with OpsDroid() as opsdroid:
             regex = r"(.*)"
             mockedskill = mock.MagicMock()
@@ -20,7 +22,7 @@ class TestMatchers(unittest.TestCase):
             self.assertEqual(opsdroid.skills[0]["regex"], regex)
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
 
-    def test_match_apiai(self):
+    async def test_match_apiai(self):
         with OpsDroid() as opsdroid:
             action = "myaction"
             mockedskill = mock.MagicMock()
@@ -36,7 +38,7 @@ class TestMatchers(unittest.TestCase):
             self.assertEqual(opsdroid.skills[1]["apiai_intent"], intent)
             self.assertIsInstance(opsdroid.skills[1]["skill"], mock.MagicMock)
 
-    def test_match_crontab(self):
+    async def test_match_crontab(self):
         with OpsDroid() as opsdroid:
             crontab = "* * * * *"
             mockedskill = mock.MagicMock()
@@ -46,7 +48,7 @@ class TestMatchers(unittest.TestCase):
             self.assertEqual(opsdroid.skills[0]["crontab"], crontab)
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
 
-    def test_match_webhook(self):
+    async def test_match_webhook(self):
         with OpsDroid() as opsdroid:
             opsdroid.loader.current_import_config = {"name": "testhook"}
             opsdroid.web_server = Web(opsdroid)
@@ -60,3 +62,18 @@ class TestMatchers(unittest.TestCase):
             self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
             self.assertEqual(
                 opsdroid.web_server.web_app.router.add_post.call_count, 2)
+
+    async def test_match_webhook_response(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.loader.current_import_config = {"name": "testhook"}
+            opsdroid.web_server = Web(opsdroid)
+            opsdroid.web_server.web_app = mock.Mock()
+            webhook = "test"
+            mockedskill = mock.CoroutineMock()
+            decorator = matchers.match_webhook(webhook)
+            decorator(mockedskill)
+            postcalls, _ = \
+                opsdroid.web_server.web_app.router.add_post.call_args_list[0]
+            wrapperfunc = postcalls[1]
+            webhookresponse = await wrapperfunc(None)
+            self.assertEqual(type(webhookresponse), aiohttp.web.Response)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,63 @@
+
+import asynctest
+
+from opsdroid.core import OpsDroid
+from opsdroid import web
+import aiohttp.web
+
+
+class TestWeb(asynctest.TestCase):
+    """Test the opsdroid web class."""
+
+    async def test_web(self):
+        """Create a web object and check the config."""
+        with OpsDroid() as opsdroid:
+            app = web.Web(opsdroid)
+            self.assertEqual(app.config, {})
+
+    async def test_web_get_port(self):
+        """Check the port getter."""
+        with OpsDroid() as opsdroid:
+            opsdroid.config["web"] = {}
+            app = web.Web(opsdroid)
+            self.assertEqual(app.get_port, 8080)
+
+            opsdroid.config["web"] = {"port": 8000}
+            app = web.Web(opsdroid)
+            self.assertEqual(app.get_port, 8000)
+
+    async def test_web_get_host(self):
+        """Check the host getter."""
+        with OpsDroid() as opsdroid:
+            opsdroid.config["web"] = {}
+            app = web.Web(opsdroid)
+            self.assertEqual(app.get_host, "127.0.0.1")
+
+            opsdroid.config["web"] = {"host": "0.0.0.0"}
+            app = web.Web(opsdroid)
+            self.assertEqual(app.get_host, "0.0.0.0")
+
+    async def test_web_build_response(self):
+        """Check the response builder."""
+        with OpsDroid() as opsdroid:
+            opsdroid.config["web"] = {}
+            app = web.Web(opsdroid)
+            response = {"test": "test"}
+            resp = app.build_response(200, response)
+            self.assertEqual(type(resp), aiohttp.web.Response)
+
+    async def test_web_index_handler(self):
+        """Check the index handler."""
+        with OpsDroid() as opsdroid:
+            opsdroid.config["web"] = {}
+            app = web.Web(opsdroid)
+            self.assertEqual(
+                type(app.web_index_handler(None)), aiohttp.web.Response)
+
+    async def test_web_stats_handler(self):
+        """Check the stats handler."""
+        with OpsDroid() as opsdroid:
+            opsdroid.config["web"] = {}
+            app = web.Web(opsdroid)
+            self.assertEqual(
+                type(app.web_stats_handler(None)), aiohttp.web.Response)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 
 import asynctest
+import asynctest.mock as amock
 
 from opsdroid.core import OpsDroid
 from opsdroid import web
@@ -61,3 +62,11 @@ class TestWeb(asynctest.TestCase):
             app = web.Web(opsdroid)
             self.assertEqual(
                 type(app.web_stats_handler(None)), aiohttp.web.Response)
+
+    async def test_web_start(self):
+        """Check the stats handler."""
+        with OpsDroid() as opsdroid:
+            with amock.patch('aiohttp.web.run_app') as webmock:
+                app = web.Web(opsdroid)
+                app.start()
+                self.assertTrue(webmock.called)


### PR DESCRIPTION
- [x] code
  - [x] web server
  - [x] matcher
- [x] tests
- [x] documentation

This PR adds a web server to opsdroid. The two main uses of this will be adding a RESTful web server for querying things like stats for monitoring and also a new matcher for webhooks to specific urls.

#### Web server and RESTful API
There are currently two methods implemented:
 - `/` returns a welcome message to opsdroid
 - `/stats/` returns a dictionary of metrics for opsdroid including messages parsed

There are new optional config items for specifying the server host and port numbers.

```yaml
web:
  host: "127.0.0.1"  # Only accept local requests, set to "0.0.0.0" to accept all traffic
  port: 8080
```

#### webhook parser
A new matcher `match_webhook` has been added which will cause a skill to be executed when an API endpoint receives a request. The API will return a success message if a skill is triggered but no information on the skill's execution as it happens asynchronously. 

Methods will be added dynamically at load time and follow this format:

 - `/skill/{skillname}/{webhookname}/`

example skill
```python
from opsdroid.matchers import match_webhook

@match_webhook("testhook")
async def testhook(opsdroid, config, message):
    # Call some skill code
```

example config
```yaml
skills:
  - name: "testskill"
```

To trigger this skill make a request to `http://localhost:8080/skill/testskill/testhook`. The response body will look like:

```json
{
  "timestamp": "2017-02-03T23:49:06.130275",
  "status": 200,
  "result": {
    "called_skill": "testhook"
  }
}
```