### PR TITLE
Auto generate config if none exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,14 @@ An open source python chat-ops bot framework.
 
 ```
 pip3 install opsdroid
-mkdir ~/.opsdroid
-opsdroid --gen-config > ~/.opsdroid/configuration.yaml
 opsdroid
 ```
 
 ## Configuration
 
-Configuration is done in a yaml file called `configuration.yaml`. See the [full reference](http://opsdroid.readthedocs.io/en/latest/configuration-reference/).
+Configuration is done in a yaml file called `configuration.yaml`. This will be created automatically for you in `~/.opsdroid`. See the [full reference](http://opsdroid.readthedocs.io/en/latest/configuration-reference/).
 
-Example:
+Example config:
 
 ```yaml
 ##                      _           _     _

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,8 @@ For configuration you simply need to create a single YAML file named `configurat
  * `~/.opsdroid/configuration.yaml`
  * `/etc/opsdroid/configuration.yaml`
 
+ If none are found then `~/.opsdroid/configuration.yaml` will be created for you.
+
 The opsdroid project itself is very simple and requires modules to give it functionality. In your configuration file you must specify the connector, skill and database* modules you wish to use and any options they may require.
 
 **Connectors** are modules for connecting opsdroid to your specific chat service. **Skills** are modules which define what actions opsdroid should perform based on different chat messages. **Database** modules connect opsdroid to your chosen database and allows skills to store information between messages.

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -1,7 +1,6 @@
 """Starts opsdroid."""
 
 import sys
-import os
 import logging
 import argparse
 

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -6,7 +6,7 @@ import logging
 import argparse
 
 from opsdroid.core import OpsDroid
-from opsdroid.const import LOG_FILENAME
+from opsdroid.const import LOG_FILENAME, EXAMPLE_CONFIG_FILE
 from opsdroid.web import Web
 
 
@@ -88,10 +88,7 @@ def main():
     args = parse_args(sys.argv[1:])
 
     if args.gen_config:
-        path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "configuration/example_configuration.yaml")
-        with open(path, 'r') as conf:
+        with open(EXAMPLE_CONFIG_FILE, 'r') as conf:
             print(conf.read())
         sys.exit(0)
 

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -37,6 +37,7 @@
 ## Connector modules
 connectors:
   - name: shell
+  - name: websocket
 
 ## Database modules (optional)
 # databases:

--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -1,9 +1,14 @@
 """Constants used by OpsDroid."""
+import os
 
 __version__ = "0.8.0"
 
 LOG_FILENAME = 'output.log'
 DEFAULT_GIT_URL = "https://github.com/opsdroid/"
 MODULES_DIRECTORY = "opsdroid-modules"
-DEFAULT_MODULES_PATH = "~/.opsdroid/modules"
+DEFAULT_ROOT_PATH = os.path.join(os.path.expanduser("~"), ".opsdroid")
+DEFAULT_MODULES_PATH = os.path.join(DEFAULT_ROOT_PATH, "modules")
+DEFAULT_CONFIG_PATH = os.path.join(DEFAULT_ROOT_PATH, "configuration.yaml")
 DEFAULT_MODULE_BRANCH = "master"
+EXAMPLE_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   "configuration/example_configuration.yaml")

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -13,6 +13,7 @@ from opsdroid.loader import Loader
 from opsdroid.parsers.regex import parse_regex
 from opsdroid.parsers.apiai import parse_apiai
 from opsdroid.parsers.crontab import parse_crontab
+from opsdroid.const import DEFAULT_CONFIG_PATH
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,8 +90,7 @@ class OpsDroid():
         """Load configuration."""
         self.config = self.loader.load_config_file([
             "./configuration.yaml",
-            os.path.join(os.path.expanduser("~"),
-                         ".opsdroid/configuration.yaml"),
+            DEFAULT_CONFIG_PATH,
             "/etc/opsdroid/configuration.yaml"
             ])
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -4,7 +4,6 @@ import logging
 import sys
 import weakref
 import asyncio
-import os.path
 
 from opsdroid.memory import Memory
 from opsdroid.connector import Connector

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -9,7 +9,7 @@ import importlib
 import yaml
 from opsdroid.const import (
     DEFAULT_GIT_URL, MODULES_DIRECTORY, DEFAULT_MODULES_PATH,
-    DEFAULT_MODULE_BRANCH)
+    DEFAULT_MODULE_BRANCH, DEFAULT_CONFIG_PATH, EXAMPLE_CONFIG_FILE)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -100,6 +100,16 @@ class Loader:
                     _LOGGER.debug(str(line).strip())
         process.wait()
 
+    @staticmethod
+    def create_default_config():
+        """Create a default config file based on the included example."""
+        _LOGGER.info("Creating %s.", DEFAULT_CONFIG_PATH)
+        config_dir, _ = os.path.split(DEFAULT_CONFIG_PATH)
+        if not os.path.isdir(config_dir):
+            os.makedirs(config_dir)
+        shutil.copyfile(EXAMPLE_CONFIG_FILE, DEFAULT_CONFIG_PATH)
+        return DEFAULT_CONFIG_PATH
+
     def load_config_file(self, config_paths):
         """Load a yaml config file from path."""
         config_path = ""
@@ -112,7 +122,8 @@ class Loader:
                 break
 
         if not config_path:
-            self.opsdroid.critical("No configuration files found", 1)
+            _LOGGER.info("No configuration files found.")
+            config_path = self.create_default_config()
 
         try:
             with open(config_path, 'r') as stream:

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -101,14 +101,14 @@ class Loader:
         process.wait()
 
     @staticmethod
-    def create_default_config():
+    def create_default_config(config_path):
         """Create a default config file based on the included example."""
-        _LOGGER.info("Creating %s.", DEFAULT_CONFIG_PATH)
-        config_dir, _ = os.path.split(DEFAULT_CONFIG_PATH)
+        _LOGGER.info("Creating %s.", config_path)
+        config_dir, _ = os.path.split(config_path)
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir)
-        shutil.copyfile(EXAMPLE_CONFIG_FILE, DEFAULT_CONFIG_PATH)
-        return DEFAULT_CONFIG_PATH
+        shutil.copyfile(EXAMPLE_CONFIG_FILE, config_path)
+        return config_path
 
     def load_config_file(self, config_paths):
         """Load a yaml config file from path."""
@@ -123,7 +123,7 @@ class Loader:
 
         if not config_path:
             _LOGGER.info("No configuration files found.")
-            config_path = self.create_default_config()
+            config_path = self.create_default_config(DEFAULT_CONFIG_PATH)
 
         try:
             with open(config_path, 'r') as stream:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -38,12 +38,20 @@ class TestLoader(unittest.TestCase):
         self.assertTrue(os.path.isfile(test_config_path))
         shutil.rmtree(os.path.split(test_config_path)[0])
 
-    def test_load_non_existant_config_file(self):
+    def test_generate_config_if_none_exist(self):
         opsdroid, loader = self.setup()
         loader.create_default_config = mock.Mock(
             return_value="tests/configs/minimal.yaml")
         loader.load_config_file(["file_which_does_not_exist"])
         self.assertTrue(loader.create_default_config.called)
+
+    def test_load_non_existant_config_file(self):
+        opsdroid, loader = self.setup()
+        loader.create_default_config = mock.Mock(
+            return_value="/tmp/my_nonexistant_config")
+        loader.load_config_file(["file_which_does_not_exist"])
+        self.assertTrue(loader.create_default_config.called)
+        self.assertTrue(loader.opsdroid.critical.called)
 
     def test_load_broken_config_file(self):
         opsdroid, loader = self.setup()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -31,9 +31,10 @@ class TestLoader(unittest.TestCase):
 
     def test_load_non_existant_config_file(self):
         opsdroid, loader = self.setup()
-        loader.opsdroid.critical = mock.Mock()
+        loader.create_default_config = mock.Mock(
+            return_value="tests/configs/minimal.yaml")
         loader.load_config_file(["file_which_does_not_exist"])
-        self.assertTrue(loader.opsdroid.critical.called)
+        self.assertTrue(loader.create_default_config.called)
 
     def test_load_broken_config_file(self):
         opsdroid, loader = self.setup()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -29,6 +29,15 @@ class TestLoader(unittest.TestCase):
         config = loader.load_config_file(["tests/configs/minimal.yaml"])
         self.assertIsNotNone(config)
 
+    def test_create_default_config(self):
+        test_config_path = "/tmp/test_config_path/configuration.yaml"
+        opsdroid, loader = self.setup()
+
+        self.assertEqual(loader.create_default_config(test_config_path),
+                         test_config_path)
+        self.assertTrue(os.path.isfile(test_config_path))
+        shutil.rmtree(os.path.split(test_config_path)[0])
+
     def test_load_non_existant_config_file(self):
         opsdroid, loader = self.setup()
         loader.create_default_config = mock.Mock(


### PR DESCRIPTION
Automatically generate config in `~/.opsdroid/configuration.yaml` if no config can be found.

Fixes #127.

