### PR TITLE
Install module deps to ~/.opsdroid

### DIFF
--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -8,6 +8,7 @@ DEFAULT_GIT_URL = "https://github.com/opsdroid/"
 MODULES_DIRECTORY = "opsdroid-modules"
 DEFAULT_ROOT_PATH = os.path.join(os.path.expanduser("~"), ".opsdroid")
 DEFAULT_MODULES_PATH = os.path.join(DEFAULT_ROOT_PATH, "modules")
+DEFAULT_MODULE_DEPS_PATH = os.path.join(DEFAULT_ROOT_PATH, "site-packages")
 DEFAULT_CONFIG_PATH = os.path.join(DEFAULT_ROOT_PATH, "configuration.yaml")
 DEFAULT_MODULE_BRANCH = "master"
 EXAMPLE_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -92,7 +92,8 @@ class Loader:
     def pip_install_deps(requirements_path):
         """Pip install a requirements.txt file and wait for finish."""
         process = subprocess.Popen(["pip", "install",
-                                    "--target={}".format(DEFAULT_MODULE_DEPS_PATH),
+                                    "--target={}".format(
+                                        DEFAULT_MODULE_DEPS_PATH),
                                     "--ignore-installed",
                                     "-r", requirements_path],
                                    shell=False,

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -9,7 +9,8 @@ import importlib
 import yaml
 from opsdroid.const import (
     DEFAULT_GIT_URL, MODULES_DIRECTORY, DEFAULT_MODULES_PATH,
-    DEFAULT_MODULE_BRANCH, DEFAULT_CONFIG_PATH, EXAMPLE_CONFIG_FILE)
+    DEFAULT_MODULE_BRANCH, DEFAULT_CONFIG_PATH, EXAMPLE_CONFIG_FILE,
+    DEFAULT_MODULE_DEPS_PATH)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -90,7 +91,10 @@ class Loader:
     @staticmethod
     def pip_install_deps(requirements_path):
         """Pip install a requirements.txt file and wait for finish."""
-        process = subprocess.Popen(["pip", "install", "-r", requirements_path],
+        process = subprocess.Popen(["pip", "install",
+                                    "--target={}".format(DEFAULT_MODULE_DEPS_PATH),
+                                    "--ignore-installed",
+                                    "-r", requirements_path],
                                    shell=False,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
@@ -180,6 +184,10 @@ class Loader:
         """Install and load modules."""
         _LOGGER.debug("Loading " + modules_type + " modules")
         loaded_modules = []
+
+        if not os.path.isdir(DEFAULT_MODULE_DEPS_PATH):
+            os.makedirs(DEFAULT_MODULE_DEPS_PATH)
+        sys.path.append(DEFAULT_MODULE_DEPS_PATH)
 
         for module in modules:
 


### PR DESCRIPTION
Install module requirements to `~/.opsdroid/site-packages` and add that to the path before importing modules.

Fixes #166.