### PR TITLE
Add restart and stop methods to opsdroid.

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -93,12 +93,15 @@ def main():
 
     check_dependencies()
 
-    with OpsDroid() as opsdroid:
-        opsdroid.load()
-        configure_logging(opsdroid.config)
-        opsdroid.web_server = Web(opsdroid)
-        opsdroid.start_loop()
-        opsdroid.exit()
+    restart = True
+
+    while restart:
+        with OpsDroid() as opsdroid:
+            opsdroid.load()
+            configure_logging(opsdroid.config)
+            opsdroid.web_server = Web(opsdroid)
+            opsdroid.start_loop()
+            restart = opsdroid.should_restart
 
 
 if __name__ == "__main__":

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -115,6 +115,11 @@ class Loader:
         shutil.copyfile(EXAMPLE_CONFIG_FILE, config_path)
         return config_path
 
+    @staticmethod
+    def _reload_modules(modules):
+        for module in modules:
+            importlib.reload(module["module"])
+
     def load_config_file(self, config_paths):
         """Load a yaml config file from path."""
         config_path = ""
@@ -169,6 +174,8 @@ class Loader:
 
         if 'skills' in config.keys():
             skills = self._load_modules('skill', config['skills'])
+            self.opsdroid.skills = []
+            self._reload_modules(skills)
         else:
             self.opsdroid.critical(
                 "No skills in configuration, at least 1 required", 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,7 +47,7 @@ class TestCore(unittest.TestCase):
             opsdroid.start_connector_tasks = mock.Mock()
             opsdroid.eventloop.run_forever = mock.Mock()
 
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(RuntimeError):
                 opsdroid.start_loop()
 
             self.assertTrue(opsdroid.start_databases.called)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -29,6 +29,18 @@ class TestCore(unittest.TestCase):
         with OpsDroid() as opsdroid, self.assertRaises(SystemExit):
             opsdroid.critical("An error", 1)
 
+    def test_stop(self):
+        with OpsDroid() as opsdroid:
+            self.assertFalse(opsdroid.eventloop.is_closed())
+            opsdroid.stop()
+            self.assertFalse(opsdroid.eventloop.is_running())
+
+    def test_restart(self):
+        with OpsDroid() as opsdroid:
+            self.assertFalse(opsdroid.should_restart)
+            opsdroid.restart()
+            self.assertTrue(opsdroid.should_restart)
+
     def test_load_config(self):
         with OpsDroid() as opsdroid:
             opsdroid.loader = mock.Mock()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 
+import asyncio
 import unittest
 import unittest.mock as mock
 import asynctest
@@ -37,6 +38,7 @@ class TestCore(unittest.TestCase):
 
     def test_restart(self):
         with OpsDroid() as opsdroid:
+            opsdroid.eventloop.create_task(asyncio.sleep(1))
             self.assertFalse(opsdroid.should_restart)
             opsdroid.restart()
             self.assertTrue(opsdroid.should_restart)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -150,7 +150,7 @@ class TestLoader(unittest.TestCase):
         config['module-path'] = self._tmp_dir + "/opsdroid"
 
         loader.load_modules_from_config(config)
-        self.assertEqual(len(loader._load_modules.mock_calls), 3)
+        self.assertEqual(len(loader._load_modules.mock_calls), 4)
 
     def test_load_empty_config(self):
         opsdroid, loader = self.setup()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -304,3 +304,10 @@ class TestLoader(unittest.TestCase):
             loader._install_local_module(config)
             logmock.assert_called_with(
                     "Failed to install from " + config["path"])
+
+    def test_reload_modules(self):
+        opsdroid, loader = self.setup()
+        with mock.patch('importlib.reload') as reload_mock:
+            mock_module = {"module": "fake_import"}
+            loader._reload_modules([mock_module])
+            self.assertTrue(reload_mock.called_with("fake_import"))


### PR DESCRIPTION
Allow opsdroid to be restarted without exiting.

Fixes #157.