### PR TITLE
Change default log location

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -64,7 +64,7 @@ You may not want opsdroid to log to the console, for example if you are using th
 
 ```yaml
 logging:
-  path: output.log
+  path: ~/.opsdroid/output.log
   level: info
   console: true
 

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -20,7 +20,10 @@ def configure_logging(config):
         rootlogger.handlers.pop()
 
     try:
-        logfile_path = os.path.expanduser(config["logging"]["path"])
+        if config["logging"]["path"]:
+            logfile_path = os.path.expanduser(config["logging"]["path"])
+        else:
+            logfile_path = config["logging"]["path"]
     except KeyError:
         logfile_path = DEFAULT_LOG_FILENAME
 

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -1,11 +1,12 @@
 """Starts opsdroid."""
 
+import os
 import sys
 import logging
 import argparse
 
 from opsdroid.core import OpsDroid
-from opsdroid.const import LOG_FILENAME, EXAMPLE_CONFIG_FILE
+from opsdroid.const import DEFAULT_LOG_FILENAME, EXAMPLE_CONFIG_FILE
 from opsdroid.web import Web
 
 
@@ -19,9 +20,9 @@ def configure_logging(config):
         rootlogger.handlers.pop()
 
     try:
-        logfile_path = config["logging"]["path"]
+        logfile_path = os.path.expanduser(config["logging"]["path"])
     except KeyError:
-        logfile_path = LOG_FILENAME
+        logfile_path = DEFAULT_LOG_FILENAME
 
     try:
         log_level = get_logging_level(

--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -3,10 +3,10 @@ import os
 
 __version__ = "0.8.1"
 
-LOG_FILENAME = 'output.log'
 DEFAULT_GIT_URL = "https://github.com/opsdroid/"
 MODULES_DIRECTORY = "opsdroid-modules"
-DEFAULT_ROOT_PATH = os.path.join(os.path.expanduser("~"), ".opsdroid")
+DEFAULT_ROOT_PATH = os.path.expanduser("~/.opsdroid")
+DEFAULT_LOG_FILENAME = os.path.join(DEFAULT_ROOT_PATH, 'output.log')
 DEFAULT_MODULES_PATH = os.path.join(DEFAULT_ROOT_PATH, "modules")
 DEFAULT_MODULE_DEPS_PATH = os.path.join(DEFAULT_ROOT_PATH, "site-packages")
 DEFAULT_CONFIG_PATH = os.path.join(DEFAULT_ROOT_PATH, "configuration.yaml")


### PR DESCRIPTION
Logs are now put in `~/.opsdroid` rather than in the directory where opsdroid is initialised. 

Fixes #174.