### PR TITLE
Parse environment variables in config

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -176,3 +176,15 @@ databases:
     repo: https://github.com/username/mymongofork.git
     no-cache: true
 ```
+
+## Environment variables
+
+You can use environment variables in your config. You need to specify the variable in the place of a value.
+
+```yaml
+skills:
+  - name: myawesomeskill
+    somekey: $ENVIRONMENT_VARIABLE
+```
+
+_Note: Your environment variable names must consist of uppercase characters and underscores only. The value must also be just the environment variable, you cannot currently mix env vars inside strings._

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -144,7 +144,7 @@ class Loader:
             value = loader.construct_scalar(node)
             [env_var] = env_var_pattern.match(value).groups()
             return os.environ[env_var]
-        
+
         yaml.add_constructor('!envvar', envvar_constructor)
 
         try:

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -6,6 +6,7 @@ import sys
 import shutil
 import subprocess
 import importlib
+import re
 import yaml
 from opsdroid.const import (
     DEFAULT_GIT_URL, MODULES_DIRECTORY, DEFAULT_MODULES_PATH,
@@ -134,6 +135,17 @@ class Loader:
         if not config_path:
             _LOGGER.info("No configuration files found.")
             config_path = self.create_default_config(DEFAULT_CONFIG_PATH)
+
+        env_var_pattern = re.compile(r'^\$([A-Z_]*)$')
+        yaml.add_implicit_resolver("!envvar", env_var_pattern)
+
+        def envvar_constructor(loader, node):
+            """Yaml parser for env vars."""
+            value = loader.construct_scalar(node)
+            [env_var] = env_var_pattern.match(value).groups()
+            return os.environ[env_var]
+        
+        yaml.add_constructor('!envvar', envvar_constructor)
 
         try:
             with open(config_path, 'r') as stream:

--- a/tests/configs/minimal_with_envs.yaml
+++ b/tests/configs/minimal_with_envs.yaml
@@ -1,0 +1,1 @@
+test: $ENVVAR

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -29,6 +29,13 @@ class TestLoader(unittest.TestCase):
         config = loader.load_config_file(["tests/configs/minimal.yaml"])
         self.assertIsNotNone(config)
 
+    def test_load_config_file_with_env_vars(self):
+        opsdroid, loader = self.setup()
+        os.environ["ENVVAR"] = 'test'
+        config = loader.load_config_file(
+            ["tests/configs/minimal_with_envs.yaml"])
+        self.assertEqual(config["test"], os.environ["ENVVAR"])
+
     def test_create_default_config(self):
         test_config_path = "/tmp/test_config_path/configuration.yaml"
         opsdroid, loader = self.setup()


### PR DESCRIPTION
Replaces all environment variables in the opsdroid config file.

Closes #194.

- [x] Code
- [x] Docs
- [x] Tests