### PR TITLE
Fix #232: Directory of DEFAULT_LOG_FILENAME should be created, if it does not exist

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -59,7 +59,6 @@ def configure_logging(config):
     _LOGGER.info("="*40)
     _LOGGER.info("Stated application")
 
-
 def get_logging_level(logging_level):
     """Get the logger level based on the user configuration."""
     if logging_level == 'critical':

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -59,6 +59,7 @@ def configure_logging(config):
     _LOGGER.info("="*40)
     _LOGGER.info("Stated application")
 
+
 def get_logging_level(logging_level):
     """Get the logger level based on the user configuration."""
     if logging_level == 'critical':

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -48,6 +48,9 @@ def configure_logging(config):
         pass
 
     if logfile_path:
+        logdir = os.path.dirname(os.path.realpath(logfile_path))
+        if not os.path.isdir(logdir):
+            os.makedirs(logdir)
         file_handler = logging.FileHandler(logfile_path)
         file_handler.setLevel(log_level)
         file_handler.setFormatter(formatter)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -65,7 +65,7 @@ class TestMain(unittest.TestCase):
             "console": False,
         }}
         opsdroid.configure_logging(config)
-        self.assertEqual(os.path.isfile(config['logging']['path']), True) 
+        self.assertEqual(os.path.isfile(config['logging']['path']), True)
 
     def test_configure_console_logging(self):
         config = {"logging": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,6 +58,14 @@ class TestMain(unittest.TestCase):
         self.assertEqual(rootlogger.handlers[0].level, logging.CRITICAL)
         self.assertEqual(logging.FileHandler, type(rootlogger.handlers[1]))
         self.assertEqual(rootlogger.handlers[1].level, logging.INFO)
+        
+    def test_configure_file_logging_directory_not_exists(self):
+        config = {"logging": {
+            "path": '/tmp/mynonexistingdirectory' + "/output.log",
+            "console": False,
+        }}
+        opsdroid.configure_logging(config)
+        self.assertEqual(os.path.isfile(config['logging']['path']), True) 
 
     def test_configure_console_logging(self):
         config = {"logging": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,7 +58,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(rootlogger.handlers[0].level, logging.CRITICAL)
         self.assertEqual(logging.FileHandler, type(rootlogger.handlers[1]))
         self.assertEqual(rootlogger.handlers[1].level, logging.INFO)
-        
+
     def test_configure_file_logging_directory_not_exists(self):
         config = {"logging": {
             "path": '/tmp/mynonexistingdirectory' + "/output.log",


### PR DESCRIPTION
Fixes #232. After the changes, we surpass the mentioned issue, and we hit #219 :

```
ubuntu@ubuntu:~/opsdroid$ docker run --rm -v /var/tmp/configuration.yaml:/etc/opsdroid/configuration.yaml:ro opsdroid/opsdroid:latest
INFO opsdroid: ========================================
INFO opsdroid: Stated application
WARNING opsdroid.loader: No databases in configuration
opsdroid> ERROR asyncio: Fatal read error on pipe transport
protocol: <asyncio.streams.StreamReaderProtocol object at 0x7f50e4df2c18>
transport: <_UnixReadPipeTransport fd=0 polling>
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/asyncio/unix_events.py", line 381, in _read_ready
    data = os.read(self._fileno, self.max_size)
OSError: [Errno 9] Bad file descriptor
INFO opsdroid.web: ======== Running on http://127.0.0.1:8080 ========
```

The configuration file contains the following:
```
connectors:
  - name: shell

skills:
  - name: hello
```

