### PR TITLE
Add LUIS parser/matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ See the [full reference](http://opsdroid.readthedocs.io/en/latest/configuration-
 #   path: opsdroid.log
 #   console: true
 
+## Configure the web server
+# web:
+#   host: '127.0.0.1'
+#   port: 8080
+#   ssl:
+#     cert: /path/to/cert.pem
+#     key: /path/to/key.pem
+
 ## Set the location for opsdroid to install modules
 # module-path: "."
 

--- a/docs/matchers/luis.ai.md
+++ b/docs/matchers/luis.ai.md
@@ -1,0 +1,90 @@
+# luis.ai Parser
+
+[luis.ai](https://www.luis.ai) is an NLP API for matching strings to [intents](https://docs.microsoft.com/en-us/azure/cognitive-services/LUIS/Home). Intents are created on the luis.ai website.
+
+## Example 1
+
+```python
+from opsdroid.matchers import match_luisai_intent
+
+@match_luisai_intent('Calendar.Add')
+async def passthrough(opsdroid, config, message):
+    if message.luisai["topScoringIntent"]["intent"]=="Calendar.Add":
+        await message.respond(str(message.luisai))
+```
+
+The above skill would be called on any intent which has an action of `'Calendar.Add'`
+
+## Creating a LUIS app
+
+You can find a quick getting started with luis.ai guide [here](https://docs.microsoft.com/en-us/azure/cognitive-services/LUIS/luis-get-started-create-app).
+
+## Configuring opsdroid
+
+In order to enable luis.ai skills you must specify an `appid` and `appkey` for your bot. You can further configure the bot by enabling `verbose` or setting a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
+
+```yaml
+
+parsers:
+   - name: luisai
+     appid: "<application-id>"
+     appkey: "<subscription-key>"
+     verbose: True
+     min-score: 0.6
+```
+
+## Message object additional parameters
+
+### `message.luisai`
+
+An http response object which has been returned by the luis.ai API. This allows you to access any information from the matched intent including the query, top scoring intent, intents etc.
+
+```python
+from opsdroid.matchers import match_luisai_intent
+
+@match_luisai_intent('Calendar.Add')
+async def passthrough(opsdroid, config, message):
+    if message.luisai["topScoringIntent"]["intent"]=="Calendar.Add":
+        await message.respond(str(message.luisai))
+```
+
+This example skill will print the following on the message "schedule meeting"
+
+```json
+{
+   "query":"schedule meeting",
+   "topScoringIntent":{
+      "intent":"Calendar.Add",
+      "score":0.900492251
+   },
+   "intents":[
+      {
+         "intent":"Calendar.Add",
+         "score":0.900492251
+      },
+      {
+         "intent":"None",
+         "score":0.08836186
+      },
+      {
+         "intent":"Calendar.Edit",
+         "score":0.026984252
+      },
+      {
+         "intent":"Calendar.CheckAvailability",
+         "score":0.0102987411
+      },
+      {
+         "intent":"Calendar.Delete",
+         "score":0.00722231576
+      },
+      {
+         "intent":"Calendar.Find",
+         "score":0.005946379
+      }
+   ],
+   "entities":[
+
+   ]
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,10 +10,10 @@ pages:
     - Adding skills: 'extending/skills.md'
     - Adding connectors: 'extending/connectors.md'
     - Adding databases: 'extending/databases.md'
-  - Parsers:
-    - Overview: 'parsers/overview.md'
-    - Regular Expressions: 'parsers/regex.md'
-    - API.AI: 'parsers/api.ai.md'
-    - Crontab: 'parsers/crontab.md'
-    - Webhook: 'parsers/webhook.md'
+  - Matchers:
+    - Overview: 'matchers/overview.md'
+    - Regular Expressions: 'matchers/regex.md'
+    - API.AI: 'matchers/api.ai.md'
+    - Crontab: 'matchers/crontab.md'
+    - Webhook: 'matchers/webhook.md'
   - Contributing: 'contributing.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ pages:
     - Overview: 'matchers/overview.md'
     - Regular Expressions: 'matchers/regex.md'
     - API.AI: 'matchers/api.ai.md'
+    - LUIS.AI: 'matchers/luis.ai.md'
     - Crontab: 'matchers/crontab.md'
     - Webhook: 'matchers/webhook.md'
   - Contributing: 'contributing.md'

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -13,6 +13,7 @@ from opsdroid.database import Database
 from opsdroid.loader import Loader
 from opsdroid.parsers.regex import parse_regex
 from opsdroid.parsers.apiai import parse_apiai
+from opsdroid.parsers.luisai import parse_luisai
 from opsdroid.parsers.crontab import parse_crontab
 from opsdroid.const import DEFAULT_CONFIG_PATH
 
@@ -109,7 +110,7 @@ class OpsDroid():
     def load(self):
         """Load configuration."""
         self.config = self.loader.load_config_file([
-            "./configuration.yaml",
+            "configuration.yaml",
             DEFAULT_CONFIG_PATH,
             "/etc/opsdroid/configuration.yaml"
             ])
@@ -199,4 +200,14 @@ class OpsDroid():
                     tasks.append(
                         self.eventloop.create_task(
                             parse_apiai(self, message, apiai[0])))
+
+                luisai = [p for p in parsers if p["name"] == "luisai"]
+                _LOGGER.debug("Checking luisai")
+                if len(luisai) == 1 and \
+                        ("enabled" not in luisai[0] or
+                         luisai[0]["enabled"] is not False):
+                    _LOGGER.debug("Parsing with luisai")
+                    tasks.append(
+                        self.eventloop.create_task(
+                            parse_luisai(self, message, luisai[0])))
         return tasks

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -46,6 +46,7 @@ def match_apiai_intent(intent):
         return func
     return matcher
 
+
 def match_luisai_intent(intent):
     """Return luisai intent match decorator."""
     def matcher(func):
@@ -56,6 +57,7 @@ def match_luisai_intent(intent):
                                 opsdroid.loader.current_import_config})
         return func
     return matcher
+
 
 def match_crontab(crontab, timezone=None):
     """Return crontab match decorator."""

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -46,6 +46,16 @@ def match_apiai_intent(intent):
         return func
     return matcher
 
+def match_luisai_intent(intent):
+    """Return luisai intent match decorator."""
+    def matcher(func):
+        """Add decorated function to skills list for luisai matching."""
+        opsdroid = get_opsdroid()
+        opsdroid.skills.append({"luisai_intent": intent, "skill": func,
+                                "config":
+                                opsdroid.loader.current_import_config})
+        return func
+    return matcher
 
 def match_crontab(crontab, timezone=None):
     """Return crontab match decorator."""

--- a/opsdroid/parsers/luisai.py
+++ b/opsdroid/parsers/luisai.py
@@ -49,7 +49,6 @@ async def parse_luisai(opsdroid, message, config):
                     _LOGGER.error("luis.ai error - " +
                                   str(result["statusCode"]) + " " +
                                   result["message"])
-                    return
             except KeyError:
                 pass
 

--- a/opsdroid/parsers/luisai.py
+++ b/opsdroid/parsers/luisai.py
@@ -1,0 +1,77 @@
+"""A helper function for parsing and executing luis.ai skills."""
+
+import logging
+import json
+
+import aiohttp
+
+
+_LOGGER = logging.getLogger(__name__)
+
+async def call_luisai(message, config):
+    """Call the luis.ai api and return the response."""
+    async with aiohttp.ClientSession() as session:
+        payload = {
+            "subscription-key": config['appkey'],
+            "q": message.text,
+            "timezoneOffset": 0,
+            "verbose": config['verbose']
+        }
+        headers = {
+            "Content-Type": "application/json"
+        }
+        resp = await session.get('https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/{}?subscription-key={}&timezoneOffset={}&verbose={}&q={}'
+                                .format(config['appid'],config['appkey'],0,config['verbose'],message.text),
+                                headers=headers)
+        result = await resp.json()
+        _LOGGER.debug("luis.ai response - " + json.dumps(result))
+
+        return result
+
+async def parse_luisai(opsdroid, message, config):
+    """Parse a message against all luisai skills."""
+    # pylint: disable=broad-except
+    # We want to catch all exceptions coming from a skill module and not
+    # halt the application. If a skill throws an exception it just doesn't
+    # give a response to the user, so an error response should be given.
+    if 'appid' in config and 'appkey' in config:
+        try:
+            result = await call_luisai(message, config)
+        except aiohttp.ClientOSError:
+            _LOGGER.error("No response from luis.ai, check your network.")
+            return
+
+        if result:
+
+            # if there is an error (eg. 404 error), luis.ai responds with a status code
+            try:
+                if result["statusCode"] >= 300:
+                    _LOGGER.error("luis.ai error - " +
+                                  str(result["statusCode"]) + " " +
+                                  result["message"])
+                    return
+            except:
+                pass
+
+            if "min-score" in config and \
+                    result["topScoringIntent"]["score"] < config["min-score"]:
+                _LOGGER.debug("luis.ai score lower than min-score")
+                return
+
+            for skill in opsdroid.skills:
+
+                if "luisai_intent" in skill:
+                    if (skill["luisai_intent"] in [i["intent"] for i in result["intents"]]):
+                        message.luisai = result
+                        try:
+                            await skill["skill"](opsdroid, skill["config"],
+                                                 message)
+                        except Exception:
+                            await message.respond(
+                                "Whoops there has been an error")
+                            await message.respond(
+                                "Check the log for details")
+                            _LOGGER.exception("Exception when parsing '" +
+                                              message.text +
+                                              "' against skill '" +
+                                              result["query"] + "'")

--- a/opsdroid/parsers/luisai.py
+++ b/opsdroid/parsers/luisai.py
@@ -51,27 +51,32 @@ async def parse_luisai(opsdroid, message, config):
                                   result["message"])
                     return
             except KeyError:
-                if "min-score" in config and \
-                        result["topScoringIntent"]["score"] \
-                        < config["min-score"]:
-                    _LOGGER.debug("luis.ai score lower than min-score")
-                    return
+                pass
 
-                for skill in opsdroid.skills:
+            if "min-score" in config and \
+                    result["topScoringIntent"]["score"] \
+                    < config["min-score"]:
+                _LOGGER.debug("luis.ai score lower than min-score")
+                return
 
-                    if "luisai_intent" in skill:
+            for skill in opsdroid.skills:
+                if "luisai_intent" in skill:
+                    try:
                         intents = [i["intent"] for i in result["intents"]]
-                        if skill["luisai_intent"] in intents:
-                            message.luisai = result
-                            try:
-                                await skill["skill"](opsdroid, skill["config"],
-                                                     message)
-                            except Exception:
-                                await message.respond(
-                                    "Whoops there has been an error")
-                                await message.respond(
-                                    "Check the log for details")
-                                _LOGGER.exception("Exception when parsing '" +
-                                                  message.text +
-                                                  "' against skill '" +
-                                                  result["query"] + "'")
+                    except KeyError:
+                        continue
+
+                    if skill["luisai_intent"] in intents:
+                        message.luisai = result
+                        try:
+                            await skill["skill"](opsdroid, skill["config"],
+                                                 message)
+                        except Exception:
+                            await message.respond(
+                                "Whoops there has been an error")
+                            await message.respond(
+                                "Check the log for details")
+                            _LOGGER.exception("Exception when parsing '" +
+                                              message.text +
+                                              "' against skill '" +
+                                              result["query"] + "'")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,8 @@ import importlib
 from opsdroid.core import OpsDroid
 from opsdroid.message import Message
 from opsdroid.connector import Connector
-from opsdroid.matchers import match_regex, match_apiai_action
+from opsdroid.matchers import (match_regex, match_apiai_action,
+                               match_luisai_intent)
 
 
 class TestCore(unittest.TestCase):
@@ -178,5 +179,20 @@ class TestCoreAsync(asynctest.TestCase):
             with amock.patch('opsdroid.parsers.apiai.parse_apiai'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 2)  # apiai and regex
+                for task in tasks:
+                    await task
+
+    async def test_parse_luisai(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [{"name": "luisai"}]
+            luisai_intent = ""
+            skill = amock.CoroutineMock()
+            mock_connector = Connector({})
+            decorator = match_luisai_intent(luisai_intent)
+            decorator(skill)
+            message = Message("Hello world", "user", "default", mock_connector)
+            with amock.patch('opsdroid.parsers.luisai.parse_luisai'):
+                tasks = await opsdroid.parse(message)
+                self.assertEqual(len(tasks), 2)  # luisai and regex
                 for task in tasks:
                     await task

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -38,6 +38,16 @@ class TestMatchers(asynctest.TestCase):
             self.assertEqual(opsdroid.skills[1]["apiai_intent"], intent)
             self.assertIsInstance(opsdroid.skills[1]["skill"], mock.MagicMock)
 
+    async def test_match_luisai(self):
+        with OpsDroid() as opsdroid:
+            intent = "myIntent"
+            mockedskill = mock.MagicMock()
+            decorator = matchers.match_luisai_intent(intent)
+            decorator(mockedskill)
+            self.assertEqual(len(opsdroid.skills), 1)
+            self.assertEqual(opsdroid.skills[0]["luisai_intent"], intent)
+            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+
     async def test_match_crontab(self):
         with OpsDroid() as opsdroid:
             crontab = "* * * * *"

--- a/tests/test_parser_luisai.py
+++ b/tests/test_parser_luisai.py
@@ -1,0 +1,180 @@
+
+import asynctest
+import asynctest.mock as amock
+
+from aiohttp import helpers
+
+from opsdroid.core import OpsDroid
+from opsdroid.matchers import match_luisai_intent
+from opsdroid.message import Message
+from opsdroid.parsers import luisai
+from opsdroid.connector import Connector
+
+
+class TestParserLuisai(asynctest.TestCase):
+    """Test the opsdroid luis.ai parser."""
+
+    async def test_call_luisai(self):
+        mock_connector = Connector({})
+        message = Message("schedule meeting", "user", "default",
+                          mock_connector)
+        config = {'name': 'luisai',
+                  'appid': 'test',
+                  'appkey': 'test',
+                  'verbose': True}
+        result = amock.Mock()
+        result.json = amock.CoroutineMock()
+        result.json.return_value = {
+                "query": "schedule meeting",
+                "topScoringIntent": {
+                    "intent": "Calendar.Add",
+                    "score": 0.900492251
+                },
+                "intents": [
+                    {
+                        "intent": "Calendar.Add",
+                        "score": 0.900492251
+                    }
+                ],
+                "entities": []
+            }
+        with amock.patch('aiohttp.ClientSession.get') as patched_request:
+            patched_request.return_value = helpers.create_future(self.loop)
+            patched_request.return_value.set_result(result)
+            await luisai.call_luisai(message, config)
+            self.assertTrue(patched_request.called)
+
+    async def test_parse_luisai(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = [
+                    {'name': 'luisai',
+                     'appid': 'test',
+                     'appkey': 'test',
+                     'verbose': True}
+                ]
+            mock_skill = amock.CoroutineMock()
+            match_luisai_intent('Calendar.Add')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
+
+            with amock.patch.object(luisai, 'call_luisai') as \
+                    mocked_call_luisai:
+                mocked_call_luisai.return_value = {
+                        "query": "schedule meeting",
+                        "topScoringIntent": {
+                            "intent": "Calendar.Add",
+                            "score": 0.900492251
+                        },
+                        "intents": [
+                            {
+                                "intent": "Calendar.Add",
+                                "score": 0.900492251
+                            }
+                        ],
+                        "entities": []
+                    }
+                await luisai.parse_luisai(opsdroid, message,
+                                          opsdroid.config['parsers'][0])
+
+            self.assertTrue(mock_skill.called)
+
+    async def test_parse_luisai_raises(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = [
+                    {'name': 'luisai',
+                     'appid': 'test',
+                     'appkey': 'test',
+                     'verbose': True}
+                ]
+            mock_skill = amock.CoroutineMock()
+            mock_skill.side_effect = Exception()
+            match_luisai_intent('Calendar.Add')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
+
+            with amock.patch.object(luisai, 'call_luisai') as \
+                    mocked_call_luisai:
+                mocked_call_luisai.return_value = {
+                        "query": "schedule meeting",
+                        "topScoringIntent": {
+                            "intent": "Calendar.Add",
+                            "score": 0.900492251
+                        },
+                        "intents": [
+                            {
+                                "intent": "Calendar.Add",
+                                "score": 0.900492251
+                            }
+                        ],
+                        "entities": []
+                    }
+                await luisai.parse_luisai(opsdroid, message,
+                                          opsdroid.config['parsers'][0])
+
+            self.assertTrue(mock_skill.called)
+
+    async def test_parse_luisai_failure(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = [
+                    {'name': 'luisai',
+                     'appid': 'test',
+                     'appkey': 'test',
+                     'verbose': True}
+                ]
+            mock_skill = amock.CoroutineMock()
+            match_luisai_intent('Calendar.Add')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
+
+            with amock.patch.object(luisai, 'call_luisai') as \
+                    mocked_call_luisai:
+                mocked_call_luisai.return_value = {
+                        "statusCode": 401
+                    }
+                await luisai.parse_luisai(opsdroid, message,
+                                          opsdroid.config['parsers'][0])
+
+            self.assertFalse(mock_skill.called)
+
+    async def test_parse_luisai_low_score(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config['parsers'] = [
+                    {'name': 'luisai',
+                     'appid': 'test',
+                     'appkey': 'test',
+                     'verbose': True,
+                     'min-score': 0.95}
+                ]
+            mock_skill = amock.CoroutineMock()
+            match_luisai_intent('Calendar.Add')(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
+
+            with amock.patch.object(luisai, 'call_luisai') as \
+                    mocked_call_luisai:
+                mocked_call_luisai.return_value = {
+                        "query": "schedule meeting",
+                        "topScoringIntent": {
+                            "intent": "Calendar.Add",
+                            "score": 0.900492251
+                        },
+                        "intents": [
+                            {
+                                "intent": "Calendar.Add",
+                                "score": 0.900492251
+                            }
+                        ],
+                        "entities": []
+                    }
+                await luisai.parse_luisai(opsdroid, message,
+                                          opsdroid.config['parsers'][0])
+
+            self.assertFalse(mock_skill.called)


### PR DESCRIPTION
fix for #252 

Some notes: 

I used the sample Calendar pre-built entity provided by microsoft, and tested for the action `Calendar.Add`. `LUIS` doesn't offer the same `speech` return as `api.ai` does (at least I don't think I can find it), so I tried to parse the message returned in a similar way as `api.ai`

example `__init__.py`
```
from opsdroid.matchers import match_luisai_intent

@match_luisai_intent('Calendar.Add')
async def passthrough(opsdroid, config, message):
    if message.luisai["topScoringIntent"]["score"]:
        await message.respond(str(message.luisai["topScoringIntent"]["score"]))

```

example configuration.yaml
```
##                      _           _     _
##   ___  _ __  ___  __| |_ __ ___ (_) __| |
##  / _ \| '_ \/ __|/ _` | '__/ _ \| |/ _` |
## | (_) | |_) \__ \ (_| | | | (_) | | (_| |
##  \___/| .__/|___/\__,_|_|  \___/|_|\__,_|
##       |_|
##                   __ _
##   ___ ___  _ __  / _(_) __ _
##  / __/ _ \| '_ \| |_| |/ _` |
## | (_| (_) | | | |  _| | (_| |
##  \___\___/|_| |_|_| |_|\__, |
##                        |___/
##
## A default config file to use with opsdroid

## Set the logging level
# logging:
#   level: info
#   path: opsdroid.log
#   console: true

## Set the location for opsdroid to install modules
# module-path: "."

## Show welcome message
welcome-message: true

## Configure the web server
# web:
#   host: '127.0.0.1'
#   port: 8080
#   ssl:
#     cert: /path/to/cert.pem
#     key: /path/to/key.pem

## Parsers
parsers:
#   - name: regex
#     enabled: true
#
#   - name: crontab
#     enabled: true
#
   - name: apiai
     access-token: "<access-token>"
     min-score: 0.6

   - name: luisai
     appid: "<application-id>"
     appkey: "<subscription-key>"
     verbose: True
     min-score: 0.6


## Connector modules
connectors:
  - name: shell
  - name: websocket

  # Uncomment the connector(s) that you wish opsdroid to work on
#  ## Slack (https://github.com/opsdroid/connector-slack)
#  - name: slack
#    # Required
#    api-token: "zyxw-abdcefghi-12345"
#    # optional
#    bot-name: "mybot"       # default "opsdroid"
#    default-room: "#random" # default "#general"
#    icon-imoji: ":smile:"   # default ":robot_face:"
#
#  ## Facebook (https://github.com/opsdroid/connector-facebook)
#  - name: facebook
#    # Required
#    verify-token: aabbccddee
#    page-access-token: aabbccddee112233445566
#    # Optional
#    bot-name: "mybot" # default "opsdroid"
#
#  ## Twitter (https://github.com/opsdroid/connector-twitter)
#  - name: twitter
#    # Required
#    consumer_key: "zyxw-abdcefghi-12345"
#    consumer_secret: "zyxw-abdcefghi-12345-zyxw-abdcefghi-12345"
#    oauth_token: ""zyxw-abdcefghi-12345-zyxw-abdcefghi-12345"
#    oauth_token_secret: "zyxw-abdcefghi-12345-zyxw-abdcefghi-12345"
#    # Optional
#    enable_dms: true    # Should the bot respond to Direct Messages
#    enable_tweets: true # Should the bot respond to tweets
#
#  ## Telegram (https://github.com/opsdroid/connector-telegram)
#  - name: telegram
#    # Required
#    token: "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ-ZYXWVUT"  # Telegram bot token
#    # Optional
#    update_interval: 0.5  # Interval between checking for messages
#    default_user: user1   # Default user to send messages to (overrides default room in connector)
#    whitelisted_users:    # List of users who can speak to the bot, if not set anyone can speak
#      - user1
#      - user2

## Database modules (optional)
# databases:
#   - name: mongo
#     host:       "my host"     # (Optional) default "localhost"
#     port:       "12345"       # (Optional) default "27017"
#     database:   "mydatabase"  # (Optional) default "opsdroid"

## Skill modules
skills:

  ## Hello world (https://github.com/opsdroid/skill-hello)
  # - name: hello

  ## Last seen (https://github.com/opsdroid/skill-seen)
  # - name: seen

  ## Dance (https://github.com/opsdroid/skill-dance)
  # - name: dance

  ## Loud noises (https://github.com/opsdroid/skill-loudnoises)
  # - name: loudnoises

   # Configurations for other skills uncomment desired skill to activate it.
#
#  ## Grafana (https://github.com/opsdroid/skill-grafana)
#  - name: grafana
#    room: "#monitoring"  # (Optional) room to send alert to
#
#  ## Travis (https://github.com/opsdroid/skill-travis)
#  - name: travis
#    room: "#monitoring"     # (Optional) room to send alert to
#    travis_endpoint: "org"  # (Optional) endpoint for travis, change to "com" if using enterprise Travis CI
#
#  ## Devtools (https://github.com/opsdroid/skill-devtools)
#  - name: devtools
#
#  ## Food (https://github.com/opsdroid/skill-food)
#  - name: food
#    api-key: "myapikeyfromfood2fork"  # Required
#
#  ## Magpi (https://github.com/opsdroid/skill-magpi)
#  - name: magpi
#    room: "#raspberrypi"    # (Optional) room to send notifications to
#
#  ## Google it (https://github.com/opsdroid/skill-google-it/)
#  - name: google-it
#    # Use Google search engine (Default)
#    engine-url: https://www.google.co.uk/
#    query-arg: search?q=
#    # Other search engines that can be used (keep only one active at a time)
#    # Use Bing search engine
#    engine-url: https://www.bing.com/
#    query-arg: search?=
#    # Use DuckDuckGo search engine
#    engine-url: https://duckduckgo.com/
#    query-arg: ?q=
#    # Use Yahoo search engine
#    engine-url: http://search.yahoo.com/
#    query-arg: search?p=
#    # Use Aol search engine
#    engine-url: https://search.aol.co.uk/aol/
#    query-arg: search?query=
#    # Use Ask search engine
#    engine-url: https://uk.ask.com/
#    query-arg: web?q=
#    # Use Wolframalpha search engine
#    engine-url: https://www.wolframalpha.com/input/
#    query-arg: ?i=
#
#  ## API.AI (https://github.com/opsdroid/skill-apiai)
  - name: apiai
    include:
      - smalltalk
    exclude:
      - smalltalk.agent

  - name: luisai
    include:
      - Calendar.Add
#
#  ## Vault (https://github.com/opsdroid/skill-vault)
#  - name: vault
#    # Required
#    vault-url: https://vault.example.com:8443
#    vault-token: aabbccddee1122334455
#    # Optional
#    announce-on-seal: false   # Announce the vault status in the default room on seal
#    announce-sealed: true     # Announce the vault is sealed hourly
#    announce-unsealed: false  # Announce the vault is unsealed hourly
#
#  ## ISS (https://github.com/opsdroid/skill-iss)
#  - name: iss
#    # Required
#    api-key: "mygooglemapsapikey"
#    # Optional
#    zoom: "5"
#    map-size: "1024x768"
#    map-type: "hybrid"    # hybrid, satellite or roadmap
#
# ## HomeAssistant (https://github.com/opsdroid/skill-homeassistant)
#  - name: homeassistant
#    room: "#homeassistant"

```

example command: `schedule meeting`