### PR TITLE
Better logging when loading modules

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -6,6 +6,7 @@ import sys
 import shutil
 import subprocess
 import importlib
+from importlib import util
 import re
 import yaml
 from opsdroid.const import (
@@ -28,29 +29,34 @@ class Loader:
         _LOGGER.debug("Loaded loader")
 
     @staticmethod
+    def import_module_from_spec(module_spec):
+        """Import from a given module spec and return imported module."""
+        module = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(module)
+        return module
+
+    @staticmethod
     def import_module(config):
         """Import module namespace as variable and return it."""
-        try:
-            module = importlib.import_module(
-                config["module_path"] + "." + config["name"])
-            _LOGGER.debug("Loaded " + config["type"] + ": " +
-                          config["module_path"])
-            return module
-        except ImportError as error:
-            _LOGGER.debug("Failed to load " + config["type"] +
-                          " " + config["module_path"] + "." + config["name"])
-            _LOGGER.debug(error)
+        # Check if the module can be imported and proceed with import
 
-        try:
-            module = importlib.import_module(
-                config["module_path"])
-            _LOGGER.debug("Loaded " + config["type"] + ": " +
-                          config["module_path"])
+        # Proceed only if config.name is specified
+        # and parent module can be imported
+        if config["name"] and util.find_spec(config["module_path"]):
+            module_spec = util.find_spec(config["module_path"] +
+                                         "." + config["name"])
+            if module_spec:
+                module = Loader.import_module_from_spec(module_spec)
+                _LOGGER.debug("Loaded " + config["type"] +
+                              ": " + config["module_path"])
+                return module
+
+        module_spec = util.find_spec(config["module_path"])
+        if module_spec:
+            module = Loader.import_module_from_spec(module_spec)
+            _LOGGER.debug("Loaded " + config["type"] +
+                          ": " + config["module_path"])
             return module
-        except ImportError as error:
-            _LOGGER.debug("Failed to load " + config["type"] +
-                          " " + config["module_path"])
-            _LOGGER.debug(error)
 
         _LOGGER.error("Failed to load " + config["type"] +
                       " " + config["module_path"])


### PR DESCRIPTION

Tests: Performed using tox. Code convention score 10/10

# Description
Root cause: Logging after every failed import

Fix: Utilize importlib.util's find_spec method to check if module can
     be imported before importing. Log once if the import fails for both
     variations of module imports.

**Fixes:** #281 


## Status
**READY**


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

 Existing unit tests in test_loader.py. Plus, full test suite.


# Checklist:

- [ ] I have performed a self-review of my own code
