### PR TITLE
Revert "Better logging when loading modules"

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -6,7 +6,6 @@ import sys
 import shutil
 import subprocess
 import importlib
-from importlib import util
 import re
 import yaml
 from opsdroid.const import (
@@ -29,34 +28,29 @@ class Loader:
         _LOGGER.debug("Loaded loader")
 
     @staticmethod
-    def import_module_from_spec(module_spec):
-        """Import from a given module spec and return imported module."""
-        module = importlib.util.module_from_spec(module_spec)
-        module_spec.loader.exec_module(module)
-        return module
-
-    @staticmethod
     def import_module(config):
         """Import module namespace as variable and return it."""
-        # Check if the module can be imported and proceed with import
-
-        # Proceed only if config.name is specified
-        # and parent module can be imported
-        if config["name"] and util.find_spec(config["module_path"]):
-            module_spec = util.find_spec(config["module_path"] +
-                                         "." + config["name"])
-            if module_spec:
-                module = Loader.import_module_from_spec(module_spec)
-                _LOGGER.debug("Loaded " + config["type"] +
-                              ": " + config["module_path"])
-                return module
-
-        module_spec = util.find_spec(config["module_path"])
-        if module_spec:
-            module = Loader.import_module_from_spec(module_spec)
-            _LOGGER.debug("Loaded " + config["type"] +
-                          ": " + config["module_path"])
+        try:
+            module = importlib.import_module(
+                config["module_path"] + "." + config["name"])
+            _LOGGER.debug("Loaded " + config["type"] + ": " +
+                          config["module_path"])
             return module
+        except ImportError as error:
+            _LOGGER.debug("Failed to load " + config["type"] +
+                          " " + config["module_path"] + "." + config["name"])
+            _LOGGER.debug(error)
+
+        try:
+            module = importlib.import_module(
+                config["module_path"])
+            _LOGGER.debug("Loaded " + config["type"] + ": " +
+                          config["module_path"])
+            return module
+        except ImportError as error:
+            _LOGGER.debug("Failed to load " + config["type"] +
+                          " " + config["module_path"])
+            _LOGGER.debug(error)
 
         _LOGGER.error("Failed to load " + config["type"] +
                       " " + config["module_path"])


### PR DESCRIPTION
Reverts opsdroid/opsdroid#287

Testing locally results in the following error

```
Traceback (most recent call last):
  File "/Users/jacob/.pyenv/versions/3.5.1/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/jacob/.pyenv/versions/3.5.1/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/jacob/Projects/opsdroid/opsdroid/opsdroid/__main__.py", line 134, in <module>
    main()
  File "/Users/jacob/Projects/opsdroid/opsdroid/opsdroid/__main__.py", line 129, in main
    opsdroid.start_loop()
  File "/Users/jacob/Projects/opsdroid/opsdroid/opsdroid/core.py", line 123, in start_loop
    self.loader.load_modules_from_config(self.config)
  File "/Users/jacob/Projects/opsdroid/opsdroid/opsdroid/loader.py", line 206, in load_modules_from_config
    self._reload_modules(skills)
  File "/Users/jacob/Projects/opsdroid/opsdroid/opsdroid/loader.py", line 128, in _reload_modules
    importlib.reload(module["module"])
  File "/Users/jacob/.pyenv/versions/3.5.1/lib/python3.5/importlib/__init__.py", line 147, in reload
    raise ImportError(msg.format(name), name=name)
ImportError: module opsdroid-modules.skill.hello not in sys.modules
```