### PR TITLE
Fix warning in tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,7 +50,8 @@ class TestCore(unittest.TestCase):
             opsdroid.load()
             self.assertTrue(opsdroid.loader.load_config_file.called)
 
-    def test_start_loop(self):
+    @asynctest.patch('opsdroid.core.parse_crontab')
+    def test_start_loop(self, mocked_parse_crontab):
         with OpsDroid() as opsdroid:
             mockconfig = {}, {}, {}
             opsdroid.web_server = mock.Mock()
@@ -60,15 +61,10 @@ class TestCore(unittest.TestCase):
             opsdroid.start_databases = mock.Mock()
             opsdroid.setup_skills = mock.Mock()
             opsdroid.start_connector_tasks = mock.Mock()
-            opsdroid.eventloop.run_forever = mock.Mock()
-
-            with self.assertRaises(RuntimeError):
-                opsdroid.start_loop()
-
+            opsdroid.start_loop()
             self.assertTrue(opsdroid.start_databases.called)
             self.assertTrue(opsdroid.setup_skills.called)
             self.assertTrue(opsdroid.start_connector_tasks.called)
-            self.assertTrue(opsdroid.eventloop.run_forever.called)
 
     def test_load_regex_skill(self):
         with OpsDroid() as opsdroid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,13 @@ from opsdroid.matchers import (match_regex, match_apiai_action,
 class TestCore(unittest.TestCase):
     """Test the opsdroid core class."""
 
+    def setUp(self):
+        self.previous_loop = asyncio.get_event_loop()
+
+    def tearDown(self):
+        self.previous_loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
     def test_core(self):
         with OpsDroid() as opsdroid:
             self.assertIsInstance(opsdroid, OpsDroid)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -68,10 +68,15 @@ class TestCore(unittest.TestCase):
             opsdroid.start_databases = mock.Mock()
             opsdroid.setup_skills = mock.Mock()
             opsdroid.start_connector_tasks = mock.Mock()
-            opsdroid.start_loop()
+            opsdroid.eventloop.run_forever = mock.Mock()
+
+            with self.assertRaises(RuntimeError):
+                opsdroid.start_loop()
+
             self.assertTrue(opsdroid.start_databases.called)
             self.assertTrue(opsdroid.setup_skills.called)
             self.assertTrue(opsdroid.start_connector_tasks.called)
+            self.assertTrue(opsdroid.eventloop.run_forever.called)
 
     def test_load_regex_skill(self):
         with OpsDroid() as opsdroid:


### PR DESCRIPTION
Hi  there :)

# Description

When running tests they complain about `coroutine 'parse_crontab' was never awaited.` The root cause is that `asyncio.create_task` for `parse_crontab` is not isolated properly. After this issue is solved in https://github.com/freedomofkeima/opsdroid/commit/d4a7d023f67a523e55e09e7095879a63d6d56f94 + https://github.com/freedomofkeima/opsdroid/commit/c4ece48aeb92eca61016bdc79a257e504b969a77, there's another new occurring problem.

```
========================== 113 passed in 2.50 seconds ==========================
Exception ignored in: <bound method BaseEventLoop.__del__ of <_UnixSelectorEventLoop running=False closed=True debug=False>>
Traceback (most recent call last):
 File "/opt/python/3.6.3/lib/python3.6/asyncio/base_events.py", line 512, in __del__
 self.close()
 File "/opt/python/3.6.3/lib/python3.6/asyncio/unix_events.py", line 65, in close
 self.remove_signal_handler(sig)
 File "/opt/python/3.6.3/lib/python3.6/asyncio/unix_events.py", line 146, in remove_signal_handler
 signal.signal(sig, handler)
 File "/opt/python/3.6.3/lib/python3.6/signal.py", line 47, in signal
 handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
___________________________________ summary ____________________________________
```

Future investigations (see https://github.com/python/asyncio/issues/396, https://bugs.python.org/issue23548) shows that this problem occurred because of a bug in signal handling and we need to call `close` explicitly. `TestCore` class does a lot of manipulation against `self.eventloop`, which should be fixed in https://github.com/freedomofkeima/opsdroid/commit/b65f8bf271f2434c31eb1286438c2cca65b4ec2f.

**Fixes:** #288


## Status
**READY**


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run the test at [Travis CI](https://travis-ci.org/freedomofkeima/opsdroid/builds/290881477) and ensure there's no warning given there.

# Checklist:

- [x] I have performed a self-review of my own code

