### PR TITLE
Update asynctest to 0.11.0 with test fixes

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,6 +7,6 @@ pytest-cov==2.5.1
 pytest-timeout==1.2.0
 pytest-catchlog==1.2.2
 pydocstyle==2.1.1
-asynctest==0.10.1
+asynctest==0.11.0
 requests_mock==1.3.0
 mypy-lang==0.5.0

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -24,7 +24,9 @@ class TestMemory(asynctest.TestCase):
 
     async def test_database_callouts(self):
         memory = self.setup()
-        memory.databases = [mock.CoroutineMock()]
+        memory.databases = [mock.MagicMock()]
+        memory.databases[0].get = mock.CoroutineMock()
+        memory.databases[0].put = mock.CoroutineMock()
         data = "Hello world!"
 
         await memory.put("test", data)

--- a/tests/test_parser_always.py
+++ b/tests/test_parser_always.py
@@ -42,7 +42,8 @@ class TestParserAlways(asynctest.TestCase):
             match_always()(mock_skill)
             self.assertEqual(len(opsdroid.skills), 1)
 
-            mock_connector = amock.CoroutineMock()
+            mock_connector = amock.MagicMock()
+            mock_connector.respond = amock.CoroutineMock()
             message = Message("Hello world", "user",
                               "default", mock_connector)
 

--- a/tests/test_parser_dialogflow.py
+++ b/tests/test_parser_dialogflow.py
@@ -73,7 +73,8 @@ class TestParserDialogflow(asynctest.TestCase):
             mock_skill.side_effect = Exception()
             match_dialogflow_action('myaction')(mock_skill)
 
-            mock_connector = amock.CoroutineMock()
+            mock_connector = amock.MagicMock()
+            mock_connector.respond = amock.CoroutineMock()
             message = Message("Hello world", "user", "default", mock_connector)
 
             with amock.patch.object(dialogflow, 'call_dialogflow') as \

--- a/tests/test_parser_luisai.py
+++ b/tests/test_parser_luisai.py
@@ -92,7 +92,8 @@ class TestParserLuisai(asynctest.TestCase):
             mock_skill.side_effect = Exception()
             match_luisai_intent('Calendar.Add')(mock_skill)
 
-            mock_connector = amock.CoroutineMock()
+            mock_connector = amock.MagicMock()
+            mock_connector.respond = amock.CoroutineMock()
             message = Message("schedule meeting", "user", "default",
                               mock_connector)
 

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -30,7 +30,8 @@ class TestParserRegex(asynctest.TestCase):
             match_regex(r"(.*)")(mock_skill)
             self.assertEqual(len(opsdroid.skills), 1)
 
-            mock_connector = amock.CoroutineMock()
+            mock_connector = amock.MagicMock()
+            mock_connector.respond = amock.CoroutineMock()
             message = Message("Hello world", "user",
                               "default", mock_connector)
 

--- a/tests/test_parser_witai.py
+++ b/tests/test_parser_witai.py
@@ -75,7 +75,8 @@ class TestParserWitai(asynctest.TestCase):
             mock_skill.side_effect = Exception()
             match_witai('get_weather')(mock_skill)
 
-            mock_connector = amock.CoroutineMock()
+            mock_connector = amock.MagicMock()
+            mock_connector.respond = amock.CoroutineMock()
             message = Message("how's the weather outside", "user",
                               "default", mock_connector)
 


### PR DESCRIPTION
# Description

Updating asynctest to 0.11.0 in #296 fails because the way we are using `CoroutineMock` was not indended by @Martiusweb. This PR updates the dependancy and also updates the test following advice in Martiusweb/asynctest#52.

**Fixes:** #301 (and supersedes #296)


## Status
**READY**


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Unit tests run and pass.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

