### PR TITLE
Replace regex parser - use re.search instead re.match

### DIFF
--- a/docs/matchers/regex.md
+++ b/docs/matchers/regex.md
@@ -2,7 +2,9 @@
 
 This is the simplest matcher available in opsdroid. It matches the message from the user against a regular expression. If the regex matches the function is called.
 
-## Example
+_note: The use of position anchors(`^` or `$`) are encouraged when using regex to match a function. This should prevent opsdroid to be triggered with every use of the matched regular expression_
+
+## Example 1
 
 ```python
 from opsdroid.matchers import match_regex
@@ -13,6 +15,52 @@ async def hello(opsdroid, config, message):
 ```
 
 The above skill would be called on any message which matches the regex `'hi'`, `'Hi'` or `'HI`. The `case_sensitive` kwarg is optional and defaults to `True`. 
+
+
+## Example 2
+
+```python
+from opsdroid.matchers import match_regex
+
+@match_regex('cold')
+async def is_cold(opsdroid, config, message):
+    await message.respond('it is')
+```
+
+The above skill would be called on any message that matches the regex `'cold'` . 
+
+> user: is it cold?
+>
+> opsdroid: it is
+
+Undesired effect: 
+
+> user:  Wow, yesterday was so cold at practice!
+>
+> opsdroid: it is.
+
+Since this matcher searches a message for the regular expression used on a skill, opsdroid will trigger any mention of the `'cold'`. To prevent this position anchors should be used.
+
+#### Fixed example
+```python
+from opsdroid.matchers import match_regex
+
+@match_regex('cold$')
+async def is_cold(opsdroid, config, message):
+    await message.respond('it is')
+```
+
+Now this skill will only be triggered if `'cold'` is located at the end of the message.
+
+> user: is it cold
+>
+> opsdroid: it is
+>
+> user: Wow it was so cold outside yesterday!
+>
+> opsdroid: 
+
+Since `'cold'` wasn't located at the end of the message, opsdroid didn't react to the second message posted by the user.
 
 ## Message object additional parameters
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -92,7 +92,7 @@ class OpsDroid():
         """Exit due to unrecoverable error."""
         self.sys_status = code
         _LOGGER.critical(error)
-        print("Error: " + error)
+        print("Error:", error)
         self.exit()
 
     def restart(self):

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -16,11 +16,11 @@ async def parse_regex(opsdroid, message):
     for skill in opsdroid.skills:
         if "regex" in skill:
             if skill["regex"]["case_sensitive"]:
-                regex = re.match(skill["regex"]["expression"],
-                                 message.text)
+                regex = re.search(skill["regex"]["expression"],
+                                  message.text)
             else:
-                regex = re.match(skill["regex"]["expression"],
-                                 message.text, re.IGNORECASE)
+                regex = re.search(skill["regex"]["expression"],
+                                  message.text, re.IGNORECASE)
             if regex:
                 message.regex = regex
                 try:


### PR DESCRIPTION
# Description
As @gabeduke mentioned in gitter, the regex parser is ignoring the regular expression to be searched if it's not at the beginning of the string. After a few testing and reading it seems that the reason why this is happening because re.match will only match a regular expression if ifound at the beginning of the string.

Using re.search seems to fix this issue as this method will search through the whole string for the regular expression specified on the skill.  So I've replaced `re.match` with `re.search` in opsdroid.parsers.regex

I've also updated the documentation to show the importance of using anchors when building skills, please let me know if the examples make sense of if they are too confusing.

I've also replaced line 94 of opsdroid.core: `print("Error: " + error)`. When spaces are not used properly in configuration.yaml the following exception is returned:

```python
  File "/Users/fabiorosado/Documents/GitHub/opsdroid/opsdroid/core.py", line 94, in critical
    print("Error:" + error)
TypeError: must be str, not ParserError
```

By replacing concatenation with a comma the print statement works normally. I've noticed that we are currently logging this, do we still need this print?

**Fixes:** N/A


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Documentation (fix or adds documentation)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested both locally and Travis CI - All tests passed
- [X] Tested different skills to see if any side-effects occur - none experienced


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes