### PR TITLE
Allows use of apiai in config

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -205,7 +205,18 @@ class OpsDroid():
                 _LOGGER.debug("Processing parsers...")
                 parsers = self.config["parsers"]
 
-                dialogflow = [p for p in parsers if p["name"] == "dialogflow"]
+                dialogflow = [p for p in parsers if p["name"] == "dialogflow"
+                              or p["name"] == "apiai"]
+
+                # Show deprecation message but  parse message
+                # Once it stops working remove this bit
+                apiai = [p for p in parsers if p["name"] == "apiai"]
+                if apiai:
+                    _LOGGER.warning("Api.ai is now called Dialogflow. This "
+                                    "parser will stop working in the future "
+                                    "please swap: 'name: apiai' for "
+                                    "'name: dialogflow' in configuration.yaml")
+
                 _LOGGER.debug("Checking dialogflow...")
                 if len(dialogflow) == 1 and \
                         ("enabled" not in dialogflow[0] or

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -206,6 +206,14 @@ class TestCoreAsync(asynctest.TestCase):
             with amock.patch('opsdroid.parsers.dialogflow.parse_dialogflow'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 3)  # dialogflow, regex and always
+
+                # Once apiai parser stops working, remove this test!
+                with amock.patch('opsdroid.core._LOGGER.warning') as logmock:
+                    opsdroid.config["parsers"] = [{"name": "apiai"}]
+                    tasks = await opsdroid.parse(message)
+                    self.assertTrue(logmock.called)
+
+                # But leave this bit
                 for task in tasks:
                     await task
 


### PR DESCRIPTION
# Description

Fixed the problem with the parser not working if the apiai parser is set in the configuration.yaml
I apologise for this issue, I should had thought that people could still have the apiai set in their configuration. Everything should work fine now though!


**Fixes:** #306


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran unit tests locally and Travis CI - All passed
- [x] Tested parsing few skills/pages using api in config - worked as it should


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

