### PR TITLE
Restore the message.apiai attribute

### DIFF
--- a/opsdroid/parsers/dialogflow.py
+++ b/opsdroid/parsers/dialogflow.py
@@ -67,6 +67,9 @@ async def parse_dialogflow(opsdroid, message, config):
                                 skill["dialogflow_intent"] in
                                 result["result"]["intentName"]):
                         message.dialogflow = result
+                        # Support backward compatibility for deprecated name
+                        # Remove when apiai name support is dropped
+                        message.apiai = message.dialogflow
                         try:
                             await skill["skill"](opsdroid, skill["config"],
                                                  message)


### PR DESCRIPTION
# Description

The `message.apiai` attribute has been dropped in favour of `message.dialogflow`. Restoring an alias to maintain backward compatibility.

**Fixes:** #306


## Status
**READY**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation (fix or adds documentation)


# How Has This Been Tested?

Unit tests pass


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

