### PR TITLE
Remove print from core.critical function

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -92,7 +92,6 @@ class OpsDroid():
         """Exit due to unrecoverable error."""
         self.sys_status = code
         _LOGGER.critical(error)
-        print("Error:", error)
         self.exit()
 
     def restart(self):


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

The function core.critical is both printing and logging the error message. I'm not sure if the print is needed when using opsdroid from the command line so I'm raising the PR in case this is a mistake.

@jacobtomlinson  let me know your opinion on this 👍 

**Fixes** #<issue>


## Status
**READY** (?) | ~~**UNDER DEVELOPMENT** | **ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all passed
- virtualenv:  using a bad configuration.yaml all seem okay


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

