### PR TITLE
Better log message when installing skill via git

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -311,12 +311,14 @@ class Loader:
         if any(prefix in git_url for prefix in ["http", "https", "ssh"]):
             # TODO Test if url or ssh path exists
             # TODO Handle github authentication
-            _LOGGER.info("Cloning from remote repository")
+            _LOGGER.info("Cloning %s from remote repository",
+                         config["name"])
             self.git_clone(git_url, config["install_path"],
                            config["branch"])
         else:
             if os.path.isdir(git_url):
-                _LOGGER.debug("Cloning from local repository")
+                _LOGGER.debug("Cloning %s from local repository",
+                              config["name"])
                 self.git_clone(git_url, config["install_path"],
                                config["branch"])
             else:


### PR DESCRIPTION
# Description

A minor change to include the name of the skill being cloned in the log. Currently logs look like this:

```
INFO opsdroid: ========================================
INFO opsdroid: Stated application
WARNING opsdroid.loader: No databases in configuration.
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
INFO opsdroid.loader: Cloning from remote repository
```

This isn't very helpful. After the change the name of the skill being clones will be included in the log message.

**Fixes** N/A


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- Unit tests pass


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] New and existing unit tests pass locally with my changes

