### PR TITLE
Ignore .docker directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.docker/


### PR DESCRIPTION
# Description

When running `tox` locally the new docker tests create a directory called `.docker` which should be ignored by version control.
