### PR TITLE
Update pylint and astroid and tweak formatting to pass lint.

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -99,8 +99,8 @@ def welcome_message(config):
                          "http://opsdroid.readthedocs.io/#configuration")
             _LOGGER.info("Watch the Get Started Videos at: "
                          "http://bit.ly/2fnC0Fh")
-            _LOGGER.info("Install Opsdroid Desktop at: \n" +
-                         "https://github.com/opsdroid/opsdroid-desktop/" +
+            _LOGGER.info("Install Opsdroid Desktop at: \n"
+                         "https://github.com/opsdroid/opsdroid-desktop/"
                          "releases")
             _LOGGER.info("=" * 40)
     except KeyError:

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -84,7 +84,7 @@ class OpsDroid():
 
     def exit(self):
         """Exit application."""
-        _LOGGER.info("Exiting application with return code " +
+        _LOGGER.info("Exiting application with return code %s",
                      str(self.sys_status))
         sys.exit(self.sys_status)
 

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -79,11 +79,12 @@ class Loader:
     def build_module_path(self, path_type, config):
         """Generate the module path from name and type."""
         if path_type == "import":
-            return MODULES_DIRECTORY + "." + config["type"] + \
+            path = MODULES_DIRECTORY + "." + config["type"] + \
                         "." + config["name"]
         elif path_type == "install":
-            return self.modules_directory + "/" + config["type"] + \
+            path = self.modules_directory + "/" + config["type"] + \
                         "/" + config["name"]
+        return path
 
     @staticmethod
     def git_clone(git_url, install_path, branch):
@@ -345,4 +346,4 @@ class Loader:
             installed = True
 
         if not installed:
-            _LOGGER.error("Failed to install from " + config["path"])
+            _LOGGER.error("Failed to install from %s", config["path"])

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,11 +1,10 @@
 flake8==3.5.0
-pylint==1.7.5
+pylint==1.8.1
 coveralls==1.2.0
-astroid==1.5.3
+astroid==1.6.0
 pytest==3.3.1
 pytest-cov==2.5.1
 pytest-timeout==1.2.1
-pytest-catchlog==1.2.2
 pydocstyle==2.1.1
 asynctest==0.11.1
 requests_mock==1.4.0


### PR DESCRIPTION
Combines #361 and #362 along with some stylistic code changes to pass the newly added `logging-not-lazy` and `inconsistent-return-statements` lints.

Most of the work for `logging-not-lazy` has already been done by @FabioRosado so thanks! There were just a couple left that the updated linter picked up.

I think the fix for `inconsistent-return-statements` in `loader.Loader.build_module_path` is actually a false positive in pylint but it's such a minor change to work around it I don't mind.