### PR TITLE
Add typing/thinking delay and user is typing event

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -90,6 +90,20 @@ connectors:
     secret_key: "myoauthsecret"
 ```
 
+Some connectors will allow you to specify a thinking and typing delay(in seconds) to simulate a real user. You just need to add the delay option under a connector.
+
+Example:
+
+```yaml
+connectors:
+  - name: slack
+    token: "mysecretslacktoken"
+    typing-delay: <int, float or two element list>
+    thinking-delay: <int or float>
+```
+
+_Note: As expected this will cause a delay on opsdroid time of response so make sure you don't pass a high number._ 
+
 See [module options](#module-options) for installing custom connectors.
 
 ### Database Modules

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -90,7 +90,11 @@ connectors:
     secret_key: "myoauthsecret"
 ```
 
-Some connectors will allow you to specify a thinking and typing delay(in seconds) to simulate a real user. You just need to add the delay option under a connector.
+Some connectors will allow you to specify a delay to simulate a real user, you just need to add the delay option under a connector in the `configuration.yaml` file.
+
+**Thinking Delay:** accepts a _int_, _float_ or a _list_ to delay reply by _x_ seconds.
+**Typing Delay:** accepts a _int_ or _float_ that represents the number of characters typed per second. This number should be larger or equal to 6 to avoid lagging. 
+
 
 Example:
 
@@ -98,8 +102,8 @@ Example:
 connectors:
   - name: slack
     token: "mysecretslacktoken"
-    typing-delay: <int, float or two element list>
-    thinking-delay: <int or float>
+    thinking-delay: <int, float or two element list>
+    typing-delay: <int or float>
 ```
 
 _Note: As expected this will cause a delay on opsdroid time of response so make sure you don't pass a high number._ 

--- a/docs/extending/connectors.md
+++ b/docs/extending/connectors.md
@@ -2,11 +2,19 @@
 
 Connectors are a class which extends the base opsdroid Connector. The class has three mandatory methods, `connect`, `listen` and `respond`. There are also some default values you can override with the `__init__` function, just be sure you are setting everything that the default init sets.
 
+#### configuration  (property)
+*configuration* is a class property of Connector. It's used to access the config parameters of a Connector. This can be used to retrieve specific parameters of a connector from `configuration.yaml`.
+
 #### connect
 *connect* is a method which connects to a specific chat service
 
+### Methods
+
 #### listen
 *listen* uses the open connection to the chat service and retrieves messages from it. Each message is formatted into an opsdroid Message object and then parsed. This method should block the thread with an infinite loop but use `await` commands when getting new messages and parsing with opsdroid. This allows the [event loop](https://docs.python.org/3/library/asyncio-eventloop.html) to hand control of the thread to a different function while we are waiting.
+
+#### user_typing
+*user_typing* triggers the event message *user is typing* if the connector allows it. This method uses a parameter `trigger` that takes in a boolean value to trigger the event on/off.
 
 #### respond
 *respond* will take a Message object and return the contents to the chat service.
@@ -66,3 +74,6 @@ class MyConnector(Connector):
     await self.connection.disconnect()
 
 ```
+
+---
+You might also be interested in reading the [configuration reference - Connector Modules](../configuration-reference.md/#connector-modules) in the documentation.

--- a/opsdroid/connector.py
+++ b/opsdroid/connector.py
@@ -72,6 +72,15 @@ class Connector():
         """
         raise NotImplementedError
 
+    async def user_typing(self, opsdroid):
+        """Signals that opsdroid is typing.
+
+        Triggers the "user is typing" event if the chat service that
+        opsdroid is connected to accepts it.
+        """
+
+        raise NotImplementedError
+
     async def disconnect(self, opsdroid):
         """Disconnect from the chat service.
 

--- a/opsdroid/connector.py
+++ b/opsdroid/connector.py
@@ -26,6 +26,11 @@ class Connector():
         self.config = config
         self.default_room = None
 
+    @property
+    def configuration(self):
+        """Class property used to access the connector config."""
+        return self.config
+
     async def connect(self, opsdroid):
         """Connect to chat service.
 
@@ -72,14 +77,17 @@ class Connector():
         """
         raise NotImplementedError
 
-    async def user_typing(self, opsdroid):
+    async def user_typing(self, opsdroid, trigger):
         """Signals that opsdroid is typing.
+
+        Args:
+            opsdroid (OpsDroid): An instance of the opsdroid core.
+            trigger: a bool that allows the event to be triggered on/off
 
         Triggers the "user is typing" event if the chat service that
         opsdroid is connected to accepts it.
         """
-
-        raise NotImplementedError
+        pass
 
     async def disconnect(self, opsdroid):
         """Disconnect from the chat service.

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -22,7 +22,7 @@ class Message:
         self.regex = None
         self.responded_to = False
 
-    async def _thinking_delay(self, seconds=0):
+    async def _thinking_delay(self):
         """Make opsdroid wait x-seconds before responding."""
         seconds = self.connector.configuration.get('thinking-delay', 0)
 
@@ -32,11 +32,13 @@ class Message:
         await asyncio.sleep(seconds)
 
     async def _typing_delay(self, text):
-        """Simulate typing, default is set to 6 characters per second."""
-        seconds = self.connector.configuration.get('typing-delay', 1)
-
-        char_count = len(text)
-        await asyncio.sleep(char_count//seconds)
+        """Simulate typing, takes an int(characters per second typed)."""
+        try:
+            char_per_sec = self.connector.configuration['typing-delay']
+            char_count = len(text)
+            await asyncio.sleep(char_count//char_per_sec)
+        except KeyError:
+            pass
 
     async def respond(self, text):
         """Respond to this message using the connector it was created by."""
@@ -44,9 +46,11 @@ class Message:
         response = copy(self)
         response.text = text
 
-        await self._thinking_delay()
-        await self._typing_delay(response.text,)
-        print(self.connector.configuration)
+        if 'thinking-delay' in self.connector.configuration or \
+           'typing-delay' in self.connector.configuration:
+            await self._thinking_delay()
+            await self._typing_delay(response.text)
+
         await self.connector.respond(response)
         if not self.responded_to:
             now = datetime.now()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -38,6 +38,13 @@ class TestConnectorBaseClass(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.loop.run_until_complete(connector.respond({}))
 
+    def test_user_typing(self):
+        opsdroid = 'opsdroid'
+        connector = Connector({})
+        user_typing = self.loop.run_until_complete(
+            connector.user_typing(opsdroid, trigger=True))
+        assert user_typing is None
+
 
 class TestConnectorAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid connector base class."""

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -19,6 +19,10 @@ class TestConnectorBaseClass(unittest.TestCase):
         self.assertEqual("", connector.name)
         self.assertEqual("test", connector.config["example_item"])
 
+    def test_property(self):
+        connector = Connector({"name": "shell"})
+        self.assertEqual("shell", connector.configuration.get("name"))
+
     def test_connect(self):
         connector = Connector({})
         with self.assertRaises(NotImplementedError):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -44,6 +44,37 @@ class TestMessage(asynctest.TestCase):
 
             self.assertTrue(logmock.called)
 
+    async def test_thinking_sleep(self):
+        mock_connector_int = Connector({
+            'name': 'shell',
+            'thinking-delay': 3,
+            'type': 'connector',
+            'module_path': 'opsdroid-modules.connector.shell'
+        })
+
+        with amock.patch('asyncio.sleep') as mocksleep_int:
+            message = Message("hi", "user", "default", mock_connector_int)
+            with self.assertRaises(NotImplementedError):
+                await message.respond("Hello there")
+
+            self.assertTrue(mocksleep_int.called)
+
+        # Test thinking-delay with a list
+
+        mock_connector_list = Connector({
+            'name': 'shell',
+            'thinking-delay': [1, 4],
+            'type': 'connector',
+            'module_path': 'opsdroid-modules.connector.shell'
+        })
+
+        with amock.patch('asyncio.sleep') as mocksleep_list:
+            message = Message("hi", "user", "default", mock_connector_list)
+            with self.assertRaises(NotImplementedError):
+                await message.respond("Hello there")
+
+            self.assertTrue(mocksleep_list.called)
+
     async def test_typing_delay(self):
         mock_connector = Connector({
             'name': 'shell',

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,5 +1,6 @@
 
 import asynctest
+import asynctest.mock as amock
 
 from opsdroid.message import Message
 from opsdroid.connector import Connector
@@ -26,3 +27,38 @@ class TestMessage(asynctest.TestCase):
         with self.assertRaises(NotImplementedError):
             await message.respond("Goodbye world")
         self.assertEqual(message_text, message.text)
+
+    async def test_thinking_delay(self):
+        mock_connector = Connector({
+            'name': 'shell',
+            'thinking-delay': 3,
+            'type': 'connector',
+             'module_path': 'opsdroid-modules.connector.shell'
+        })
+
+        with amock.patch(
+                'opsdroid.message.Message._thinking_delay') as logmock:
+            with amock.patch('asyncio.sleep') as mocksleep:
+                message = Message("hi", "user", "default", mock_connector)
+                with self.assertRaises(NotImplementedError):
+                    await message.respond("Hello there")
+
+                self.assertTrue(logmock.called)
+                self.assertTrue(mocksleep.called)
+
+    async def test_typing_delay(self):
+        mock_connector = Connector({
+            'name': 'shell',
+            'typing-delay': 3,
+            'type': 'connector',
+             'module_path': 'opsdroid-modules.connector.shell'
+        })
+        with amock.patch(
+                'opsdroid.message.Message._typing_delay') as logmock:
+            with amock.patch('asyncio.sleep') as mocksleep:
+                message = Message("hi", "user", "default", mock_connector)
+                with self.assertRaises(NotImplementedError):
+                    await message.respond("Hello there")
+
+                self.assertTrue(logmock.called)
+                self.assertTrue(mocksleep.called)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -91,3 +91,17 @@ class TestMessage(asynctest.TestCase):
 
                 self.assertTrue(logmock.called)
                 self.assertTrue(mocksleep.called)
+
+    async def test_typing_sleep(self):
+        mock_connector = Connector({
+            'name': 'shell',
+            'typing-delay': 6,
+            'type': 'connector',
+            'module_path': 'opsdroid-modules.connector.shell'
+        })
+        with amock.patch('asyncio.sleep') as mocksleep:
+            message = Message("hi", "user", "default", mock_connector)
+            with self.assertRaises(NotImplementedError):
+                await message.respond("Hello there")
+
+            self.assertTrue(mocksleep.called)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -33,25 +33,23 @@ class TestMessage(asynctest.TestCase):
             'name': 'shell',
             'thinking-delay': 3,
             'type': 'connector',
-             'module_path': 'opsdroid-modules.connector.shell'
+            'module_path': 'opsdroid-modules.connector.shell'
         })
 
         with amock.patch(
                 'opsdroid.message.Message._thinking_delay') as logmock:
-            with amock.patch('asyncio.sleep') as mocksleep:
-                message = Message("hi", "user", "default", mock_connector)
-                with self.assertRaises(NotImplementedError):
-                    await message.respond("Hello there")
+            message = Message("hi", "user", "default", mock_connector)
+            with self.assertRaises(NotImplementedError):
+                await message.respond("Hello there")
 
-                self.assertTrue(logmock.called)
-                self.assertTrue(mocksleep.called)
+            self.assertTrue(logmock.called)
 
     async def test_typing_delay(self):
         mock_connector = Connector({
             'name': 'shell',
-            'typing-delay': 3,
+            'typing-delay': 6,
             'type': 'connector',
-             'module_path': 'opsdroid-modules.connector.shell'
+            'module_path': 'opsdroid-modules.connector.shell'
         })
         with amock.patch(
                 'opsdroid.message.Message._typing_delay') as logmock:


### PR DESCRIPTION
# Description

This issue is a work in progress that adds thinking and typing functionality, I've actually been thinking about it for a while but only started to work on it now.  I'm making this PR just to show what I've wrote so far and to get some feedback and clarification on how to best implement these functionalities in opsdroid.

**Thinking delay** 
- defaults to 0 seconds - this to keeps opsdroid as fast as possible
- can be set in config.yaml with commands: `thinking-delay: < int or array>`
- accepts an int or array 

**Typing delay**

I'm dividing the character count of opsdroid's response by 6 - this means that every second opsdroid will type 6 characters which is +/- 66 words per second. This seems like a good number for someone that's a fast typer.

**Questions**
- Should I add a way for users to customise the typing delay or just allow the users to turn it on/off?
- Should these functions be left outside the message class?
- Is using get_opsdroid() the best way to to access config.yaml?

Hope this isn't too bad of a PR, please @jacobtomlinson let me know what you think 👍 




**Fixes** #66 & #65 


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox
- Ran opsdroid and tested the delays


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
