### PR TITLE
Fix for parsers being None

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -213,7 +213,7 @@ class OpsDroid():
 
         if "parsers" in self.config:
             _LOGGER.debug("Processing parsers...")
-            parsers = self.config["parsers"]
+            parsers = self.config["parsers"] or []
 
             dialogflow = [p for p in parsers if p["name"] == "dialogflow"
                           or p["name"] == "apiai"]


### PR DESCRIPTION
# Description

Closes #378. Sets `parsers` to `[]` if it is `None`.

**Fixes** #378


## Status
**READY** 


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- Unit tests
- Running opsdroid with default config but with `parsers:` uncommented.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

