### PR TITLE
Second fix for parsers being None

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -160,7 +160,7 @@ class OpsDroid():
     def train_parsers(self, skills):
         """Train the parsers."""
         if "parsers" in self.config:
-            parsers = self.config["parsers"]
+            parsers = self.config["parsers"] or []
             tasks = []
             rasanlu = [p for p in parsers if p["name"] == "rasanlu"]
             if len(rasanlu) == 1 and \


### PR DESCRIPTION
# Description
A follow up to #379. Fixes the same bug in the new `train_parsers(skills)` method of the core.