### PR TITLE
remove useless pylint disable comment

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -315,7 +315,6 @@ class Loader:
         return loaded_modules
 
     def _install_module(self, config):
-        # pylint: disable=R0201
         """Install a module."""
         _LOGGER.debug("Installing %s...", config["name"])
 


### PR DESCRIPTION
# Description

I was reading some code to understand Opsdroid before select some issue to collaborate and I noticed that there is one useless pylint disable comment.

Then I searched across all the repo looking for more, but that's the only one :smile: 


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

_It's not exactly a bug fix, but it's the closest category_


# How Has This Been Tested?

I just run again the linter and all the testsuite with tox


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

