### PR TITLE
Increment to v0.11.1

### DIFF
--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -1,7 +1,7 @@
 """Constants used by OpsDroid."""
 import os
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 DEFAULT_GIT_URL = "https://github.com/opsdroid/"
 MODULES_DIRECTORY = "opsdroid-modules"


### PR DESCRIPTION
# Description

New release to get docs building again.

The documentation for 0.11.0 is currently unavailable due #395. This has been fixed and this release is purely to get a new version of the docs built.