### PR TITLE
Update git modules on startup

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -226,6 +226,8 @@ connectors:
     repo: https://github.com/username/myconnector.git
 ```
 
+_Note: When using a git repository, Opsdroid will try to update it at startup pulling with fast forward strategy._
+
 #### Local Directory
 
 A local path to install the module from.

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -325,19 +325,18 @@ class Loader:
         """Install a module."""
         _LOGGER.debug("Installing %s...", config["name"])
 
-        if os.path.isdir(config["install_path"]) or \
-                os.path.isfile(config["install_path"] + ".py"):
+        if self._is_module_installed(config):
             # TODO Allow for updating or reinstalling of modules
             _LOGGER.debug("Module %s already installed, skipping.",
                           config["name"])
             return
 
-        if "path" in config:
+        if self._is_local_module(config):
             self._install_local_module(config)
         else:
             self._install_git_module(config)
 
-        if os.path.isdir(config["install_path"]):
+        if self._is_module_installed(config):
             _LOGGER.debug("Installed %s to %s", config["name"],
                           config["install_path"])
         else:
@@ -348,6 +347,15 @@ class Loader:
                 config["install_path"], "requirements.txt")):
             self.pip_install_deps(os.path.join(config["install_path"],
                                                "requirements.txt"))
+
+    @staticmethod
+    def _is_module_installed(config):
+        return os.path.isdir(config["install_path"]) or \
+            os.path.isfile(config["install_path"] + ".py")
+
+    @staticmethod
+    def _is_local_module(config):
+        return "path" in config
 
     def _install_git_module(self, config):
         """Install a module from a git repository."""

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -94,11 +94,17 @@ class Loader:
                                     git_url, install_path], shell=False,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
-        for output in process.communicate():
-            if output != "":
-                for line in output.splitlines():
-                    _LOGGER.debug(str(line).strip())
-        process.wait()
+        Loader._communicate_process(process)
+
+    @staticmethod
+    def git_pull(repository_path):
+        """Pull the current branch of git repo forcing fast forward"""
+        process = subprocess.Popen(["git", "-C", repository_path,
+                                    "pull", "--ff-only"],
+                                   shell=False,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        Loader._communicate_process(process)
 
     @staticmethod
     def pip_install_deps(requirements_path):
@@ -132,13 +138,14 @@ class Loader:
         if not process:
             raise OSError("Pip and pip3 not found, exiting...")
 
-        for output in process.communicate():
-            if output != "":
-                for line in output.splitlines():
-                    _LOGGER.debug(str(line).strip())
-
-        process.wait()
+        Loader._communicate_process(process)
         return True
+
+    @staticmethod
+    def _communicate_process(process):
+        for output in process.communicate():
+            for line in output.splitlines():
+                _LOGGER.debug(str(line).strip())
 
     @staticmethod
     def _load_intents(config):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -97,6 +97,12 @@ class TestLoader(unittest.TestCase):
                              os.path.join(self._tmp_dir, "/test"), "master")
             self.assertTrue(mock_subproc_popen.called)
 
+    def test_git_pull(self):
+        with mock.patch.object(subprocess, 'Popen') as mock_subproc_popen:
+            opsdroid, loader = self.setup()
+            loader.git_pull(os.path.join(self._tmp_dir, "/test"))
+            self.assertTrue(mock_subproc_popen.called)
+
     def test_pip_install_deps(self):
         with mock.patch.object(subprocess, 'Popen') as mocked_popen:
             mocked_popen.return_value.communicate.return_value = ['Test\nTest']

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -137,9 +137,9 @@ class TestLoader(unittest.TestCase):
         loader = mock.Mock()
         loader.modules_directory = ""
         self.assertIn("test.test",
-                      ld.Loader.build_module_path(loader, "import", config))
+                      ld.Loader.build_module_import_path(config))
         self.assertIn("test",
-                      ld.Loader.build_module_path(loader, "install", config))
+                      ld.Loader.build_module_install_path(loader, config))
 
     def test_check_cache_removes_dir(self):
         config = {}
@@ -299,17 +299,29 @@ class TestLoader(unittest.TestCase):
             self.assertTrue(mockimport.called)
             self.assertEqual(loaded_modules, [])
 
-    def test_install_existing_module(self):
+    def test_load_existing_modules(self):
         opsdroid, loader = self.setup()
-        config = {"name": "testmodule",
-                  "install_path": os.path.join(
-                      self._tmp_dir, "test_existing_module")}
-        os.mkdir(config["install_path"])
-        with mock.patch('opsdroid.loader._LOGGER.debug') as logmock:
-            loader._install_module(config)
-            self.assertTrue(logmock.called)
 
-        shutil.rmtree(config["install_path"], onerror=del_rw)
+        modules_type = "test"
+        modules = [{"name": "testmodule"}]
+        install_path = os.path.join(
+            self._tmp_dir, "test_existing_module")
+        mockedmodule = mock.Mock(return_value={"name": "testmodule"})
+        mocked_install_path = mock.Mock(return_value=install_path)
+
+        os.mkdir(install_path)
+        with mock.patch.object(loader, '_update_module') as mockupdate, \
+                mock.patch.object(loader, 'import_module',
+                                  mockedmodule) as mockimport, \
+                mock.patch.object(loader, 'build_module_install_path',
+                                  mocked_install_path) as mockbuildpath:
+            loader.setup_modules_directory({})
+            loader._load_modules(modules_type, modules)
+            self.assertTrue(mockbuildpath.called)
+            self.assertTrue(mockupdate.called)
+            self.assertTrue(mockimport.called)
+
+        shutil.rmtree(install_path, onerror=del_rw)
 
     def test_install_missing_local_module(self):
         opsdroid, loader = self.setup()
@@ -432,6 +444,39 @@ class TestLoader(unittest.TestCase):
         with mock.patch('opsdroid.loader._LOGGER.error') as logmock:
             loader._install_local_module(config)
             self.assertTrue(logmock.called)
+
+    def test_update_existing_local_module(self):
+        opsdroid, loader = self.setup()
+        base_path = os.path.join(self._tmp_dir, "long")
+        config = {"name": "testmodule",
+                  "type": "test",
+                  "install_path": os.path.join(
+                      base_path, os.path.normpath("test/path/test")),
+                  "path": os.path.join(
+                      self._tmp_dir, os.path.normpath("install/from/here"))}
+        os.makedirs(config["install_path"], exist_ok=True, mode=0o777)
+        os.makedirs(config["path"], exist_ok=True, mode=0o777)
+
+        with mock.patch('opsdroid.loader._LOGGER.debug') as logmock:
+            loader._update_module(config)
+            self.assertTrue(logmock.called)
+
+        shutil.rmtree(base_path, onerror=del_rw)
+
+    def test_update_existing_git_module(self):
+        opsdroid, loader = self.setup()
+        config = {"name": "testmodule",
+                  "install_path":
+                  os.path.join(self._tmp_dir, "test_specific_remote_module"),
+                  "repo": "https://github.com/rmccue/test-repository.git",
+                  "branch": "master"}
+        os.mkdir(config["install_path"])
+        with mock.patch('opsdroid.loader._LOGGER.debug'), \
+                mock.patch.object(loader, 'git_pull') as mockpull:
+            loader._update_module(config)
+            mockpull.assert_called_with(config["install_path"])
+
+        shutil.rmtree(config["install_path"], onerror=del_rw)
 
     def test_reload_module(self):
         config = {}


### PR DESCRIPTION
# Description

I saw an issue asking for updating modules from git repositories and I found it interesting.

This change just add git pull capabilities to Opsdroid, and avoids strange behaviours forcing only fast forward.

Some other points to consider:
- The common code in `process.communicate()` is refactored to a method, and the `wait()` call is suppressed (`communicate` [already waits](https://docs.python.org/3.6/library/subprocess.html#subprocess.Popen.communicate))
- `build_module_path` is refactored and splitted into two methods, to avoid the use of [flag arguments](https://www.martinfowler.com/bliki/FlagArgument.html)
- `_is_module_installed` and `_is_local_module` are refactors of some `ifs` to simplify the level of abstraction

**Fixes** #295


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


# How Has This Been Tested?

I fixed `build_module_path` test, removed `test_install_existing_module` (as now has no sense), and added some tests to check the new behaviour:

- test_load_existing_modules
- test_update_existing_local_module
- test_update_existing_git_module


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
