### PR TITLE
Document use of interactive shell in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check out the [Getting Started](https://www.youtube.com/watch?v=7wyIi_cpodE&list
 docker pull opsdroid/opsdroid:latest
 
 # Run the container
-docker run --rm -v /path/to/configuration.yaml:/etc/opsdroid/configuration.yaml:ro opsdroid/opsdroid:latest
+docker run --rm -it -v /path/to/configuration.yaml:/etc/opsdroid/configuration.yaml:ro opsdroid/opsdroid:latest
 ```
 
 ### Ubuntu 16.04 LTS


### PR DESCRIPTION

# Description

Added `-it` param to `docker run` installation with Docker

As explained on https://docs.docker.com/engine/reference/run/#foreground

"For interactive processes (like a shell), you must use -i -t together in order to allocate a tty for the container process. -i -t is often written -it as you’ll see in later examples."

**Fixes** #416 and at least #219. 


## Status

**READY**

IMHO this is ready to merge, but would be nice to review a few issues related to docker, like #219, that could be just caused just because the lack of `-it`, and not the websocket hypotesis here https://github.com/opsdroid/opsdroid/issues/219#issuecomment-329237551

**I suggest to [recheck docker related issues](https://github.com/opsdroid/opsdroid/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+docker) with this new change**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Documentation (fix or adds documentation)

# How Has This Been Tested?

Explained here https://github.com/fititnt/chatops-wg-ia-python-opsdroid/issues/3


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] <s>I have added tests that prove my fix is effective or that my feature works</s>
- [ ] <s>New and existing unit tests pass locally with my changes</s>

