### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ _\* databases are optional, however bot memory will not persist between differen
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute. [[Contribute](/docs/contributing.md)].
 <a href="graphs/contributors"><img src="https://opencollective.com/opsdroid/contributors.svg?width=890" /></a>
 
 


### PR DESCRIPTION
The contributing link in the [contributors](https://github.com/opsdroid/opsdroid#contributors) section now points to [docs/contributing.md](https://github.com/opsdroid/opsdroid/blob/master/docs/contributing.md).
