### PR TITLE
raw_message kwarg addition to the Message class.

### DIFF
--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -12,13 +12,14 @@ class Message:
     # pylint: disable=too-few-public-methods
     """A message object."""
 
-    def __init__(self, text, user, room, connector):
+    def __init__(self, text, user, room, connector, raw_message=None):
         """Create object with minimum properties."""
         self.created = datetime.now()
         self.text = text
         self.user = user
         self.room = room
         self.connector = connector
+        self.raw_message = raw_message
         self.regex = None
         self.responded_to = False
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-PyGithub==1.35
+PyGithub==1.36
 Jinja2==2.10
 Pygments==2.2.0
 docutils==0.14

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -19,9 +19,9 @@ class TestMessage(asynctest.TestCase):
             'messageId': '101'
         }
         message = Message(
-            "Hello world", 
-            "user", 
-            "default", 
+            "Hello world",
+            "user",
+            "default",
             mock_connector,
             raw_message)
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -11,11 +11,20 @@ class TestMessage(asynctest.TestCase):
 
     async def test_message(self):
         mock_connector = Connector({})
-        message = Message("Hello world", "user", "default", mock_connector)
+        raw_message = {
+            'text': 'Hello world',
+            'user': 'user',
+            'room': 'default',
+            'timestamp': '01/01/2000 19:23:00',
+            'messageId': '101'
+        }
+        message = Message("Hello world", "user", "default", mock_connector, raw_message)
 
         self.assertEqual(message.text, "Hello world")
         self.assertEqual(message.user, "user")
         self.assertEqual(message.room, "default")
+        self.assertEqual(message.raw_message['timestamp'], '01/01/2000 19:23:00')
+        self.assertEqual(message.raw_message['messageId'], '101')
         with self.assertRaises(NotImplementedError):
             await message.respond("Goodbye world")
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -18,12 +18,19 @@ class TestMessage(asynctest.TestCase):
             'timestamp': '01/01/2000 19:23:00',
             'messageId': '101'
         }
-        message = Message("Hello world", "user", "default", mock_connector, raw_message)
+        message = Message(
+            "Hello world", 
+            "user", 
+            "default", 
+            mock_connector,
+            raw_message)
 
         self.assertEqual(message.text, "Hello world")
         self.assertEqual(message.user, "user")
         self.assertEqual(message.room, "default")
-        self.assertEqual(message.raw_message['timestamp'], '01/01/2000 19:23:00')
+        self.assertEqual(
+            message.raw_message['timestamp'], '01/01/2000 19:23:00'
+            )
         self.assertEqual(message.raw_message['messageId'], '101')
         with self.assertRaises(NotImplementedError):
             await message.respond("Goodbye world")


### PR DESCRIPTION
# Description

The change allows to store complete message from a connector in its raw format, this allows for 
meta-data to be more readily available and prevents the need for extending the Message class with addition parameters

**Fixes** #443 


## Status
**READY** 


## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

