### PR TITLE
add a parser using parse lib (proposal)

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -14,6 +14,7 @@ from opsdroid.database import Database
 from opsdroid.loader import Loader
 from opsdroid.parsers.always import parse_always
 from opsdroid.parsers.regex import parse_regex
+from opsdroid.parsers.parseformat import parse_format
 from opsdroid.parsers.dialogflow import parse_dialogflow
 from opsdroid.parsers.luisai import parse_luisai
 from opsdroid.parsers.recastai import parse_recastai
@@ -228,6 +229,7 @@ class OpsDroid():
         """Take a message and return a ranked list of matching skills."""
         skills = []
         skills = skills + await parse_regex(self, message)
+        skills = skills + await parse_format(self, message)
 
         if "parsers" in self.config:
             _LOGGER.debug(_("Processing parsers..."))

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -5,7 +5,6 @@ import logging
 from opsdroid.helper import get_opsdroid
 from opsdroid.web import Web
 
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -16,6 +15,19 @@ def match_regex(regex, case_sensitive=True):
         opsdroid = get_opsdroid()
         opsdroid.skills.append({"regex": {"expression": regex,
                                           "case_sensitive": case_sensitive},
+                                "skill": func,
+                                "config":
+                                opsdroid.loader.current_import_config})
+        return func
+    return matcher
+
+
+def match_parse(format_str):
+    """Return parse match decorator."""
+    def matcher(func):
+        """Add decorated function to skills list for parse matching."""
+        opsdroid = get_opsdroid()
+        opsdroid.skills.append({"parse_format": format_str,
                                 "skill": func,
                                 "config":
                                 opsdroid.loader.current_import_config})

--- a/opsdroid/parsers/parseformat.py
+++ b/opsdroid/parsers/parseformat.py
@@ -1,0 +1,26 @@
+"""A helper function for parsing and executing regex skills."""
+
+import logging
+from parse import parse
+
+from opsdroid.parsers.regex import calculate_score
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def parse_format(opsdroid, message):
+    """Parse a message against all parse_format skills."""
+    matched_skills = []
+    for skill in opsdroid.skills:
+        if "parse_format" in skill:
+            result = parse(skill["parse_format"], message.text)
+            if result:
+                message.parse_result = result
+                matched_skills.append({
+                    "score": await calculate_score(skill["parse_format"]),
+                    "skill": skill["skill"],
+                    "config": skill["config"],
+                    "message": message
+                })
+    return matched_skills

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ aiohttp==2.3.10
 pycron==0.80.0
 pyyaml==3.12
 Babel==2.5.3
+parse==1.8.2

--- a/tests/test_parser_format.py
+++ b/tests/test_parser_format.py
@@ -1,0 +1,24 @@
+
+import asynctest
+import asynctest.mock as amock
+
+from opsdroid.core import OpsDroid
+from opsdroid.matchers import match_parse
+from opsdroid.message import Message
+from opsdroid.parsers.parseformat import parse_format
+
+
+class TestParserRegex(asynctest.TestCase):
+    """Test the opsdroid regex parser."""
+
+    async def test_parse_format(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = amock.CoroutineMock()
+            match_parse("Hello {name}")(mock_skill)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            skills = await parse_format(opsdroid, message)
+            self.assertEqual(mock_skill, skills[0]["skill"])
+            self.assertEqual(message.parse_result['name'], 'world')


### PR DESCRIPTION
# Description

I was reading the issue #447, thinking about the code in:
```python
@match_regex('my name is (?P<name>\w+) and my wife is called (?P<wife>\w+) and my son is called (?P<son>\w+)')
async def my_name_is(opsdroid, config, message):
    name = message.regex.group('name')
    wife = message.regex.group('wife')
    son = message.regex.group('son')
```
I thought that that's very "complicated" for just get some parameters. Regex it's very powerful and flexible, but for easy cases like this it's an overhead.

That's the reason why I make this proposal aiming to add a new core parser using [parse](https://github.com/r1chardj0n3s/parse) python lib.

It simplify a lot that type of matchers, using the classic format python style. For example, the example above will become:
```python
@match_parse('my name is {name} and my wife is called {wife} and my son is called {son}')
async def my_name_is(opsdroid, config, message):
    name = message.parse_result['name']
    wife = message.parse_result['wife']
    son = message.parse_result['son']
```

It can be very useful for easy matches, and can help to developers with few regex skills.

What do you think? If you like it, I will finish the implementation with tests and doc 😄 

## Status
**UNDER DEVELOPMENT**


## Type of change


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

It must be tested if we find it interesting.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

