### PR TITLE
Add documentation for maintainers

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,12 +67,6 @@ Running the tests
 docker run --rm -ti -v $(pwd):/usr/src/app opsdroid/opsdroid:myfeature tox
 ```
 
-## Maintainer scripts
-
-This project contains a directory called [`scripts`](https://github.com/opsdroid/opsdroid/tree/master/scripts) which are simple python scripts for use by maintainers when working on opsdroid. Each directory contains the script itself, a README and other supporting files. See the individual README files for more information.
-
-_These scripts may have dependancies so you should run `pip install -r requirements_dev.txt` from the root of the project._
-
 ## Documentation
 More documentation is always appreciated and it's something that you can contribute to from the GitHub web interface.  This might be a great start point if you are new to Open Source and GitHub!
 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -1,0 +1,35 @@
+# Maintainers
+
+A maintainer should be polite and respectful towards every member of the community in order to make opsdroid a great project for both newbies and veterans in open source.
+
+
+- **Responsibilities**
+  - Responding to issues and PRs (even just to say thanks and we'll look into it)
+  - Reviewing and merging Pull Requests
+  - Providing support on [gitter](https://gitter.im/opsdroid/developers)
+  - Engaging in discussions on how to grow and shape opsdroid
+  - Promote the project (blogging, tweeting, speaking at events, etc)
+  - Make regular contributions and tackle old issues
+ 
+- **Other important things**
+  - Jacob, the creator of opsdroid, is the one to cut releases for now
+  - If in doubt about a PR please mention @jacobtomlinson and ask for a review
+  - New contributors get [stickers](https://medium.com/opsdroid/stickers-for-contributors-a0a1f9c30ec1)! Get them to send their address to @jacobtomlinson if you merge their PR.
+
+## Reviewing and Merging Pull Requests
+As a maintainer one of the tasks that you have to take on will be reviewing pull requests and merge them if it meets the criteria. 
+
+**Criteria for merging a PR**
+  - You didn't write it yourself (this may not be practical yet, we should discuss it)
+  - The [PR template](PULL_REQUEST_TEMPLATE.md) criteria are met (has tests, is documented, etc)
+  - The existing tests pass and coverage remains the same
+  - It is related to an open issue
+  - It moves us towards our [core aims](https://github.com/opsdroid/opsdroid/issues/1)
+  
+Depending on the pull request, coverage might drop a bit. If that is the case, as a maintainer you should ask that a test is created to bump the coverage back up. You might need to give some guidance as to how to properly test the code in the PR.
+
+If a PR is not related to an open issue, then it's a proposal for the project. Jacob, the creator of opsdroid, and the community should give feedback and discuss the Pull Request either in the PR itself, an issue or in the [gitter](https://gitter.im/opsdroid/developers) channel.
+
+When merging a PR into opsdroid main branch you should take a few things into consideration.
+- The title of the merge will be included in the release notes of a new opsdroid version, so the title should make sense.
+- Remove unnecessary stuff from the description. If it takes 4 commits to get the tests to pass those lines should be deleted.

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -13,14 +13,14 @@ A maintainer should be polite and respectful towards every member of the communi
  
 - **Other important things**
   - Jacob, the creator of opsdroid, is the one to cut releases for now
-  - If in doubt about a PR please mention @jacobtomlinson and ask for a review
-  - New contributors get [stickers](https://medium.com/opsdroid/stickers-for-contributors-a0a1f9c30ec1)! Get them to send their address to @jacobtomlinson if you merge their PR.
+  - If in doubt about a PR please mention @opsdroid/maintainers and ask for a review
+  - New contributors get [stickers](https://medium.com/opsdroid/stickers-for-contributors-a0a1f9c30ec1)! Get them to send their address through DM to [@opsdroid](https://twitter.com/opsdroid) twitter account if you merge their PR.
 
 ## Reviewing and Merging Pull Requests
 As a maintainer one of the tasks that you have to take on will be reviewing pull requests and merge them if it meets the criteria. 
 
 **Criteria for merging a PR**
-  - You didn't write it yourself (this may not be practical yet, we should discuss it)
+  - You didn't write it yourself
   - The [PR template](PULL_REQUEST_TEMPLATE.md) criteria are met (has tests, is documented, etc)
   - The existing tests pass and coverage remains the same
   - It is related to an open issue
@@ -31,5 +31,13 @@ Depending on the pull request, coverage might drop a bit. If that is the case, a
 If a PR is not related to an open issue, then it's a proposal for the project. Jacob, the creator of opsdroid, and the community should give feedback and discuss the Pull Request either in the PR itself, an issue or in the [gitter](https://gitter.im/opsdroid/developers) channel.
 
 When merging a PR into opsdroid main branch you should take a few things into consideration.
+- Use Squash and Merge option when merging a PR into opsdroid's master branch
 - The title of the merge will be included in the release notes of a new opsdroid version, so the title should make sense.
 - Remove unnecessary stuff from the description. If it takes 4 commits to get the tests to pass those lines should be deleted.
+
+
+## Maintainer scripts
+
+This project contains a directory called [`scripts`](https://github.com/opsdroid/opsdroid/tree/master/scripts) which are simple python scripts for use by maintainers when working on opsdroid. Each directory contains the script itself, a README and other supporting files. See the individual README files for more information.
+
+_These scripts may have dependancies so you should run `pip install -r requirements_dev.txt` from the root of the project._

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,3 +26,4 @@ pages:
       - 'Always': 'matchers/always.md'
   - 'Contributing': 'contributing.md'
   - 'Releasing': 'project/making-a-release.md'
+  - 'Maintainers': 'maintainers.md'


### PR DESCRIPTION
# Description

This is my first attempt at creating documentation for maintainers. I've used most of what you said @jacobtomlinson on #434 and just added some guide text.

Would love to hear your opinions about this and if I should add/remove or mention something else.

I also have a question about merging a PR. Should squash and marge be chosen when merging? What is the best way to do it? (So I can add it up in the documentation)

**Fixes** #434 (maybe?)


## Status
~~**READY**~~ | **UNDER DEVELOPMENT** | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Documentation (fix or adds documentation)


# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

