### PR TITLE
add message reactions

### DIFF
--- a/docs/extending/connectors.md
+++ b/docs/extending/connectors.md
@@ -19,6 +19,8 @@ Connectors are a class which extends the base opsdroid Connector. The class has 
 #### respond
 *respond* will take a Message object and return the contents to the chat service.
 
+#### react
+*react* will take a Message object and an emoji name and add this emoji as a Message reaction (if the chat service supports this feature).
 
 #### disconnect
 *disconnect* there is also an optional disconnect method that will be called upon shutdown of opsdroid. This can be used to perform any disconnect operations for the connector.

--- a/opsdroid/connector.py
+++ b/opsdroid/connector.py
@@ -1,6 +1,10 @@
 """A base class for connectors to inherit from."""
 
+import logging
 from opsdroid.message import Message  # NOQA # pylint: disable=unused-import
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Connector():
@@ -76,6 +80,24 @@ class Connector():
 
         """
         raise NotImplementedError
+
+    async def react(self, message, emoji):
+        """React to a message.
+
+        Not all connectors will have capabilities to react messages, so this
+        method don't have to be implemented and by default logs a debug message
+        and returns False.
+
+        Args:
+            message (Message): A message received by the connector.
+            emoji    (string): The emoji name with which opsdroid will react
+
+        Returns:
+            bool: True for message successfully sent. False otherwise.
+
+        """
+        _LOGGER.debug(_("%s connector can't react to messages"), self.name)
+        return False
 
     async def user_typing(self, opsdroid, trigger):
         """Signals that opsdroid is typing.

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -61,3 +61,9 @@ class Message:
                 opsdroid.stats["total_response_time"] + \
                 (now - self.created).total_seconds()
             self.responded_to = True
+
+    async def react(self, emoji):
+        """React to this message using the connector it was created by."""
+        if 'thinking-delay' in self.connector.configuration:
+            await self._thinking_delay()
+        return await self.connector.react(self, emoji)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -38,6 +38,11 @@ class TestConnectorBaseClass(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.loop.run_until_complete(connector.respond({}))
 
+    def test_react(self):
+        connector = Connector({})
+        reacted = self.loop.run_until_complete(connector.react({}, 'emoji'))
+        self.assertFalse(reacted)
+
     def test_user_typing(self):
         opsdroid = 'opsdroid'
         connector = Connector({})

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -121,3 +121,9 @@ class TestMessage(asynctest.TestCase):
                 await message.respond("Hello there")
 
             self.assertTrue(mocksleep.called)
+
+    async def test_react(self):
+        mock_connector = Connector({})
+        message = Message("Hello world", "user", "default", mock_connector)
+        reacted = await message.react("emoji")
+        self.assertFalse(reacted)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -123,7 +123,13 @@ class TestMessage(asynctest.TestCase):
             self.assertTrue(mocksleep.called)
 
     async def test_react(self):
-        mock_connector = Connector({})
-        message = Message("Hello world", "user", "default", mock_connector)
-        reacted = await message.react("emoji")
-        self.assertFalse(reacted)
+        mock_connector = Connector({
+            'name': 'shell',
+            'thinking-delay': 2,
+            'type': 'connector',
+        })
+        with amock.patch('asyncio.sleep') as mocksleep:
+            message = Message("Hello world", "user", "default", mock_connector)
+            reacted = await message.react("emoji")
+            self.assertTrue(mocksleep.called)
+            self.assertFalse(reacted)


### PR DESCRIPTION
# Description

This PR add reaction capabilities to opsdroid, adding a new `react` method in `Message` and `Connector`.

By default it just log a debug message and return False, but can be implemented by connectors that have react capabilities (like Slack or Github).

**Fixes** #442


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

(By now it will be documented in the Slack connector, because it will be the only one that implements it)


# How Has This Been Tested?

I tested and checked that the new `react` methods returns False as expected.


# Checklist:

- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

