### PR TITLE
Add no-dep flag

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -15,6 +15,7 @@
    - [Git Repository](#git-repository)
    - [Local Directory](#local-directory)
    - [Disable Caching](#disable-caching)
+   - [Disable dependency install](#disable-dependency-install)
 - [Environment Variables](#environment-variables)
 - [Include Additional Yaml Files](#include-additional-yaml-files)
 
@@ -278,6 +279,19 @@ databases:
     repo: https://github.com/username/mymongofork.git
     no-cache: true
 ```
+
+### Disable dependency install
+
+Set `no-dep` to true to skip the installation of dependencies on every start of opsdroid. 
+
+```yaml
+skills:
+  - name: myawesomeskill
+    no-cache: true
+    no-deps: true
+```
+
+_Note: This might be useful when you are developing a skill and already have the dependencies installed._
 
 ## Environment variables
 

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -356,11 +356,13 @@ class Loader:
         if config.get('no-dep', False):
             _LOGGER.debug(_("'no-dep' set in configuration, skipping the "
                             "install of dependencies."))
+            return None
         else:
             if os.path.isfile(os.path.join(
                     config["install_path"], "requirements.txt")):
                 self.pip_install_deps(os.path.join(config["install_path"],
                                                    "requirements.txt"))
+        return True
 
     def _install_git_module(self, config):
         """Install a module from a git repository."""

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -357,15 +357,16 @@ class Loader:
             _LOGGER.debug(_("'no-dep' set in configuration, skipping the "
                             "install of dependencies."))
             return None
-        else:
-            if os.path.isfile(os.path.join(
-                    config["install_path"], "requirements.txt")):
-                self.pip_install_deps(os.path.join(config["install_path"],
-                                                   "requirements.txt"))
-            else:
-                _LOGGER.debug("Couldn't find the file requirements.txt, skipping.")
-                return None
-        return True
+
+        if os.path.isfile(os.path.join(
+                config["install_path"], "requirements.txt")):
+            self.pip_install_deps(os.path.join(config["install_path"],
+                                               "requirements.txt"))
+            return True
+
+        _LOGGER.debug("Couldn't find the file requirements.txt, "
+                      "skipping.")
+        return None
 
     def _install_git_module(self, config):
         """Install a module from a git repository."""

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -353,10 +353,14 @@ class Loader:
         return "path" in config
 
     def _install_module_dependencies(self, config):
-        if os.path.isfile(os.path.join(
-                config["install_path"], "requirements.txt")):
-            self.pip_install_deps(os.path.join(config["install_path"],
-                                               "requirements.txt"))
+        if config.get('no-dep', False):
+            _LOGGER.debug(_("'no-dep' set in configuration, skipping the "
+                            "install of dependencies."))
+        else:
+            if os.path.isfile(os.path.join(
+                    config["install_path"], "requirements.txt")):
+                self.pip_install_deps(os.path.join(config["install_path"],
+                                                   "requirements.txt"))
 
     def _install_git_module(self, config):
         """Install a module from a git repository."""

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -362,6 +362,9 @@ class Loader:
                     config["install_path"], "requirements.txt")):
                 self.pip_install_deps(os.path.join(config["install_path"],
                                                    "requirements.txt"))
+            else:
+                _LOGGER.debug("Couldn't find the file requirements.txt, skipping.")
+                return None
         return True
 
     def _install_git_module(self, config):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -203,6 +203,12 @@ class TestLoader(unittest.TestCase):
         with mock.patch('opsdroid.loader._LOGGER.debug') as logmock:
             loader._install_module_dependencies(config)
             self.assertTrue(logmock.called)
+            self.assertEqual(loader._install_module_dependencies(config), None)
+
+        with mock.patch.object(loader, '_install_module_dependencies') \
+                as nodep:
+            config['no-dep'] = False
+            self.assertTrue(nodep)
 
     def test_import_module(self):
         config = {}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -212,11 +212,12 @@ class TestLoader(unittest.TestCase):
 
     def test_no_req_in_install_module_dependencies(self):
         opsdroid, loader = self.setup()
-        config = {'install_path': ''}
-        with mock.patch.object(opsdroid, 'loader._LOGGER.debug') as logmock:
-            self.assertIsNone(loader._install_module_dependencies(config))
+        config = {}
+        config['install_path'] = ''
 
-
+        with mock.patch('os.path.isfile') as file:
+            file.return_value = False
+            self.assertEqual(loader._install_module_dependencies(config), None)
 
     def test_import_module(self):
         config = {}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -194,6 +194,16 @@ class TestLoader(unittest.TestCase):
         loaded_intents = ld.Loader._load_intents(config)
         self.assertEqual(None, loaded_intents)
 
+    def test_no_dep(self):
+        opsdroid, loader = self.setup()
+
+        config = {}
+        config['no-dep'] = True
+
+        with mock.patch('opsdroid.loader._LOGGER.debug') as logmock:
+            loader._install_module_dependencies(config)
+            self.assertTrue(logmock.called)
+
     def test_import_module(self):
         config = {}
         config["module_path"] = "os"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -210,6 +210,14 @@ class TestLoader(unittest.TestCase):
             config['no-dep'] = False
             self.assertTrue(nodep)
 
+    def test_no_req_in_install_module_dependencies(self):
+        opsdroid, loader = self.setup()
+        config = {'install_path': ''}
+        with mock.patch.object(opsdroid, 'loader._LOGGER.debug') as logmock:
+            self.assertIsNone(loader._install_module_dependencies(config))
+
+
+
     def test_import_module(self):
         config = {}
         config["module_path"] = "os"


### PR DESCRIPTION
# Description

This adds the `no-dep` flag to opsdroid so the installation of dependencies of a specific module can be skipped. I've added the if statement on the `_install_module_dependencies()` method, but I'm not sure how to test it.

I had this version before:

```python
    def _install_module_dependencies(self, config):
        if not config.get('no-dep', False):
            if os.path.isfile(os.path.join(
                    config["install_path"], "requirements.txt")):
                self.pip_install_deps(os.path.join(config["install_path"],
                                                   "requirements.txt"))
```

And tested to see if `_install_module_dependencies` returned None when the flag `no-dep` is set to true. My tests with a mock function worked, but not with opsdroid, so I changed the implementation to just log that the installation of dependencies will be skipped.

What do you think it's the best version? 
How should I test this bit better than what I have done?

**Fixes** #444


## Status
~~**READY**~~ | **UNDER DEVELOPMENT** | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox (green)
- Ran tests on pycharm(green)


# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
