### PR TITLE
Revert changes to loader.py

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -257,7 +257,7 @@ class TestLoader(unittest.TestCase):
         config['module-path'] = os.path.join(self._tmp_dir, "opsdroid")
 
         loader.load_modules_from_config(config)
-        self.assertEqual(len(loader._load_modules.mock_calls), 3)
+        self.assertEqual(len(loader._load_modules.mock_calls), 4)
 
     def test_load_empty_config(self):
         opsdroid, loader = self.setup()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -500,3 +500,17 @@ class TestLoader(unittest.TestCase):
             mockpull.assert_called_with(config["install_path"])
 
         shutil.rmtree(config["install_path"], onerror=del_rw)
+
+    def test_reload_module(self):
+        config = {}
+        config["module_path"] = "os.path"
+        config["name"] = "path"
+        config["type"] = "system"
+        from os import path
+        opsdriod, loader = self.setup()
+
+        with mock.patch('importlib.reload') as reload_mock:
+            mock_module = {"module": path,
+                           "config": config}
+            loader._reload_modules([mock_module])
+        self.assertTrue(reload_mock.called)


### PR DESCRIPTION
# Description

After the commit #461 was merged into opsdroid by me, opsdroid stopped answering to commands. 
I did some digging around and reverting the changes to `opsdroid.loader` fixed the issue.
This PR is just a quick fix to opsdroid in order to keep it working. 

I've tried different things to try and understand why the method `_reload_modules`, the thing that makes everything work seems to be the line `importlib.reload(sys.modules[module_name])` but, to be honest, I have no idea why.

Also, should I raise an issue about this in order to have this method removed?

## Status
**READY** 


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Ran opsdroid to see if opsdroid will respond to a command
- Tox - all green

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes