### PR TITLE
Removes  line that was breaking opsdroid

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -245,7 +245,6 @@ class Loader:
 
         if 'skills' in config.keys() and config['skills']:
             skills = self._load_modules('skill', config['skills'])
-            self.opsdroid.skills = []
 
         else:
             self.opsdroid.critical(_(


### PR DESCRIPTION
# Description

This PR removes the line `self.opsdroid.skills = []` in opsdroid.loader. @jacobtomlinson  suggested removing it and that fixed the issue 👍 

**Fixes** #473 


## Status
**READY**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran opsdroid - all working as expected


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
