### PR TITLE
Fix opsdroid failing if Rasa NLU is not available

### DIFF
--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -68,12 +68,15 @@ async def _get_existing_models(config):
     """Get a list of models already trained in the Rasa NLU project."""
     project = config.get("project", RASANLU_DEFAULT_PROJECT)
     async with aiohttp.ClientSession() as session:
-        resp = await session.get(await _build_status_url(config))
-        if resp.status == 200:
-            result = await resp.json()
-            if project in result["available_projects"]:
-                project_models = result["available_projects"][project]
-                return project_models["available_models"]
+        try:
+            resp = await session.get(await _build_status_url(config))
+            if resp.status == 200:
+                result = await resp.json()
+                if project in result["available_projects"]:
+                    project_models = result["available_projects"][project]
+                    return project_models["available_models"]
+        except aiohttp.ClientOSError:
+            pass
     return []
 
 

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -134,6 +134,11 @@ class TestParserRasaNLU(asynctest.TestCase):
                     opsdroid, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
+                mocked_call_rasanlu.side_effect = ClientOSError
+                await rasanlu.parse_rasanlu(
+                    opsdroid, message, opsdroid.config['parsers'][0])
+                self.assertRaises(ClientOSError)
+
     async def test_parse_rasanlu_raises(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = [

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -424,12 +424,10 @@ class TestParserRasaNLU(asynctest.TestCase):
             self.assertEqual(models, ["hello", "world"])
 
     async def test__get_existing_models_exception(self):
-        result = amock.Mock()
-        result.status = ClientOSError()
 
         with amock.patch('aiohttp.ClientSession.get') as patched_request:
             patched_request.return_value = asyncio.Future()
-            patched_request.return_value.set_result(result)
+            patched_request.side_effect = ClientOSError()
             models = await rasanlu._get_existing_models(
                 {"project": "opsdroid"})
             self.assertRaises(ClientOSError)


### PR DESCRIPTION
# Description

I've sent a message about this in gitter but with all the chatter I think it got lost. Anyhow, this seems to fix the issue #412 a simple try/except made opsdroid work without any problems. I'm not sure if this is the best option to fix this issue tho.

When running opsdroid with rasanlu set on the config file the debug console shows this:

```
DEBUG opsdroid.core: Parsing input: hi
DEBUG opsdroid.core: Processing parsers...
DEBUG opsdroid.core: Checking Rasa NLU...
ERROR opsdroid.parsers.rasanlu: Unable to connect to Rasa NLU
opsdroid> ERROR opsdroid.parsers.rasanlu: Rasa NLU error - No intent found. Did you forget to create one?
DEBUG root: Responding with: Hi fabiorosado
```

The reason why I decided not to create a logging function on the pass method was because of the previous logging  message when `clientOSError` is raised "Unable to connect to Rasa NLU"

It's also possible to make opsdroid work when using the except: `aiohttp.client_exceptions.ClientConnectionError` but since we are already raising ClientOSError in the parse function, I've decided to just just ClientOSError (as both except makes opsdroid work)

Would love to know your opinion on this. It will probably need a test on the try/except which I can create if needed.

**Fixes** #412


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran opsdroid - all good


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
