### PR TITLE
Pass extra kwargs to connector.respond()

### DIFF
--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -69,9 +69,10 @@ A _string_ containing the name of the room or chat channel the message was sent 
 
 A pointer to the opsdroid _connector object_ which receieved the message.
 
-### `respond(text)`
+### `respond(text, **connector_kwargs)`
 
-A method which responds to the message in the same room using the same connector that it was received.
+A method which responds to the received message using the same connector.
+By default the response is sent to the same room, but arguments may be passed to `connector.respond()` using `**connector_kwargs` to change this behaviour, if the connector supports this.
 
 ## Persisting data
 

--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -69,10 +69,10 @@ A _string_ containing the name of the room or chat channel the message was sent 
 
 A pointer to the opsdroid _connector object_ which receieved the message.
 
-### `respond(text, **connector_kwargs)`
+### `respond(text, room=None)`
 
 A method which responds to the received message using the same connector.
-By default the response is sent to the same room, but arguments may be passed to `connector.respond()` using `**connector_kwargs` to change this behaviour, if the connector supports this.
+By default the response is sent to the same room, but arguments may be passed to `connector.respond()` using the `room` argument to change this behaviour, if the connector supports this.
 
 ## Persisting data
 

--- a/opsdroid/connector.py
+++ b/opsdroid/connector.py
@@ -65,7 +65,7 @@ class Connector():
         """
         raise NotImplementedError
 
-    async def respond(self, message):
+    async def respond(self, message, room=None):
         """Send a message back to the chat service.
 
         The message object will have a `text` property which should be sent
@@ -74,6 +74,7 @@ class Connector():
 
         Args:
             message (Message): A message received by the connector.
+            room (string): Name of the room to send the message to
 
         Returns:
             bool: True for message successfully sent. False otherwise.

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -41,7 +41,7 @@ class Message:
         except KeyError:
             pass
 
-    async def respond(self, text, **connector_kwargs):
+    async def respond(self, text, room=None):
         """Respond to this message using the connector it was created by."""
         opsdroid = get_opsdroid()
         response = copy(self)
@@ -52,7 +52,7 @@ class Message:
             await self._thinking_delay()
             await self._typing_delay(response.text)
 
-        await self.connector.respond(response, **connector_kwargs)
+        await self.connector.respond(response, room)
         if not self.responded_to:
             now = datetime.now()
             opsdroid.stats["total_responses"] = \

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -41,7 +41,7 @@ class Message:
         except KeyError:
             pass
 
-    async def respond(self, text):
+    async def respond(self, text, **connector_kwargs):
         """Respond to this message using the connector it was created by."""
         opsdroid = get_opsdroid()
         response = copy(self)
@@ -52,7 +52,7 @@ class Message:
             await self._thinking_delay()
             await self._typing_delay(response.text)
 
-        await self.connector.respond(response)
+        await self.connector.respond(response, **connector_kwargs)
         if not self.responded_to:
             now = datetime.now()
             opsdroid.stats["total_responses"] = \


### PR DESCRIPTION
# Description

Allows `Message.respond()` to take extra keyword arguments which are passed to `connector.respond()`. Doesn't fix any existing issue, but is required for the Matrix connector to be able to [respond in arbitrary rooms](https://github.com/opsdroid/connector-matrix/pull/18). No dependencies are required for this change.

## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

No formal tests, but since the only change is to add optional keyword arguments, nothing else should break. Works locally with Matrix connector patched to take a room name and respond in that room.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (not necessary?)
- [x] New and existing unit tests pass locally with my changes

