### PR TITLE
Refactor maintainer script to take updates from all modules

### DIFF
--- a/scripts/update_example_config/README.md
+++ b/scripts/update_example_config/README.md
@@ -21,3 +21,4 @@ You can also pass a few optional arguments when running the above command in you
 - first argument - path and file to be updated by the script. If this is not provided the default is the file located in [configuration/example_configuration.yaml](/opsdroid/configuration/example_configuration.yaml)
 - `-t` or `--token` - Your personal GitHub API token. If not used, GitHub will only accept 60 calls to its API from your IP address, instead of the 5000 calls allowed if authenticated.
 - `-a` or `--active-skills` -  A list of all the skills you wish to mark as active when the file gets updated.
+- `-c` or `--active-connectors` - A list of all the connectors that you wish to mark as active when the file gets updated.

--- a/scripts/update_example_config/README.md
+++ b/scripts/update_example_config/README.md
@@ -20,5 +20,4 @@ You can also pass a few optional arguments when running the above command in you
 
 - first argument - path and file to be updated by the script. If this is not provided the default is the file located in [configuration/example_configuration.yaml](/opsdroid/configuration/example_configuration.yaml)
 - `-t` or `--token` - Your personal GitHub API token. If not used, GitHub will only accept 60 calls to its API from your IP address, instead of the 5000 calls allowed if authenticated.
-- `-a` or `--active-skills` -  A list of all the skills you wish to mark as active when the file gets updated.
-- `-c` or `--active-connectors` - A list of all the connectors that you wish to mark as active when the file gets updated.
+- `-a` or `--active-modules` -  A list of all the modules(skills, connectors, databases and parsers) you wish to mark as active when the file gets updated, the order in which you specify the modules doesn't matter.

--- a/scripts/update_example_config/configuration.j2
+++ b/scripts/update_example_config/configuration.j2
@@ -59,6 +59,14 @@ connectors:
 
 
 ## Database modules (optional)
+{% if databases.uncommented %}
+databases:
+{% for database in databases.uncommented %}
+  {% for line in database.config.split('\n') -%}
+  {{ line }}
+  {% endfor -%}
+{% endfor %}
+{% else %}
 # databases:
 #{% for database in databases.commented %}
 #  ## {{ database.name }} ({{ database.url }})
@@ -66,6 +74,7 @@ connectors:
 #  {{ line }}
 {% endfor -%}
 #{% endfor %}
+{% endif %}
 
 ## Skill modules
 skills:

--- a/scripts/update_example_config/configuration.j2
+++ b/scripts/update_example_config/configuration.j2
@@ -35,15 +35,12 @@ welcome-message: true
 
 ## Parsers
 # parsers:
-#   - name: regex
-#     enabled: true
-#
-#   - name: crontab
-#     enabled: true
-#
-#   - name: dialogflow
-#     access-token: "youraccesstoken"
-#     min-score: 0.6
+#{% for parser in parsers %}
+#  ## {{ parser.name }} ({{ parser.url }})
+{% for line in parser.config.split('\n') -%}
+#  {{ line }}
+{% endfor -%}
+#{% endfor %}
 
 ## Connector modules
 connectors:

--- a/scripts/update_example_config/configuration.j2
+++ b/scripts/update_example_config/configuration.j2
@@ -47,66 +47,39 @@ welcome-message: true
 
 ## Connector modules
 connectors:
-  - name: shell
-  - name: websocket
-
+{% for connector in connectors.uncommented %}
+  {% for line in connector.config.split('\n') -%}
+  {{ line }}
+  {% endfor -%}
+{% endfor %}
   # Uncomment the connector(s) that you wish opsdroid to work on
-#  ## Slack (https://github.com/opsdroid/connector-slack)
-#  - name: slack
-#    # Required
-#    api-token: "zyxw-abdcefghi-12345"
-#    # optional
-#    bot-name: "mybot"       # default "opsdroid"
-#    default-room: "#random" # default "#general"
-#    icon-imoji: ":smile:"   # default ":robot_face:"
-#
-#  ## Facebook (https://github.com/opsdroid/connector-facebook)
-#  - name: facebook
-#    # Required
-#    verify-token: aabbccddee
-#    page-access-token: aabbccddee112233445566
-#    # Optional
-#    bot-name: "mybot" # default "opsdroid"
-#
-#  ## Twitter (https://github.com/opsdroid/connector-twitter)
-#  - name: twitter
-#    # Required
-#    consumer_key: "zyxw-abdcefghi-12345"
-#    consumer_secret: "zyxw-abdcefghi-12345-zyxw-abdcefghi-12345"
-#    oauth_token: ""zyxw-abdcefghi-12345-zyxw-abdcefghi-12345"
-#    oauth_token_secret: "zyxw-abdcefghi-12345-zyxw-abdcefghi-12345"
-#    # Optional
-#    enable_dms: true    # Should the bot respond to Direct Messages
-#    enable_tweets: true # Should the bot respond to tweets
-#
-#  ## Telegram (https://github.com/opsdroid/connector-telegram)
-#  - name: telegram
-#    # Required
-#    token: "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ-ZYXWVUT"  # Telegram bot token
-#    # Optional
-#    update_interval: 0.5  # Interval between checking for messages
-#    default_user: user1   # Default user to send messages to (overrides default room in connector)
-#    whitelisted_users:    # List of users who can speak to the bot, if not set anyone can speak
-#      - user1
-#      - user2
+#{% for connector in connectors.commented %}
+#  ## {{ connector.name }} ({{ connector.url }})
+{% for line in connector.config.split('\n') -%}
+#  {{ line }}
+{% endfor -%}
+#{% endfor %}
+
 
 ## Database modules (optional)
 # databases:
-#   - name: mongo
-#     host:       "my host"     # (Optional) default "localhost"
-#     port:       "12345"       # (Optional) default "27017"
-#     database:   "mydatabase"  # (Optional) default "opsdroid"
+#{% for database in databases.commented %}
+#  ## {{ database.name }} ({{ database.url }})
+{% for line in database.config.split('\n') -%}
+#  {{ line }}
+{% endfor -%}
+#{% endfor %}
 
 ## Skill modules
 skills:
-{% for skill in uncommented_skills %}
+{% for skill in skills.uncommented %}
   ## {{ skill.name }} ({{ skill.url }})
   {% for line in skill.config.split('\n') -%}
   {{ line }}
   {% endfor -%}
 {% endfor %}
   # Configurations for other skills uncomment desired skill to activate it.
-#{% for skill in commented_skills %}
+#{% for skill in skills.commented %}
 #  ## {{ skill.name }} ({{ skill.url }})
 {% for line in skill.config.split('\n') -%}
 #  {{ line }}

--- a/scripts/update_example_config/update_example_config.py
+++ b/scripts/update_example_config/update_example_config.py
@@ -127,7 +127,7 @@ def validate_yaml_format(mapping, error_strict):
         yaml.load(mapping)
     except yaml.scanner.ScannerError as e:
         if error_strict:
-            raise(e)
+            raise e
         print(
             "[WARNING] processing {0} raised an exception\n"
             "{1}\n{0}\n{1}".format(e, '='*40)
@@ -154,7 +154,6 @@ def triage_modules(g, active_modules, error_strict=False):
         if params['repo_type'] == 'skill':
             if params['raw_name'] in active_modules:
                 skills['uncommented'].append(params)
-
             skills['commented'].append(params)
 
         elif params['repo_type'] == 'connector':
@@ -163,7 +162,7 @@ def triage_modules(g, active_modules, error_strict=False):
             connectors['commented'].append(params)
         else:
             if params['raw_name'] == active_modules:
-                databases['commented'].append(params)
+                databases['uncommented'].append(params)
             databases['commented'].append(params)
 
     return modules
@@ -184,10 +183,8 @@ if __name__ == '__main__':
     parser = ArgumentParser(description='Config creator ')
     parser.add_argument('output', nargs='?', help='Path to config to update')
     parser.add_argument('-t', '--token', nargs='?', help='GitHub Token')
-    parser.add_argument('-a', '--active-skills',
-                        nargs='?', help='List of skills to be activated')
-    parser.add_argument('-c', '--active-connectors',
-                        nargs='?', help='List of connectors to be activated')
+    parser.add_argument('-a', '--active-modules',
+                        nargs='?', help='List of modules to be activated')
 
     parser.set_defaults(error_strict=False)
     group = parser.add_mutually_exclusive_group()
@@ -210,9 +207,7 @@ if __name__ == '__main__':
 
     active_modules = []
 
-    if args.active_skills:
-        active_modules.append((args.active_skills.split(',')))
-    elif args.active_connectors:
+    if args.active_modules:
         active_modules.append((args.active_skills.split(',')))
     else:
         active_modules = ['dance', 'hello', 'seen', 'loudnoises',

--- a/scripts/update_example_config/update_example_config.py
+++ b/scripts/update_example_config/update_example_config.py
@@ -49,9 +49,12 @@ def get_readme(repo):
 def get_config_details(readme):
     """Gets all the configuration details located in the readme.md file,
     under the title "Configuration".
+
+    Note: Regex divided by multiline in order to pass lint.
     """
     config = re.search(
-        '#[#\s]+(?:Configuring|Configuration)((.|\n)*?)```(yaml)?\n((.|\n)*?)\n```',
+        '#[#\s]+(?:Configuring|Configuration)((.|\n)*?)'
+        '```(yaml)?\n((.|\n)*?)\n```',
         readme,
         re.MULTILINE
     )
@@ -141,7 +144,7 @@ def triage_modules(g, active_modules, error_strict=False):
     parsers = get_parsers_details()
 
     modules = {'skills': skills, 'connectors': connectors,
-               'databases': databases, 'parsers': parsers }
+               'databases': databases, 'parsers': parsers}
 
     for repo in repos:
         readme = get_readme(repo)


### PR DESCRIPTION
# Description

This PR updates the maintainers script to update the `example_configuration.yaml`, I've changed the names of a few functions and methods, deleted one function that validates yaml (since there was one created already). 

--EDIT--

Okay so I was able to get the data from the documentation and update the file with this details, I've double checked and seems to be working okay.

Also, as I worked on this I started wondering if it's worth adding the ability to take another argument to activate parsers and databases. Also, would it be better to just take one parser flag like: `-a`/`--activate-modules` and type all the arguments in a single command instead of using different flags?

Please let me know what do you think is best @jacobtomlinson 👍 

--EDIT x2 --
Decided that it would be better to just use one single flag to mark all the modules to be activated when the configuration.yaml is updated for simplicity sake. I've also added the ability to specify databases to be either commented/uncommented.


Fixes # n/a


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~  | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._


- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Pulled changes from github and updated the file `example_configuration.yaml` successfully
- Pulled the details from documentation successfully


# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

