### PR TITLE
fix issue #515 : add a space in the warning message

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -239,7 +239,7 @@ class Loader:
             databases = self._load_modules('database', config['databases'])
         else:
             _LOGGER.warning(_("No databases in configuration."
-                              "This will cause skills which store things in"
+                              "This will cause skills which store things in "
                               "memory to lose data when opsdroid is "
                               "restarted."))
 


### PR DESCRIPTION
# Description

change the following warning message :
"No databases in configuration. This will cause skills which store things inmemory to lose data when opsdroid is restarted." 

to
"No databases in configuration. This will cause skills which store things in memory to lose data when opsdroid is restarted."  with an additional  space between "in" and "memmory".


Fixes #515 


## Status
**READY**  

## Type of change

- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?
- Test A : Run opsdroid without any database configured.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

