### PR TITLE
Switch arg parsing to click and add version flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.pytest_cache
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For information on arguments that you can pass to opsdroid run `opsdroid --help`
 $ opsdroid --help
 Usage: opsdroid [OPTIONS]
 
-  Opsdroid is chat bot framework written in python.
+  Opsdroid is a chat bot framework written in python.
 
   It is designed to be extendable, scalable and simple. See
   https://opsdroid.github.io/ for more information.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ sudo pip3 install opsdroid
 opsdroid
 ```
 
+## Usage
+
+When running the `opsdroid` command with no arguments the bot framework will start using the configuration in `~/.opsdroid/configuration.yaml`. Beginners should check out the [introduction tutorial](http://opsdroid.readthedocs.io/en/stable/tutorials/introduction/) for information on how to configure opsdroid.
+
+For information on arguments that you can pass to opsdroid run `opsdroid --help`.
+
+```
+$ opsdroid --help
+Usage: opsdroid [OPTIONS]
+
+  Opsdroid is chat bot framework written in python.
+
+  It is designed to be extendable, scalable and simple. See
+  https://opsdroid.github.io/ for more information.
+
+Options:
+  --gen-config   Print an example config and exit.
+  -v, --version  Print the version and exit.
+  --help         Show this message and exit.
+```
 
 ## Contributing
 

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -138,7 +138,7 @@ def welcome_message(config):
               expose_value=False, default=False, is_eager=True,
               help='Print the version and exit.')
 def main():
-    """Opsdroid is chat bot framework written in Python.
+    """Opsdroid is a chat bot framework written in Python.
 
     It is designed to be extendable, scalable and simple.
     See https://opsdroid.github.io/ for more information.

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -138,7 +138,7 @@ def welcome_message(config):
               expose_value=False, default=False, is_eager=True,
               help='Print the version and exit.')
 def main():
-    """Opsdroid is chat bot framework written in python.
+    """Opsdroid is chat bot framework written in Python.
 
     It is designed to be extendable, scalable and simple.
     See https://opsdroid.github.io/ for more information.

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -106,7 +106,7 @@ def print_example_config(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
     with open(EXAMPLE_CONFIG_FILE, 'r') as conf:
-        print(conf.read())
+        click.echo(conf.read())
     ctx.exit(0)
 
 

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -3,12 +3,13 @@
 import os
 import sys
 import logging
-import argparse
 import gettext
 
+import click
+
 from opsdroid.core import OpsDroid
-from opsdroid.const import DEFAULT_LOG_FILENAME, EXAMPLE_CONFIG_FILE,\
-    DEFAULT_LANGUAGE, LOCALE_DIR
+from opsdroid.const import __version__, DEFAULT_LOG_FILENAME, \
+    EXAMPLE_CONFIG_FILE, DEFAULT_LANGUAGE, LOCALE_DIR
 from opsdroid.web import Web
 
 
@@ -85,19 +86,28 @@ def get_logging_level(logging_level):
     return logging.INFO
 
 
-def parse_args(args):
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description='Run opsdroid.')
-    parser.add_argument('--gen-config', action="store_true",
-                        help='prints out an example configuration file')
-    return parser.parse_args(args)
-
-
 def check_dependencies():
     """Check for system dependencies required by opsdroid."""
     if sys.version_info.major < 3 or sys.version_info.minor < 5:
         logging.critical(_("Whoops! opsdroid requires python 3.5 or above."))
         sys.exit(1)
+
+
+def print_version(ctx, param, value):
+    """Print out the version of opsdroid that is installed."""
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo('opsdroid v{version}'.format(version=__version__))
+    ctx.exit()
+
+
+def print_example_config(ctx, param, value):
+    """Print out the example config."""
+    if not value or ctx.resilient_parsing:
+        return
+    with open(EXAMPLE_CONFIG_FILE, 'r') as conf:
+        print(conf.read())
+    sys.exit(0)
 
 
 def welcome_message(config):
@@ -120,15 +130,19 @@ def welcome_message(config):
                           "configuration.yaml"))
 
 
+@click.command()
+@click.option('--gen-config', is_flag=True, callback=print_example_config,
+              expose_value=False, default=False,
+              help='Print an example config and exit.')
+@click.option('--version', '-v', is_flag=True, callback=print_version,
+              expose_value=False, default=False, is_eager=True,
+              help='Print the version and exit.')
 def main():
-    """Parse the args and then start the application."""
-    args = parse_args(sys.argv[1:])
+    """Opsdroid is chat bot framework written in python.
 
-    if args.gen_config:
-        with open(EXAMPLE_CONFIG_FILE, 'r') as conf:
-            print(conf.read())
-        sys.exit(0)
-
+    It is designed to be extendable, scalable and simple.
+    See https://opsdroid.github.io/ for more information.
+    """
     check_dependencies()
 
     with OpsDroid() as opsdroid:

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -98,7 +98,7 @@ def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
     click.echo('opsdroid v{version}'.format(version=__version__))
-    ctx.exit()
+    ctx.exit(0)
 
 
 def print_example_config(ctx, param, value):
@@ -107,7 +107,7 @@ def print_example_config(ctx, param, value):
         return
     with open(EXAMPLE_CONFIG_FILE, 'r') as conf:
         print(conf.read())
-    sys.exit(0)
+    ctx.exit(0)
 
 
 def welcome_message(config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 arrow==0.12.1
 aiohttp==3.1.1
+Babel==2.5.3
+click==6.7
 pycron==0.80.0
 pyyaml==3.12
-Babel==2.5.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ Jinja2==2.10
 Pygments==2.2.0
 docutils==0.14
 mock==2.0.0
-pillow==5.0.0
+pillow==5.1.0
 alabaster==0.7.10
 commonmark==0.7.5
 recommonmark==0.4.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,17 +1,19 @@
 
 import unittest
+import unittest.mock as mock
 import logging
 import os
 import sys
 import shutil
 import tempfile
-import unittest.mock as mock
 import gettext
-from click.testing import CliRunner
 
+import click
+from click.testing import CliRunner
 
 import opsdroid.__main__ as opsdroid
 import opsdroid.web as web
+from opsdroid.const import __version__
 from opsdroid.core import OpsDroid
 from opsdroid.helper import del_rw
 
@@ -163,16 +165,23 @@ class TestMain(unittest.TestCase):
                 self.fail("check_dependencies() exited unexpectedly!")
 
     def test_gen_config(self):
-        with mock.patch.object(sys, 'argv', ["opsdroid", "--gen-config"]):
-            with self.assertRaises(SystemExit):
-                opsdroid.main()
+        with mock.patch.object(click, 'echo') as click_echo,\
+                mock.patch('opsdroid.core.OpsDroid.load') as opsdroid_load:
+            runner = CliRunner()
+            result = runner.invoke(opsdroid.main, ['--gen-config'])
+            self.assertTrue(click_echo.called)
+            self.assertFalse(opsdroid_load.called)
+            self.assertEqual(result.exit_code, 0)
 
     def test_print_version(self):
-        ctx = mock.MagicMock()
-        ctx.exit = mock.MagicMock()
-        ctx.resilient_parsing = False
-        opsdroid.print_version(ctx, None, True)
-        self.assertTrue(ctx.exit.called)
+        with mock.patch.object(click, 'echo') as click_echo,\
+                mock.patch('opsdroid.core.OpsDroid.load') as opsdroid_load:
+            runner = CliRunner()
+            result = runner.invoke(opsdroid.main, ['--version'])
+            self.assertTrue(click_echo.called)
+            self.assertFalse(opsdroid_load.called)
+            self.assertTrue(__version__ in click_echo.call_args[0][0])
+            self.assertEqual(result.exit_code, 0)
 
     def test_main(self):
         with mock.patch.object(sys, 'argv', ["opsdroid"]), \

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,6 @@ import shutil
 import tempfile
 import unittest.mock as mock
 import gettext
-import click
 from click.testing import CliRunner
 
 
@@ -177,7 +176,7 @@ class TestMain(unittest.TestCase):
                 mock.patch.object(web, 'Web'), \
                 mock.patch.object(OpsDroid, 'start_loop') as mock_loop:
             runner = CliRunner()
-            result = runner.invoke(opsdroid.main, [])
+            runner.invoke(opsdroid.main, [])
             self.assertTrue(mock_cd.called)
             self.assertTrue(mock_cl.called)
             self.assertTrue(mock_wm.called)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,6 +167,13 @@ class TestMain(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 opsdroid.main()
 
+    def test_print_version(self):
+        ctx = mock.MagicMock()
+        ctx.exit = mock.MagicMock()
+        ctx.resilient_parsing = False
+        opsdroid.print_version(ctx, None, True)
+        self.assertTrue(ctx.exit.called)
+
     def test_main(self):
         with mock.patch.object(sys, 'argv', ["opsdroid"]), \
                 mock.patch.object(opsdroid, 'check_dependencies') as mock_cd, \

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,8 @@ import shutil
 import tempfile
 import unittest.mock as mock
 import gettext
+import click
+from click.testing import CliRunner
 
 
 import opsdroid.__main__ as opsdroid
@@ -42,10 +44,6 @@ class TestMain(unittest.TestCase):
             with mock.patch.object(opsdroid, "__name__", "opsdroid"):
                 opsdroid.init()
                 self.assertFalse(mainfunc.called)
-
-    def test_parse_args(self):
-        args = opsdroid.parse_args(["--gen-config"])
-        self.assertEqual(True, args.gen_config)
 
     def test_configure_no_lang(self):
         with mock.patch.object(gettext, "translation") as translation:
@@ -178,7 +176,8 @@ class TestMain(unittest.TestCase):
                 mock.patch.object(OpsDroid, 'load') as mock_load, \
                 mock.patch.object(web, 'Web'), \
                 mock.patch.object(OpsDroid, 'start_loop') as mock_loop:
-            opsdroid.main()
+            runner = CliRunner()
+            result = runner.invoke(opsdroid.main, [])
             self.assertTrue(mock_cd.called)
             self.assertTrue(mock_cl.called)
             self.assertTrue(mock_wm.called)


### PR DESCRIPTION
# Description

Switches the argument parsing to use [click](http://click.pocoo.org/5/). 

Click makes handing command line flags easier and also prints useful help messages via the `--help` flag. (When installed with pip it should say `opsdroid` instead of `__main__.py`).

```
$ python -m opsdroid --help
Usage: __main__.py [OPTIONS]

  Opsdroid is chat bot framework written in python.

  It is designed to be extendable, scalable and simple. See
  https://opsdroid.github.io/ for more information.

Options:
  --gen-config   Print an example config and exit.
  -v, --version  Print the version and exit.
  --help         Show this message and exit.
```

I've moved the `--gen-config` command over to click which means removing the logic which checks for the flag and adding a decorator which eagerly runs a callback. The `print_example_config` function has been updated to conform to the click callback format.

I have also added another decorator similar to `--gen-config` called `--version` which simply prints out the current opsdroid version and then exits, similar to gen config printing the example config and exiting.

Closes #514


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- Run the test suite


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

