### PR TITLE
Update delay

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -96,7 +96,7 @@ connectors:
 Some connectors will allow you to specify a delay to simulate a real user, you just need to add the delay option under a connector in the `configuration.yaml` file.
 
 **Thinking Delay:** accepts a _int_, _float_ or a _list_ to delay reply by _x_ seconds.
-**Typing Delay:** accepts a _int_, _float_ or a _list_ to delay reply by _x_ seconds.
+**Typing Delay:** accepts a _int_, _float_ or a _list_ to delay reply by _x_ seconds - this is calculated by the length of opsdroid response text so waiting time will be variable.
 
 
 Example:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -96,7 +96,7 @@ connectors:
 Some connectors will allow you to specify a delay to simulate a real user, you just need to add the delay option under a connector in the `configuration.yaml` file.
 
 **Thinking Delay:** accepts a _int_, _float_ or a _list_ to delay reply by _x_ seconds.
-**Typing Delay:** accepts a _int_ or _float_ that represents the number of characters typed per second. This number should be larger or equal to 6 to avoid lagging. 
+**Typing Delay:** accepts a _int_, _float_ or a _list_ to delay reply by _x_ seconds.
 
 
 Example:
@@ -106,7 +106,7 @@ connectors:
   - name: slack
     token: "mysecretslacktoken"
     thinking-delay: <int, float or two element list>
-    typing-delay: <int or float>
+    typing-delay: <int, float or two element list>
 ```
 
 _Note: As expected this will cause a delay on opsdroid time of response so make sure you don't pass a high number._ 

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -32,14 +32,14 @@ class Message:
 
         await asyncio.sleep(seconds)
 
-    async def _typing_delay(self, text):
+    async def _typing_delay(self):
         """Simulate typing, takes an int(characters per second typed)."""
-        try:
-            char_per_sec = self.connector.configuration['typing-delay']
-            char_count = len(text)
-            await asyncio.sleep(char_count//char_per_sec)
-        except KeyError:
-            pass
+        seconds = self.connector.configuration.get('typing-delay', 0)
+
+        if isinstance(seconds, list):
+            seconds = randrange(seconds[0], seconds[1])
+
+        await asyncio.sleep(seconds)
 
     async def respond(self, text, room=None):
         """Respond to this message using the connector it was created by."""
@@ -50,7 +50,7 @@ class Message:
         if 'thinking-delay' in self.connector.configuration or \
            'typing-delay' in self.connector.configuration:
             await self._thinking_delay()
-            await self._typing_delay(response.text)
+            await self._typing_delay()
 
         await self.connector.respond(response, room)
         if not self.responded_to:

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -32,14 +32,19 @@ class Message:
 
         await asyncio.sleep(seconds)
 
-    async def _typing_delay(self):
-        """Simulate typing, takes an int(characters per second typed)."""
+    async def _typing_delay(self, text):
+        """Simulate typing, takes an int or float to delay reply."""
         seconds = self.connector.configuration.get('typing-delay', 0)
+        char_count = len(text)
 
         if isinstance(seconds, list):
             seconds = randrange(seconds[0], seconds[1])
 
-        await asyncio.sleep(seconds)
+        if seconds < 0:
+            await asyncio.sleep(char_count*seconds)
+
+        if seconds > 0:
+            await asyncio.sleep(seconds/char_count*2)
 
     async def respond(self, text, room=None):
         """Respond to this message using the connector it was created by."""
@@ -50,7 +55,7 @@ class Message:
         if 'thinking-delay' in self.connector.configuration or \
            'typing-delay' in self.connector.configuration:
             await self._thinking_delay()
-            await self._typing_delay()
+            await self._typing_delay(response.text)
 
         await self.connector.respond(response, room)
         if not self.responded_to:

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -40,11 +40,7 @@ class Message:
         if isinstance(seconds, list):
             seconds = randrange(seconds[0], seconds[1])
 
-        if seconds < 0:
-            await asyncio.sleep(char_count*seconds)
-
-        if seconds > 0:
-            await asyncio.sleep(seconds/char_count*2)
+        await asyncio.sleep(char_count*seconds)
 
     async def respond(self, text, room=None):
         """Respond to this message using the connector it was created by."""

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -94,7 +94,7 @@ class TestMessage(asynctest.TestCase):
     async def test_typing_delay(self):
         mock_connector = Connector({
             'name': 'shell',
-            'typing-delay': 6,
+            'typing-delay': 0.3,
             'type': 'connector',
             'module_path': 'opsdroid-modules.connector.shell'
         })
@@ -107,6 +107,22 @@ class TestMessage(asynctest.TestCase):
 
                 self.assertTrue(logmock.called)
                 self.assertTrue(mocksleep.called)
+
+        # Test thinking-delay with a list
+
+        mock_connector_list = Connector({
+            'name': 'shell',
+            'typing-delay': [1, 4],
+            'type': 'connector',
+            'module_path': 'opsdroid-modules.connector.shell'
+        })
+
+        with amock.patch('asyncio.sleep') as mocksleep_list:
+            message = Message("hi", "user", "default", mock_connector_list)
+            with self.assertRaises(NotImplementedError):
+                await message.respond("Hello there")
+
+            self.assertTrue(mocksleep_list.called)
 
     async def test_typing_sleep(self):
         mock_connector = Connector({


### PR DESCRIPTION
# Description

This is my first attempt at fixing the issue after talking with Jacob. 

I was wondering why I implemented the typing delay how it was and finally I remembered that the reason was because I tried to implement a way to make opsdroid take longer to reply if the reply is a long sentence (as it should take longer to type).

The typing function is the same as the thinking delay, so perhaps it could be better to merge them together and get the sum of both seconds (typing/delay) and just use one function just to remove the double functions.

I would also know if should implement this issue in a different way 👍 

Fixes #517 


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Ran unitests in pycharm - all green
- Ran tox - all green
- Ran opsdroid with a typing delay in the connector-shell with 0 and 0.3 - both worked as expected


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

