### PR TITLE
Replace except pass with contextlib.supress

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -6,6 +6,7 @@ import sys
 import logging
 import gettext
 import time
+import contextlib
 
 import click
 
@@ -57,11 +58,9 @@ def configure_logging(config):
     console_handler.setFormatter(formatter)
     rootlogger.addHandler(console_handler)
 
-    try:
+    with contextlib.suppress(KeyError):
         if not config["logging"]["console"]:
             console_handler.setLevel(logging.CRITICAL)
-    except KeyError:
-        pass
 
     if logfile_path:
         logdir = os.path.dirname(os.path.realpath(logfile_path))

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import weakref
 import asyncio
+import contextlib
 
 from opsdroid.memory import Memory
 from opsdroid.connector import Connector
@@ -147,11 +148,9 @@ class OpsDroid():
 
     def setup_skills(self, skills):
         """Call the setup function on the passed in skills."""
-        for skill in skills:
-            try:
+        with contextlib.suppress(AttributeError):
+            for skill in skills:
                 skill["module"].setup(self)
-            except AttributeError:
-                pass
 
     def train_parsers(self, skills):
         """Train the parsers."""

--- a/opsdroid/parsers/luisai.py
+++ b/opsdroid/parsers/luisai.py
@@ -2,6 +2,7 @@
 
 import logging
 import json
+import contextlib
 
 import aiohttp
 
@@ -42,13 +43,11 @@ async def parse_luisai(opsdroid, message, config):
 
             # if there is an error (eg. 404 error)
             # luis.ai responds with a status code
-            try:
+            with contextlib.suppress(KeyError):
                 if result["statusCode"] >= 300:
                     _LOGGER.error(_("luis.ai error - %s %s"),
                                   str(result["statusCode"]),
                                   result["message"])
-            except KeyError:
-                pass
 
             if "min-score" in config and \
                     result["topScoringIntent"]["score"] \

--- a/scripts/update_example_config/update_example_config.py
+++ b/scripts/update_example_config/update_example_config.py
@@ -5,6 +5,7 @@ import base64
 import yaml
 import re
 import os
+import contextlib
 
 
 def normalize(string):
@@ -103,7 +104,7 @@ def get_parsers_details():
         name = file[:-3]
         with open(parsers_path + file) as f:
             readme = f.read()
-            try:
+            with contextlib.suppress(AttributeError):
                 config = get_config_details(readme).group(4)
 
                 parsers.append({
@@ -112,9 +113,6 @@ def get_parsers_details():
                     'url': base_url + name,
                     'config': normalize(config)
                 })
-            except AttributeError:
-                # Doesn't contain config options - it's always activated
-                pass
 
     return parsers
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import contextlib
 import unittest
 import unittest.mock as mock
 from types import ModuleType
@@ -22,10 +23,8 @@ class TestLoader(unittest.TestCase):
     def setUp(self):
         os.umask(000)
         self._tmp_dir = os.path.join(tempfile.gettempdir(), "opsdroid_tests")
-        try:
+        with contextlib.suppress(FileExistsError):
             os.makedirs(self._tmp_dir, mode=0o777)
-        except FileExistsError:
-            pass
 
     def tearDown(self):
         shutil.rmtree(self._tmp_dir, onerror=del_rw)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,7 @@ import sys
 import shutil
 import tempfile
 import gettext
+import contextlib
 
 import click
 from click.testing import CliRunner
@@ -23,16 +24,12 @@ class TestMain(unittest.TestCase):
 
     def setUp(self):
         self._tmp_dir = os.path.join(tempfile.gettempdir(), "opsdroid_tests")
-        try:
+        with contextlib.suppress(FileExistsError):
             os.makedirs(self._tmp_dir, mode=0o777)
-        except FileExistsError:
-            pass
 
     def tearDown(self):
-        try:
+        with contextlib.suppress(PermissionError):
             shutil.rmtree(self._tmp_dir, onerror=del_rw)
-        except PermissionError:
-            pass
 
     def test_init_runs(self):
         with mock.patch.object(opsdroid, "main") as mainfunc:


### PR DESCRIPTION
# Description

I subscribe to Dan Bader daily python tips, on one of those emails he showed how you can ignore specific exceptions in a better way than using `except <exception> : pass` I remembered that we have a few bits of code like this so I decided to try and refactor the code in order to use the suggested `with contextlib.suppress(<exception>):`

Everything seems to be working fine, but I'm not sure if this improves readability since new people might need to search what the heck does contextlib.supress means (I didn't know about it before). 

Let me know if this is good or not 👍 

Fixes #<issue>


## Status
**READY**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran opsdroid all good


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
