### PR TITLE
Add a kwarg to respond to send an image

### DIFF
--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -42,12 +42,12 @@ class Message:
 
         await asyncio.sleep(char_count*seconds)
 
-    async def respond(self, text, room=None):
+    async def respond(self, text, room=None, image=None):
         """Respond to this message using the connector it was created by."""
         opsdroid = get_opsdroid()
         response = copy(self)
         response.text = text
-
+        response.image = image
         if 'thinking-delay' in self.connector.configuration or \
            'typing-delay' in self.connector.configuration:
             await self._thinking_delay()


### PR DESCRIPTION
# Description

This is a very fast drive-by at #195. It adds a keyword argument to `respond` that can take an image (format up to connectors). This still requires that some text is sent as well, both to maintain compatibility with non-image supporting connectors and as alt-text.

## Type of change

- New feature (non-breaking change which adds functionality)

