### PR TITLE
Add support for ipython notebooks as skills

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -6,7 +6,7 @@
    - [Database Modules](#database-modules)
    - [Logging](#logging)
    - [Installation Path](#installation-path)
-   - [Parsers](#parsers) 
+   - [Parsers](#parsers)
    - [Skills](#skills)
    - [Time Zone](#time-zone)
    - [Language](#language)
@@ -38,9 +38,9 @@ If you are using one of the default locations you can run the command `opsdroid 
 
 The opsdroid project itself is very simple and requires modules to give it functionality. In your configuration file, you must specify the connector, skill and database* modules you wish to use and any options they may require.
 
-**Connectors** are modules for connecting opsdroid to your specific chat service. 
+**Connectors** are modules for connecting opsdroid to your specific chat service.
 
-**Skills** are modules which define what actions opsdroid should perform based on different chat messages. 
+**Skills** are modules which define what actions opsdroid should perform based on different chat messages.
 
 **Database** modules connect opsdroid to your chosen database and allow skills to store information between messages.
 
@@ -127,7 +127,7 @@ connectors:
     typing-delay: <int, float or two element list>
 ```
 
-_Note: As expected this will cause a delay on opsdroid time of response so make sure you don't pass a high number._ 
+_Note: As expected this will cause a delay on opsdroid time of response so make sure you don't pass a high number._
 
 See [module options](#module-options) for installing custom connectors.
 
@@ -219,7 +219,7 @@ _Config options of the parsers themselves differ between parsers, see the parser
 parsers:
   - name: regex
     enabled: true
-    
+
 # NLU parser
   - name: rasanlu
     url: http://localhost:5000
@@ -314,12 +314,20 @@ skills:
     path: /home/me/src/opsdroid-skills/myawesomeskill
 ```
 
-Or you can specify a single file.
+You can specify a single file.
 
 ```yaml
 skills:
   - name: myawesomeskill
     path: /home/me/src/opsdroid-skills/myawesomeskill/myskill.py
+```
+
+Or even an [IPython/Jupyter Notebook](http://jupyter.org/).
+
+```yaml
+skills:
+  - name: myawesomeskill
+    path: /home/me/src/opsdroid-skills/myawesomeskill/myskill.ipynb
 ```
 
 ### Disable Caching
@@ -335,7 +343,7 @@ databases:
 
 ### Disable dependency install
 
-Set `no-dep` to true to skip the installation of dependencies on every start of opsdroid. 
+Set `no-dep` to true to skip the installation of dependencies on every start of opsdroid.
 
 ```yaml
 skills:
@@ -360,7 +368,7 @@ _Note: Your environment variable names must consist of uppercase characters and 
 
 ## Include additional yaml files
 
-You can split the config into smaller modules by using the value `!include file.yaml` to import the contents of a yaml file into the main config. 
+You can split the config into smaller modules by using the value `!include file.yaml` to import the contents of a yaml file into the main config.
 
 
 ```yaml

--- a/opsdroid/helper.py
+++ b/opsdroid/helper.py
@@ -6,6 +6,9 @@ import shutil
 import logging
 import filecmp
 
+import nbformat
+from nbconvert import PythonExporter
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -75,3 +78,36 @@ def move_config_to_appdir(src, dst):
                      src, dst)
         if filecmp.cmp(original_file, copied_file):
             os.remove(original_file)
+
+
+def file_is_ipython_notebook(path):
+    """Check whether a file is an iPython Notebook.
+
+    Args:
+        path (str): path to the file.
+
+    Examples:
+        path : source path with .ipynb file '/path/src/my_file.ipynb.
+
+    """
+    return path.lower().endswith('.ipynb')
+
+
+def convert_ipynb_to_script(notebook_path, output_path):
+    """Convert an iPython Notebook to a python script.
+
+    Args:
+        notebook_path (str): path to the notebook file.
+        output_path (str): path to the script file destination.
+
+    Examples:
+        notebook_path : source path with .ipynb file '/path/src/my_file.ipynb.
+        output_path : destination path with .py file '/path/src/my_file.py.
+
+    """
+    with open(notebook_path, 'r') as notebook_path_handle:
+        raw_notebook = notebook_path_handle.read()
+        notebook = nbformat.reads(raw_notebook, as_version=4)
+        script, _ = PythonExporter().from_notebook_node(notebook)
+        with open(output_path, 'w') as output_path_handle:
+            output_path_handle.write(script)

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -10,7 +10,9 @@ import importlib.util
 import re
 from collections import Mapping
 import yaml
-from opsdroid.helper import move_config_to_appdir
+from opsdroid.helper import (
+    move_config_to_appdir, file_is_ipython_notebook,
+    convert_ipynb_to_script)
 from opsdroid.const import (
     DEFAULT_GIT_URL, MODULES_DIRECTORY, DEFAULT_MODULES_PATH,
     DEFAULT_MODULE_BRANCH, DEFAULT_CONFIG_PATH, EXAMPLE_CONFIG_FILE,
@@ -428,9 +430,11 @@ class Loader:
 
         if os.path.isfile(config["path"]):
             os.makedirs(config["install_path"], exist_ok=True)
-            shutil.copyfile(config["path"],
-                            os.path.join(config["install_path"],
-                                         "__init__.py"))
+            init_path = os.path.join(config["install_path"], "__init__.py")
+            if file_is_ipython_notebook(config["path"]):
+                convert_ipynb_to_script(config["path"], init_path)
+            else:
+                shutil.copyfile(config["path"], init_path)
             installed = True
 
         if not installed:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ aiohttp==3.3.2
 arrow==0.12.1
 Babel==2.6.0
 click==6.7
+nbconvert==5.3.1
+nbformat==4.4.0
 pycron==0.80.0
 pyyaml==3.13
 slacker-asyncio==0.9.60

--- a/tests/configs/broken.yaml
+++ b/tests/configs/broken.yaml
@@ -1,1 +1,1 @@
-unbalanced blackets: ][
+unbalanced brackets: ][

--- a/tests/mockmodules/skills/test_notebook.ipynb
+++ b/tests/mockmodules/skills/test_notebook.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from opsdroid.matchers import match_regex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@match_regex(r'ping')\n",
+    "async def ping(opsdroid, config, message):\n",
+    "    await message.respond('pong')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -43,6 +43,7 @@ class TestHelper(unittest.TestCase):
         notebook_path = \
             os.path.abspath("tests/mockmodules/skills/test_notebook.ipynb")
 
-        with tempfile.NamedTemporaryFile() as output_file:
+        with tempfile.NamedTemporaryFile(
+                mode='w', delete=False) as output_file:
             convert_ipynb_to_script(notebook_path, output_file.name)
             self.assertTrue(os.path.getsize(output_file.name) > 0)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -4,7 +4,9 @@ import tempfile
 import unittest
 import unittest.mock as mock
 
-from opsdroid.helper import del_rw, move_config_to_appdir
+from opsdroid.helper import (
+    del_rw, move_config_to_appdir, file_is_ipython_notebook,
+    convert_ipynb_to_script)
 
 
 class TestHelper(unittest.TestCase):
@@ -32,3 +34,15 @@ class TestHelper(unittest.TestCase):
             self.assertTrue(mock_mkdir.called)
             self.assertTrue(logmock.called)
             self.assertTrue(mock_remove.called)
+
+    def test_file_is_ipython_notebook(self):
+        self.assertTrue(file_is_ipython_notebook('test.ipynb'))
+        self.assertFalse(file_is_ipython_notebook('test.py'))
+
+    def test_convert_ipynb_to_script(self):
+        notebook_path = \
+            os.path.abspath("tests/mockmodules/skills/test_notebook.ipynb")
+
+        with tempfile.NamedTemporaryFile() as output_file:
+            convert_ipynb_to_script(notebook_path, output_file.name)
+            self.assertTrue(os.path.getsize(output_file.name) > 0)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -467,6 +467,21 @@ class TestLoader(unittest.TestCase):
             config["install_path"], "__init__.py")))
         shutil.rmtree(config["install_path"], onerror=del_rw)
 
+    def test_install_local_module_notebook(self):
+        opsdroid, loader = self.setup()
+        config = {"name": "slack",
+                  "type": "connector",
+                  "install_path": os.path.join(
+                      self._tmp_dir, "test_local_module_file"),
+                  "path": os.path.abspath(
+                      "tests/mockmodules/skills/test_notebook.ipynb")}
+        directory, _ = os.path.split(config["path"])
+        os.makedirs(directory, exist_ok=True, mode=0o777)
+        loader._install_local_module(config)
+        self.assertTrue(os.path.isfile(os.path.join(
+            config["install_path"], "__init__.py")))
+        shutil.rmtree(config["install_path"], onerror=del_rw)
+
     def test_install_local_module_failure(self):
         opsdroid, loader = self.setup()
         config = {"name": "slack",


### PR DESCRIPTION
# Description

This PR updates the loader so that when a single file skill is specified using the `path` option it checks whether it is an iPython Notebook and if it is it converts it into a python script.

Fixes #571


## Status
 **READY** 


## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

