### PR TITLE
Fix no-else-return lint issues

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -85,11 +85,13 @@ def get_logging_level(logging_level):
     """Get the logger level based on the user configuration."""
     if logging_level == 'critical':
         return logging.CRITICAL
-    elif logging_level == 'error':
+
+    if logging_level == 'error':
         return logging.ERROR
-    elif logging_level == 'warning':
+    if logging_level == 'warning':
         return logging.WARNING
-    elif logging_level == 'debug':
+
+    if logging_level == 'debug':
         return logging.DEBUG
 
     return logging.INFO

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -114,10 +114,10 @@ async def train_rasanlu(config, skills):
                              int(time_taken))
                 await _init_model(config)
                 return True
-            else:
-                _LOGGER.debug(result)
-        else:
-            _LOGGER.error(_("Bad Rasa NLU response - %s"), await resp.text())
+
+            _LOGGER.debug(result)
+
+        _LOGGER.error(_("Bad Rasa NLU response - %s"), await resp.text())
         _LOGGER.error(_("Rasa NLU training failed."))
         return False
 

--- a/opsdroid/parsers/recastai.py
+++ b/opsdroid/parsers/recastai.py
@@ -46,7 +46,8 @@ async def parse_recastai(opsdroid, message, config):
         if result['results'] is None:
             _LOGGER.error(_("Recast.AI error - %s"), result["message"])
             return matched_skills
-        elif not result["results"]["intents"]:
+
+        if not result["results"]["intents"]:
             _LOGGER.error(_("Recast.AI error - No intent found "
                             "for the message %s"), str(message.text))
             return matched_skills

--- a/opsdroid/parsers/witai.py
+++ b/opsdroid/parsers/witai.py
@@ -42,7 +42,8 @@ async def parse_witai(opsdroid, message, config):
             _LOGGER.error(_("wit.ai error - %s %s"),
                           str(result['code']), str(result['error']))
             return matched_skills
-        elif result['entities'] == {}:
+
+        if result['entities'] == {}:
             _LOGGER.error(_("wit.ai error - No intent found. Did you "
                             "forget to create one?"))
             return matched_skills

--- a/pylintrc
+++ b/pylintrc
@@ -20,7 +20,6 @@ disable=
   unused-argument,
   global-statement,
   redefined-variable-type
-  no-else-return
 
 [EXCEPTIONS]
 overgeneral-exceptions=Exception

--- a/pylintrc
+++ b/pylintrc
@@ -20,6 +20,7 @@ disable=
   unused-argument,
   global-statement,
   redefined-variable-type
+  no-else-return
 
 [EXCEPTIONS]
 overgeneral-exceptions=Exception


### PR DESCRIPTION
# Description

Pylint is complaining about the use of return statements withint if/elsif/else statements. I get it where this error comes from since in most situations you would want to do something and only at the end of a function return a value.

We use control flow to return something some of our functions:
- warning levels
- Aiohttp logic on parsers 

We could either refactor all of these functions and only use if statements ( but that seems a silly way to control things) or disable the error in the parser files and the logging levels in `__main__.py`.

Not sure what is the preferable solution here, so this PR simply disables this error all around, would like to know what do you think about this option Jacob.

Fixes #<issue>


## Status
**READY**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

