### PR TITLE
Remove tests and test deps from docker and minor docker improvements.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 FROM python:3.5-alpine
-MAINTAINER Jacob Tomlinson <jacob@tom.linson.uk>
+LABEL maintainer="Jacob Tomlinson <jacob@tom.linson.uk>"
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Copy source
-COPY . .
+COPY opsdroid opsdroid
+COPY setup.py setup.py
+COPY setup.cfg setup.cfg
+COPY requirements.txt requirements.txt
+COPY README.md README.md
 
 RUN apk update && apk add git
 RUN pip3 install --upgrade pip
-RUN pip3 install --no-cache-dir -r requirements.txt
-RUN pip3 install -U tox
-
-RUN python3 setup.py compile_catalog
+RUN pip3 install --no-cache-dir .
 
 EXPOSE 8080
 
-CMD ["python", "-m", "opsdroid"]
+CMD ["opsdroid"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY setup.py setup.py
 COPY setup.cfg setup.cfg
 COPY requirements.txt requirements.txt
 COPY README.md README.md
+COPY MANIFEST.in MANIFEST.in
 
 RUN apk update && apk add git
 RUN pip3 install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.3.2
+aiohttp==3.0.5
 arrow==0.12.1
 Babel==2.6.0
 click==6.7

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ whitelist_externals =
 commands =
      docker build -t opsdroid-image:tmp .
      docker run -d --name opsdroid-container opsdroid-image:tmp
-     sleep 30
+     sleep 10
      docker exec opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"
      docker logs opsdroid-container
      docker stop opsdroid-container

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ whitelist_externals =
 commands =
      docker build -t opsdroid-image:tmp .
      docker run -d --name opsdroid-container opsdroid-image:tmp
-     docker exec -e TOXENV=py35 opsdroid-container tox
+     sleep 30
      docker exec opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"
      docker logs opsdroid-container
      docker stop opsdroid-container


### PR DESCRIPTION
# Description

This PR removes the test dependencies from the docker container and also makes some minor changes to the docker image and process.

As highlighted in #574 test dependencies can grow rapidly. We probably don't need to run the tests inside the container, but only test that the container builds and runs successfully.

I also took the opportunity to streamline the container image a little: 
- Changed the deprecated `MAINTAINER` flag to the new `LABEL` symantics.
- Added a `.dockerignore` which is simply a symlink to `.gitignore` as I noticed my local build context was >100MB, this change reduced it to <10MB. 
- Changed the pip install command to install the local module using pip rather than installing the dependencies. This results in the docker image being more representative of doing a regular pip install from pypi.
- Instead of copying `.` to the image I have cherry picked the required parts, this may help with the final image size. But probably not by a huge amount.

## Status
**READY** 

## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

