### PR TITLE
Safe load 'included' yaml files

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -221,7 +221,7 @@ class Loader:
                                          loader.construct_scalar(node))
 
             with open(included_yaml, 'r') as included:
-                return yaml.load(included)
+                return yaml.safe_load(included)
 
         yaml.add_constructor('!envvar', envvar_constructor)
         yaml.add_constructor('!include', include_constructor)

--- a/tests/configs/exploit.yaml
+++ b/tests/configs/exploit.yaml
@@ -1,0 +1,1 @@
+!!python/object/apply:os.system ["echo 'Oops!';"]

--- a/tests/configs/include_exploit.yaml
+++ b/tests/configs/include_exploit.yaml
@@ -1,0 +1,1 @@
+!include exploit.yaml

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -50,6 +50,14 @@ class TestLoader(unittest.TestCase):
         self.assertIsNotNone(config)
         self.assertEqual(config, config2)
 
+    def test_yaml_load_exploit(self):
+        opsdroid, loader = self.setup()
+        config = loader.load_config_file(
+            [os.path.abspath("tests/configs/include_exploit.yaml")])
+        self.assertIsNone(config)
+        # If the command in exploit.yaml is echoed it will return 0
+        self.assertNotEqual(config, 0)
+
     def test_load_config_file_with_env_vars(self):
         opsdroid, loader = self.setup()
         os.environ["ENVVAR"] = 'test'


### PR DESCRIPTION
# Description

This is the first baby-step to replace `yaml.load` with `yaml.safe_load`. Currently, I have changed how the command `!include` loads a new file into the configuration - mostly because this is the first bit where people could exploit the vulnerabilities of `yaml.load`.

When I tried to replace load with safe_load on lines `loader:229-232` the texts failed as everything was returning None, so I will need to do some further testing to see why safe_load is not loading the file properly.

Another thing I need to do will be testing opsdroid with an included file and see if it works without any issue.

Fixes #580 


## Status
~~**READY**~~ | **UNDER DEVELOPMENT** | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - All Green
- Travis - All Green
- !Include doesn't load python code related to the vulnerability
- Tested with an `!include file` - returns NoneType (needs further investigation)



# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

