### PR TITLE
Replace yaml.load with yaml.safe_load

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -229,12 +229,12 @@ class Loader:
                 return yaml.safe_load(included)
 
         yaml.add_constructor('!envvar', envvar_constructor)
-        yaml.add_constructor('!include', include_constructor)
+        yaml.SafeLoader.add_constructor('!include', include_constructor)
 
         try:
             with open(config_path, 'r') as stream:
                 _LOGGER.info(_("Loaded config from %s."), config_path)
-                return yaml.load(stream)
+                return yaml.safe_load(stream)
         except yaml.YAMLError as error:
             self.opsdroid.critical(error, 1)
         except FileNotFoundError as error:


### PR DESCRIPTION
# Description

I promised to have a look at this safe_load issue, today I have been cracking my head to try and figure out why safe_load doesn't seem to work as expected. I made some changes to the code (added `yaml.SafeLoader.add_constructor` to the `!include` constructor) but when the change was implemented on the ENVVARs the test failed no matter what I tried.

I'm raising this PR to ask for help. I tried to google and go around but seems that pyyaml is a mysterious beast, or at least safe_load is. I can't figure out why the envvar constructor is failing - mainly what happens is that the environmental variable isn't translated from the pattern `$ENVVAR`. The test fails because the value it expected to get was `test` and instead it got `$ENVVAR`.

Not sure how to go tackle this issue. Perhaps the whole envvar function needs to be changed into something else?

Fixes #580


## Status
~~**READY**~~ | **UNDER DEVELOPMENT** | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green but envvar test
- Ran opsdroid - all ok
- Ran skill-chat with !included yaml file - opsdroid replied correctly


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
