### PR TITLE
Change aioslacker to our fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.4.4
-aioslacker==0.0.10
+git+https://github.com/opsdroid/aioslacker.git@26fb78de6e9fedfaab650ea5c3b87b33c4fc9657
 arrow==0.12.1
 Babel==2.6.0
 click==6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.4.4
-git+https://github.com/opsdroid/aioslacker.git@26fb78de6e9fedfaab650ea5c3b87b33c4fc9657
+aioslacker==0.0.10
 arrow==0.12.1
 Babel==2.6.0
 click==6.7

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=REQUIRES,
+    dependency_links=[
+        "git+https://github.com/opsdroid/aioslacker.git@26fb78de6e9fedfaab650ea5c3b87b33c4fc9657#egg=aioslacker==0.0.10"
+    ],
     test_suite='tests',
     keywords=[
         'bot',

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,6 @@ deps =
 basepython = python3
 ignore_errors = True
 commands =
-     flake8 --builtins='_'
+     flake8 --builtins='_' opsdroid
      pylint opsdroid
      pydocstyle opsdroid tests


### PR DESCRIPTION
# Description

It looks like there are some issues with `aioslacker`. We should fix these upstream but in the meantime I've forked the repo and then set opsdroid to install from that repo.

Related to #649 

## Status
**READY**
