### PR TITLE
Add parameter to configure priority in every regex skill (proposal)

### DIFF
--- a/docs/matchers/regex.md
+++ b/docs/matchers/regex.md
@@ -28,7 +28,7 @@ async def hello(opsdroid, config, message):
     await message.respond('Hey')
 ```
 
-The above skill would be called on any message which matches the regex `'hi'`, `'Hi'` or `'HI`. The `case_sensitive` kwarg is optional and defaults to `True`. 
+The above skill would be called on any message which matches the regex `'hi'`, `'Hi'`, `'hI'` or `'HI'`. The `case_sensitive` kwarg is optional and defaults to `True`. 
 
 
 ## Example 2
@@ -91,3 +91,22 @@ async def remember(opsdroid, config, message):
     await opsdroid.memory.put("remember", remember)
     await message.respond("OK I'll remember that")
 ```
+
+## Score factor
+
+In order to make NLU skills execute over regex skills, opsdroid always applies a factor of `0.6` to every regex evaluated score.
+
+Sometimes can be interesting for a developer to get a regex skill executed over a NLU skill, and `score_factor` keyword argument can be used to archieve this.
+
+
+### Example 
+
+```python
+from opsdroid.matchers import match_regex
+
+@match_regex('ping', score_factor=0.9)
+async def ping(opsdroid, config, message):
+    await message.respond('pong')
+```
+
+In this example, the evaluated score of `ping` skill will be multiplied by `0.9` instead of `0.6`.

--- a/docs/matchers/regex.md
+++ b/docs/matchers/regex.md
@@ -94,9 +94,9 @@ async def remember(opsdroid, config, message):
 
 ## Score factor
 
-In order to make NLU skills execute over regex skills, opsdroid always applies a factor of `0.6` to every regex evaluated score.
+In order to make NLU skills execute over regex skills, opsdroid always applies a default factor of `0.6` to every regex evaluated score.
 
-Sometimes can be interesting for a developer to get a regex skill executed over a NLU skill, and `score_factor` keyword argument can be used to archieve this.
+If a developer want to have a regex skill executed over a NLU one then the keyword argument `score_factor` can be used to achieve this.
 
 
 ### Example 

--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -21,7 +21,7 @@ DEFAULT_LANGUAGE = 'en'
 LOCALE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'locale')
 EXAMPLE_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                    "configuration/example_configuration.yaml")
-REGEX_MAX_SCORE = 0.6
+REGEX_SCORE_FACTOR = 0.6
 
 RASANLU_DEFAULT_URL = "http://localhost:5000"
 RASANLU_DEFAULT_PROJECT = "opsdroid"

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from opsdroid.const import REGEX_SCORE_FACTOR
 from opsdroid.helper import get_opsdroid
 from opsdroid.web import Web
 
@@ -9,7 +10,7 @@ from opsdroid.web import Web
 _LOGGER = logging.getLogger(__name__)
 
 
-def match_regex(regex, case_sensitive=True):
+def match_regex(regex, case_sensitive=True, score_factor=None):
     """Return regex match decorator."""
     def matcher(func):
         """Add decorated function to skills list for regex matching."""
@@ -18,7 +19,8 @@ def match_regex(regex, case_sensitive=True):
             config = opsdroid.loader.current_import_config
             regex_setup = {
                 "expression": regex,
-                "case_sensitive": case_sensitive
+                "case_sensitive": case_sensitive,
+                "score_factor": score_factor or REGEX_SCORE_FACTOR,
             }
             opsdroid.skills.append({"regex": regex_setup,
                                     "skill": func,

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -22,6 +22,22 @@ class TestParserRegex(asynctest.TestCase):
             skills = await parse_regex(opsdroid, message)
             self.assertEqual(mock_skill, skills[0]["skill"])
 
+    async def test_parse_regex_priority(self):
+        with OpsDroid() as opsdroid:
+            regex = r"(.*)"
+
+            mock_skill_low = amock.CoroutineMock()
+            match_regex(regex, score_factor=0.6)(mock_skill_low)
+
+            mock_skill_high = amock.CoroutineMock()
+            match_regex(regex, score_factor=1)(mock_skill_high)
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            skills = await opsdroid.get_ranked_skills(message)
+            self.assertEqual(mock_skill_high, skills[0]["skill"])
+
     async def test_parse_regex_raises(self):
         with OpsDroid() as opsdroid:
             mock_skill = amock.CoroutineMock()


### PR DESCRIPTION
# Description

Here I am again! Hacktoberfest motivated me :)

So I'm recovering an [old discussion](https://github.com/opsdroid/opsdroid/issues/458) that was gone stale, I read it again, and I wrote this changes that I think would make all of us happy.

The point here is change the concept of `REGEX_MAX_SCORE` to `REGEX_SCORE_FACTOR` (in fact, it was a factor all the time, not a max score), add an optional keyword argument in `match_regex` to empower the developer to change this factor, but if not provided will be the configured `REGEX_SCORE_FACTOR` (stills in 0.6).

With this change, we let the developers prioritize skills that they want to be executed over the NLU skills.

It's a proposal, so if contributors are happy with it, I will update the docs before merging the PR.

Fixes #458


## Status
**UNDER DEVELOPMENT**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

- `TestParserRegex.test_parse_regex_priority`: it registers the same regex with different factors and ensures the skill with higher priority is executed.


# Checklist:

- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
