### PR TITLE
Update dead links on matchers.

### DIFF
--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -1,7 +1,8 @@
 # Skills
 
-Skills are modules which define what actions opsdroid should perform based on different chat messages. They can be referenced in your `configuration.yaml`,  [Config](../configuration-reference.md/#config-file) file.
+Skills are modules which define what actions opsdroid should perform based on different chat messages. They can be referenced in your `configuration.yaml`, [Config](../configuration-reference.md#config-file) file.
 Skills can be specified from opsdroid github repository, your own github, or from local path.
+
 
 ```yaml
 skills:
@@ -17,7 +18,7 @@ skills:
   ## Hello world (https://github.com/opsdroid/skill-hello)
   - name: hello
 ```
-You should look into the [Getting Started guide](/docs/tutorials/introduction.md) to know more about skills and opsdroid configuration file.
+You should look into the [Getting Started guide](../tutorials/introduction.md) to know more about skills and opsdroid configuration file.
 
 # Creating skills
 
@@ -41,7 +42,7 @@ In this example we are importing the `match_regex` decorator from the opsdroid m
 
 This decorator takes a regular expression to match against the message received from the connector. In this case we are checking to see if the message from the user is "hi".
 
-For more information about the different decorators available in opsdroid see the [matchers documentation](/docs/tutorials/introduction.md#matchers-available).
+For more information about the different decorators available in opsdroid see the [matchers documentation](../tutorials/introduction.md#matchers-available).
 
 If the message matches the regular expression then the decorated function is called. As arguments opsdroid will pass a pointer to itself along with a Message object containing information about the message from the user.
 
@@ -51,7 +52,7 @@ To ensure the bot is responsive the concurrency controls introduced in Python 3.
 
 The message object passed to the skill function is an instance of the opsdroid `Message` class which has the following properties and methods.
 
-Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](/docs/tutorials/introduction.md#matchers-available) for more details.
+Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](../tutorials/introduction.md#matchers-available) for more details.
 
 ### `text`
 

--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -17,7 +17,7 @@ skills:
   ## Hello world (https://github.com/opsdroid/skill-hello)
   - name: hello
 ```
-You should look into the [Getting Started guide](/tutorials/introduction) to know more about skills and opsdroid configuration file.
+You should look into the [Getting Started guide](/docs/tutorials/introduction.md) to know more about skills and opsdroid configuration file.
 
 # Creating skills
 
@@ -41,7 +41,7 @@ In this example we are importing the `match_regex` decorator from the opsdroid m
 
 This decorator takes a regular expression to match against the message received from the connector. In this case we are checking to see if the message from the user is "hi".
 
-For more information about the different decorators available in opsdroid see the [matchers documentation](parsers/overview).
+For more information about the different decorators available in opsdroid see the [matchers documentation](/docs/tutorials/introduction.md#matchers-available).
 
 If the message matches the regular expression then the decorated function is called. As arguments opsdroid will pass a pointer to itself along with a Message object containing information about the message from the user.
 
@@ -51,7 +51,7 @@ To ensure the bot is responsive the concurrency controls introduced in Python 3.
 
 The message object passed to the skill function is an instance of the opsdroid `Message` class which has the following properties and methods.
 
-Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](parsers/overview) for more details.
+Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](/docs/tutorials/introduction.md#matchers-available) for more details.
 
 ### `text`
 

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -101,7 +101,7 @@ skills:
     repo: "https://github.com/username/myawesomeskill.git"
 ```
 
-In this configuration we are using the [slack connector](/connectors/slack.md) with a slack [auth token](https://api.slack.com/tokens) supplied, a [mongo database](https://github.com/opsdroid/database-mongo) connection for persisting data, `hello` and `seen` skills from the official repos and finally a custom skill hosted on GitHub.
+In this configuration we are using the [slack connector](/docs/connectors/slack.md) with a slack [auth token](https://api.slack.com/tokens) supplied, a [mongo database](https://github.com/opsdroid/database-mongo) connection for persisting data, `hello` and `seen` skills from the official repos and finally a custom skill hosted on GitHub.
 
 Configuration options such as the `token` in the slack connector or the `host`, `port` and `database` options in the mongo database are specific to those modules. Ensure you check each module's required configuration items before you use them.
 
@@ -125,20 +125,23 @@ async def ping_local():
 The await keyword must be used within another function (typically an asyncio function). Otherwise, it will result in a syntax error.
 
 ## Matchers available
-Matchers are used to match a message, sent by a user, to a connector and a skill. Opsdroid comes ready with 8 different matchers, each one of them has its own settings and specification.
+Matchers are used to match a message, sent by a user, to a connector and a skill. Opsdroid comes ready with 9 different matchers, each one of them has its own settings and specification.
 
 - Basic matcher
-  - [Regular Expressions](/matchers/regex.md)
-- NPL Matchers
-  - [Dialogflow(previous Api.ai)](/matchers/dialogflow.md)
-  - [Wit.ai](/matchers/wit.ai.md)
-  - [Lui.ai](/matchers/luis.ai.md)
+  - [Regular Expressions](/docs/matchers/regex.md)
+- NLP Matchers
+  - [Dialogflow(previous Api.ai)](/docs/matchers/dialogflow.md)
+  - [Wit.ai](/docs/matchers/wit.ai.md)
+  - [Luis.ai](/docs/matchers/luis.ai.md)
+  - [Recast.ai](/docs/matchers/recast.ai.md)
+- NLU Matcher
+  - [Rasa_NLU](/docs/matchers/rasanlu.md)
 - Special Matcher
-  - [Always](/matchers/always.md)
-  - [Crontab](/matchers/crontab.md)
-  - [Webhook](/matchers/webhook.md)
+  - [Always](/docs/matchers/always.md)
+  - [Crontab](/docs/matchers/crontab.md)
+  - [Webhook](/docs/matchers/webhook.md)
 
-Read the [Matchers overview page](matchers/overview) for a quick reference guide on how to use them.
+Read the any of the matchers page for a quick reference guide on how to use them.
 
 
 ## First run - Skills available

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -101,7 +101,7 @@ skills:
     repo: "https://github.com/username/myawesomeskill.git"
 ```
 
-In this configuration we are using the [slack connector](/docs/connectors/slack.md) with a slack [auth token](https://api.slack.com/tokens) supplied, a [mongo database](https://github.com/opsdroid/database-mongo) connection for persisting data, `hello` and `seen` skills from the official repos and finally a custom skill hosted on GitHub.
+In this configuration we are using the [slack connector](../connectors/slack.md) with a slack [auth token](https://api.slack.com/tokens) supplied, a [mongo database](https://github.com/opsdroid/database-mongo) connection for persisting data, `hello` and `seen` skills from the official repos and finally a custom skill hosted on GitHub.
 
 Configuration options such as the `token` in the slack connector or the `host`, `port` and `database` options in the mongo database are specific to those modules. Ensure you check each module's required configuration items before you use them.
 
@@ -127,21 +127,21 @@ The await keyword must be used within another function (typically an asyncio fun
 ## Matchers available
 Matchers are used to match a message, sent by a user, to a connector and a skill. Opsdroid comes ready with 9 different matchers, each one of them has its own settings and specification.
 
-- Basic matcher
-  - [Regular Expressions](/docs/matchers/regex.md)
-- NLP Matchers
-  - [Dialogflow(previous Api.ai)](/docs/matchers/dialogflow.md)
-  - [Wit.ai](/docs/matchers/wit.ai.md)
-  - [Luis.ai](/docs/matchers/luis.ai.md)
-  - [Recast.ai](/docs/matchers/recast.ai.md)
-- NLU Matcher
-  - [Rasa_NLU](/docs/matchers/rasanlu.md)
-- Special Matcher
-  - [Always](/docs/matchers/always.md)
-  - [Crontab](/docs/matchers/crontab.md)
-  - [Webhook](/docs/matchers/webhook.md)
+  * Basic matcher
+    * [Regular Expressions](../matchers/regex.md)
+  * NLP Matchers
+    * [Dialogflow(previous Api.ai)](../matchers/dialogflow.md)
+    * [Wit.ai](../matchers/wit.ai.md)
+    * [Luis.ai](../matchers/luis.ai.md)
+    * [Recast.ai](../matchers/recast.ai.md)
+  * NLU Matcher
+    * [Rasa_NLU](../matchers/rasanlu.md)
+  * Special Matcher
+    * [Always](../matchers/always.md)
+    * [Crontab](../matchers/crontab.md)
+    * [Webhook](../matchers/webhook.md)
 
-Read the any of the matchers page for a quick reference guide on how to use them.
+Read any of the matchers page for a quick reference guide on how to use them.
 
 
 ## First run - Skills available


### PR DESCRIPTION
# Description

As part of #532 while documenting the matchers I found multiple dead links on the documentation, this PR update those broken links

## Status
**READY**

## Type of change

- Documentation (fix or adds documentation)

# How Has This Been Tested?

Verifying each link goes to the expected markdown file in my [repo+branch]()https://github.com/tonyskapunk/opsdroid/tree/matchers-doc/docs

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)

