### PR TITLE
[WIP] Refactor skill discovery

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -12,7 +12,7 @@ import click
 
 from opsdroid import __version__
 from opsdroid.core import OpsDroid
-from opsdroid.web import Web
+from opsdroid.loader import Loader
 from opsdroid.const import DEFAULT_LOG_FILENAME, LOCALE_DIR, \
     EXAMPLE_CONFIG_FILE, DEFAULT_LANGUAGE, DEFAULT_CONFIG_PATH
 
@@ -183,12 +183,17 @@ def main():
     """
     check_dependencies()
 
+    config = Loader.load_config_file([
+        "configuration.yaml",
+        DEFAULT_CONFIG_PATH,
+        "/etc/opsdroid/configuration.yaml"
+        ])
+    configure_lang(config)
+    configure_logging(config)
+    welcome_message(config)
+
     with OpsDroid() as opsdroid:
-        opsdroid.load()
-        configure_lang(opsdroid.config)
-        configure_logging(opsdroid.config)
-        welcome_message(opsdroid.config)
-        opsdroid.web_server = Web(opsdroid)
+        opsdroid.load(config)
         opsdroid.start_loop()
 
 

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -192,7 +192,8 @@ class Loader:
         shutil.copyfile(EXAMPLE_CONFIG_FILE, config_path)
         return config_path
 
-    def load_config_file(self, config_paths):
+    @classmethod
+    def load_config_file(cls, config_paths):
         """Load a yaml config file from path."""
         config_path = ""
         for possible_path in config_paths:
@@ -208,7 +209,7 @@ class Loader:
             except FileNotFoundError:
                 _LOGGER.info(_("No configuration files found. "
                                "Creating %s"), DEFAULT_CONFIG_PATH)
-            config_path = self.create_default_config(DEFAULT_CONFIG_PATH)
+            config_path = cls.create_default_config(DEFAULT_CONFIG_PATH)
 
         env_var_pattern = re.compile(r'^\$([A-Z_]*)$')
         yaml.add_implicit_resolver("!envvar", env_var_pattern)
@@ -236,9 +237,11 @@ class Loader:
                 _LOGGER.info(_("Loaded config from %s."), config_path)
                 return yaml.load(stream)
         except yaml.YAMLError as error:
-            self.opsdroid.critical(error, 1)
+            _LOGGER.critical(error)
+            sys.exit(1)
         except FileNotFoundError as error:
-            self.opsdroid.critical(str(error), 1)
+            _LOGGER.critical(error)
+            sys.exit(1)
 
     def setup_modules_directory(self, config):
         """Create and configure the modules directory."""
@@ -283,7 +286,9 @@ class Loader:
             self.opsdroid.critical(_(
                 "No connectors in configuration, at least 1 required"), 1)
 
-        return connectors, databases, skills
+        return {"connectors": connectors,
+                "databases": databases,
+                "skills": skills}
 
     def _load_modules(self, modules_type, modules):
         """Install and load modules."""

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -3,28 +3,32 @@
 import logging
 
 from opsdroid.const import REGEX_SCORE_FACTOR
-from opsdroid.helper import get_opsdroid
-from opsdroid.web import Web
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def add_skill_attributes(func):
+    """Add the attributes which makes a function a skill."""
+    if not hasattr(func, 'skill'):
+        func.skill = True
+    if not hasattr(func, 'matchers'):
+        func.matchers = []
+    return func
 
 
 def match_regex(regex, case_sensitive=True, score_factor=None):
     """Return regex match decorator."""
     def matcher(func):
         """Add decorated function to skills list for regex matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            regex_setup = {
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"regex": {
                 "expression": regex,
                 "case_sensitive": case_sensitive,
                 "score_factor": score_factor or REGEX_SCORE_FACTOR,
-            }
-            opsdroid.skills.append({"regex": regex_setup,
-                                    "skill": func,
-                                    "config": config})
+            }}
+        )
         return func
     return matcher
 
@@ -33,12 +37,10 @@ def match_apiai_action(action):
     """Return Dialogflow action match decorator."""
     def matcher(func):
         """Add decorated function to skills list for Dialogflow matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"dialogflow_action": action,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"dialogflow_action": action}
+        )
         return func
     _LOGGER.warning(_("Api.ai is now called Dialogflow, this matcher "
                       "will stop working in the future. "
@@ -50,12 +52,10 @@ def match_apiai_intent(intent):
     """Return Dialogflow intent match decorator."""
     def matcher(func):
         """Add decorated function to skills list for Dialogflow matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"dialogflow_intent": intent,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"dialogflow_intent": intent}
+        )
         return func
     _LOGGER.warning(_("Api.ai is now called Dialogflow, this matcher "
                       "will stop working in the future. "
@@ -67,12 +67,10 @@ def match_dialogflow_action(action):
     """Return Dialogflowi action match decorator."""
     def matcher(func):
         """Add decorated function to skills list for Dialogflow matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"dialogflow_action": action,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"dialogflow_action": action}
+        )
         return func
     return matcher
 
@@ -81,12 +79,10 @@ def match_dialogflow_intent(intent):
     """Return Dialogflow intent match decorator."""
     def matcher(func):
         """Add decorated function to skills list for Dialogflow matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"dialogflow_intent": intent,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"dialogflow_intent": intent}
+        )
         return func
     return matcher
 
@@ -95,12 +91,10 @@ def match_luisai_intent(intent):
     """Return luisai intent match decorator."""
     def matcher(func):
         """Add decorated function to skills list for luisai matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"luisai_intent": intent,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"luisai_intent": intent}
+        )
         return func
     return matcher
 
@@ -109,12 +103,10 @@ def match_rasanlu(intent):
     """Return Rasa NLU intent match decorator."""
     def matcher(func):
         """Add decorated function to skills list for Rasa NLU matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"rasanlu_intent": intent,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"rasanlu_intent": intent}
+        )
         return func
     return matcher
 
@@ -123,12 +115,10 @@ def match_recastai(intent):
     """Return recastai intent match decorator."""
     def matcher(func):
         """Add decorated function to skills list for recastai matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"recastai_intent": intent,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"recastai_intent": intent}
+        )
         return func
     return matcher
 
@@ -137,12 +127,10 @@ def match_witai(intent):
     """Return witai intent match decorator."""
     def matcher(func):
         """Add decorated function to skills list for witai matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"witai_intent": intent,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"witai_intent": intent}
+        )
         return func
     return matcher
 
@@ -151,13 +139,11 @@ def match_crontab(crontab, timezone=None):
     """Return crontab match decorator."""
     def matcher(func):
         """Add decorated function to skills list for crontab matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"crontab": crontab,
-                                    "skill": func,
-                                    "config": config,
-                                    "timezone": timezone})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"crontab": crontab,
+             "timezone": timezone}
+        )
         return func
     return matcher
 
@@ -166,25 +152,10 @@ def match_webhook(webhook):
     """Return webhook match decorator."""
     def matcher(func):
         """Add decorated function to skills list for webhook matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"webhook": webhook,
-                                    "skill": func,
-                                    "config": config})
-
-            async def wrapper(req, opsdroid=opsdroid, config=config):
-                """Wrap up the aiohttp handler."""
-                _LOGGER.info("Running skill %s via webhook", webhook)
-                opsdroid.stats["webhooks_called"] = \
-                    opsdroid.stats["webhooks_called"] + 1
-                await func(opsdroid, config, req)
-                return Web.build_response(200, {"called_skill": webhook})
-
-            opsdroid.web_server.web_app.router.add_post(
-                "/skill/{}/{}".format(config["name"], webhook), wrapper)
-            opsdroid.web_server.web_app.router.add_post(
-                "/skill/{}/{}/".format(config["name"], webhook), wrapper)
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"webhook": webhook}
+        )
 
         return func
     return matcher
@@ -194,12 +165,10 @@ def match_always(func=None):
     """Return always match decorator."""
     def matcher(func):
         """Add decorated function to skills list for always matching."""
-        opsdroid = get_opsdroid()
-        if opsdroid:
-            config = opsdroid.loader.current_import_config
-            opsdroid.skills.append({"always": True,
-                                    "skill": func,
-                                    "config": config})
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"always": True}
+        )
         return func
 
     # Allow for decorator with or without parenthesis as there are no args.

--- a/opsdroid/parsers/always.py
+++ b/opsdroid/parsers/always.py
@@ -9,7 +9,8 @@ _LOGGER = logging.getLogger(__name__)
 async def parse_always(opsdroid, message):
     """Parse a message always."""
     for skill in opsdroid.skills:
-        if "always" in skill and skill["always"]:
-            await opsdroid.run_skill(skill["skill"],
-                                     skill["config"],
-                                     message)
+        for matcher in skill.matchers:
+            if "always" in matcher:
+                await opsdroid.run_skill(skill,
+                                         skill.config,
+                                         message)

--- a/opsdroid/parsers/crontab.py
+++ b/opsdroid/parsers/crontab.py
@@ -16,12 +16,14 @@ async def parse_crontab(opsdroid):
         await asyncio.sleep(60 - arrow.now().time().second)
         _LOGGER.debug(_("Running crontab skills"))
         for skill in opsdroid.skills:
-            if "crontab" in skill:
-                if skill["timezone"] is not None:
-                    timezone = skill["timezone"]
-                else:
-                    timezone = opsdroid.config.get("timezone", "UTC")
-                if pycron.is_now(skill["crontab"], arrow.now(tz=timezone)):
-                    await opsdroid.run_skill(skill["skill"],
-                                             skill["config"],
-                                             None)
+            for matcher in skill.matchers:
+                if "crontab" in matcher:
+                    if matcher["timezone"] is not None:
+                        timezone = matcher["timezone"]
+                    else:
+                        timezone = opsdroid.config.get("timezone", "UTC")
+                    if pycron.is_now(matcher["crontab"],
+                                     arrow.now(tz=timezone)):
+                        await opsdroid.run_skill(skill,
+                                                 skill.config,
+                                                 None)

--- a/opsdroid/parsers/dialogflow.py
+++ b/opsdroid/parsers/dialogflow.py
@@ -62,23 +62,24 @@ async def parse_dialogflow(opsdroid, message, config):
         if result:
 
             for skill in opsdroid.skills:
+                for matcher in skill.matchers:
 
-                if "dialogflow_action" in skill or \
-                                "dialogflow_intent" in skill:
-                    if ("action" in result["result"] and
-                            skill["dialogflow_action"] in
-                            result["result"]["action"]) \
-                            or ("intentName" in result["result"] and
-                                skill["dialogflow_intent"] in
-                                result["result"]["intentName"]):
-                        message.dialogflow = result
-                        message.apiai = message.dialogflow
-                        _LOGGER.debug(_("Matched against skill %s"),
-                                      skill["config"]["name"])
-                        matched_skills.append({
-                            "score": result["result"]["score"],
-                            "skill": skill["skill"],
-                            "config": skill["config"],
-                            "message": message
-                        })
+                    if "dialogflow_action" in matcher or \
+                            "dialogflow_intent" in matcher:
+                        if ("action" in result["result"] and
+                                matcher["dialogflow_action"] in
+                                result["result"]["action"]) \
+                                or ("intentName" in result["result"] and
+                                    matcher["dialogflow_intent"] in
+                                    result["result"]["intentName"]):
+                            message.dialogflow = result
+                            message.apiai = message.dialogflow
+                            _LOGGER.debug(_("Matched against skill %s"),
+                                          skill.config["name"])
+                            matched_skills.append({
+                                "score": result["result"]["score"],
+                                "skill": skill,
+                                "config": skill.config,
+                                "message": message
+                            })
     return matched_skills

--- a/opsdroid/parsers/luisai.py
+++ b/opsdroid/parsers/luisai.py
@@ -56,18 +56,19 @@ async def parse_luisai(opsdroid, message, config):
                 return matched_skills
 
             for skill in opsdroid.skills:
-                if "luisai_intent" in skill:
-                    try:
-                        intents = [i["intent"] for i in result["intents"]]
-                    except KeyError:
-                        continue
+                for matcher in skill.matchers:
+                    if "luisai_intent" in matcher:
+                        try:
+                            intents = [i["intent"] for i in result["intents"]]
+                        except KeyError:
+                            continue
 
-                    if skill["luisai_intent"] in intents:
-                        message.luisai = result
-                        matched_skills.append({
-                            "score": result["topScoringIntent"]["score"],
-                            "skill": skill["skill"],
-                            "config": skill["config"],
-                            "message": message
-                        })
+                        if matcher["luisai_intent"] in intents:
+                            message.luisai = result
+                            matched_skills.append({
+                                "score": result["topScoringIntent"]["score"],
+                                "skill": skill,
+                                "config": skill.config,
+                                "message": message
+                            })
     return matched_skills

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -16,8 +16,9 @@ _LOGGER = logging.getLogger(__name__)
 
 async def _get_all_intents(skills):
     """Get all skill intents and concatenate into a single markdown string."""
-    intents = [skill["intents"] for skill in skills
-               if skill["intents"] is not None]
+    matchers = [matcher for skill in skills for matcher in skill.matchers]
+    intents = [matcher["intents"] for matcher in matchers
+               if matcher["intents"] is not None]
     if not intents:
         return None
     intents = "\n\n".join(intents)
@@ -176,14 +177,15 @@ async def parse_rasanlu(opsdroid, message, config):
 
     if result:
         for skill in opsdroid.skills:
-            if "rasanlu_intent" in skill:
-                if skill['rasanlu_intent'] == result['intent']['name']:
-                    message.rasanlu = result
-                    matched_skills.append({
-                        "score": confidence,
-                        "skill": skill["skill"],
-                        "config": skill["config"],
-                        "message": message
-                    })
+            for matcher in skill.matchers:
+                if "rasanlu_intent" in matcher:
+                    if matcher['rasanlu_intent'] == result['intent']['name']:
+                        message.rasanlu = result
+                        matched_skills.append({
+                            "score": confidence,
+                            "skill": skill,
+                            "config": skill.config,
+                            "message": message
+                        })
 
     return matched_skills

--- a/opsdroid/parsers/recastai.py
+++ b/opsdroid/parsers/recastai.py
@@ -52,26 +52,27 @@ async def parse_recastai(opsdroid, message, config):
                             "for the message %s"), str(message.text))
             return matched_skills
 
+        confidence = result["results"]["intents"][0]["confidence"]
+
         if "min-score" in config and \
-                result["results"]["intents"][0]["confidence"] < \
-                config["min-score"]:
+                confidence < config["min-score"]:
             _LOGGER.debug(_("Recast.AI score lower than min-score"))
             return matched_skills
 
         if result:
             for skill in opsdroid.skills:
-                if "recastai_intent" in skill:
-                    if (skill["recastai_intent"] in
-                            result["results"]["intents"][0]["slug"]):
-                        message.recastai = result
-                        _LOGGER.debug(_("Matched against skill %s"),
-                                      skill["config"]["name"])
+                for matcher in skill.matchers:
+                    if "recastai_intent" in matcher:
+                        if (matcher["recastai_intent"] in
+                                result["results"]["intents"][0]["slug"]):
+                            message.recastai = result
+                            _LOGGER.debug(_("Matched against skill %s"),
+                                          skill.config["name"])
 
-                        matched_skills.append({
-                            "score":
-                                result["results"]["intents"][0]["confidence"],
-                            "skill": skill["skill"],
-                            "config": skill["config"],
-                            "message": message
-                        })
+                            matched_skills.append({
+                                "score": confidence,
+                                "skill": skill,
+                                "config": skill.config,
+                                "message": message
+                            })
     return matched_skills

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -17,21 +17,22 @@ async def parse_regex(opsdroid, message):
     """Parse a message against all regex skills."""
     matched_skills = []
     for skill in opsdroid.skills:
-        if "regex" in skill:
-            opts = skill["regex"]
-            if opts["case_sensitive"]:
-                regex = re.search(opts["expression"],
-                                  message.text)
-            else:
-                regex = re.search(opts["expression"],
-                                  message.text, re.IGNORECASE)
-            if regex:
-                message.regex = regex
-                matched_skills.append({
-                    "score": await calculate_score(
-                        opts["expression"], opts["score_factor"]),
-                    "skill": skill["skill"],
-                    "config": skill["config"],
-                    "message": message
-                })
+        for matcher in skill.matchers:
+            if "regex" in matcher:
+                opts = matcher["regex"]
+                if opts["case_sensitive"]:
+                    regex = re.search(opts["expression"],
+                                      message.text)
+                else:
+                    regex = re.search(opts["expression"],
+                                      message.text, re.IGNORECASE)
+                if regex:
+                    message.regex = regex
+                    matched_skills.append({
+                        "score": await calculate_score(
+                            opts["expression"], opts["score_factor"]),
+                        "skill": skill,
+                        "config": skill.config,
+                        "message": message
+                    })
     return matched_skills

--- a/opsdroid/parsers/witai.py
+++ b/opsdroid/parsers/witai.py
@@ -58,15 +58,16 @@ async def parse_witai(opsdroid, message, config):
 
         if result:
             for skill in opsdroid.skills:
-                if "witai_intent" in skill:
-                    if (skill['witai_intent'] in
-                            [i['value'] for i in
-                             result['entities']['intent']]):
-                        message.witai = result
-                        matched_skills.append({
-                            "score": confidence,
-                            "skill": skill["skill"],
-                            "config": skill["config"],
-                            "message": message
-                        })
+                for matcher in skill.matchers:
+                    if "witai_intent" in matcher:
+                        if (matcher['witai_intent'] in
+                                [i['value'] for i in
+                                 result['entities']['intent']]):
+                            message.witai = result
+                            matched_skills.append({
+                                "score": confidence,
+                                "skill": skill,
+                                "config": skill.config,
+                                "message": message
+                            })
     return matched_skills

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -22,7 +22,7 @@ class Web:
             self.config = self.opsdroid.config["web"]
         except KeyError:
             self.config = {}
-        self.web_app = web.Application(loop=self.opsdroid.eventloop)
+        self.web_app = web.Application()
         self.web_app.router.add_get('/', self.web_index_handler)
         self.web_app.router.add_get('', self.web_index_handler)
         self.web_app.router.add_get('/stats', self.web_stats_handler)
@@ -77,12 +77,12 @@ class Web:
         """Build a json response object."""
         return web.Response(text=json.dumps(result), status=status)
 
-    def web_index_handler(self, request):
+    async def web_index_handler(self, request):
         """Handle root web request."""
         return self.build_response(200, {
             "message": "Welcome to the opsdroid API"})
 
-    def web_stats_handler(self, request):
+    async def web_stats_handler(self, request):
         """Handle stats request."""
         stats = self.opsdroid.stats
         try:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -8,7 +8,9 @@ import unittest
 import unittest.mock as mock
 from types import ModuleType
 
+from opsdroid.__main__ import configure_lang
 from opsdroid import loader as ld
+from opsdroid.loader import Loader
 from opsdroid.helper import del_rw
 
 
@@ -16,6 +18,7 @@ class TestLoader(unittest.TestCase):
     """Test the opsdroid loader class."""
 
     def setup(self):
+        configure_lang({})
         opsdroid = mock.MagicMock()
         loader = ld.Loader(opsdroid)
         return opsdroid, loader
@@ -51,12 +54,12 @@ class TestLoader(unittest.TestCase):
         self.assertEqual(config, config2)
 
     def test_yaml_load_exploit(self):
-        opsdroid, loader = self.setup()
-        config = loader.load_config_file(
-            [os.path.abspath("tests/configs/include_exploit.yaml")])
-        self.assertIsNone(config)
-        # If the command in exploit.yaml is echoed it will return 0
-        self.assertNotEqual(config, 0)
+        with mock.patch('sys.exit'):
+            config = Loader.load_config_file(
+                [os.path.abspath("tests/configs/include_exploit.yaml")])
+            self.assertIsNone(config)
+            # If the command in exploit.yaml is echoed it will return 0
+            self.assertNotEqual(config, 0)
 
     def test_load_config_file_with_env_vars(self):
         opsdroid, loader = self.setup()
@@ -76,26 +79,24 @@ class TestLoader(unittest.TestCase):
         shutil.rmtree(os.path.split(test_config_path)[0], onerror=del_rw)
 
     def test_generate_config_if_none_exist(self):
-        opsdroid, loader = self.setup()
-        loader.create_default_config = mock.Mock(
+        Loader.create_default_config = mock.Mock(
             return_value=os.path.abspath("tests/configs/minimal.yaml"))
-        loader.load_config_file(["file_which_does_not_exist"])
-        self.assertTrue(loader.create_default_config.called)
+        Loader.load_config_file(["file_which_does_not_exist"])
+        self.assertTrue(Loader.create_default_config.called)
 
     def test_load_non_existant_config_file(self):
-        opsdroid, loader = self.setup()
-        loader.create_default_config = mock.Mock(
+        Loader.create_default_config = mock.Mock(
             return_value=os.path.abspath("/tmp/my_nonexistant_config"))
-        loader.load_config_file(["file_which_does_not_exist"])
-        self.assertTrue(loader.create_default_config.called)
-        self.assertTrue(loader.opsdroid.critical.called)
+        with mock.patch('sys.exit') as mock_sysexit:
+            Loader.load_config_file(["file_which_does_not_exist"])
+            self.assertTrue(Loader.create_default_config.called)
+            self.assertTrue(mock_sysexit.called)
 
     def test_load_broken_config_file(self):
-        opsdroid, loader = self.setup()
-        loader.opsdroid.critical = mock.Mock()
-        loader.load_config_file(
-            [os.path.abspath("tests/configs/broken.yaml")])
-        self.assertTrue(loader.opsdroid.critical.called)
+        with mock.patch('sys.exit') as patched_sysexit:
+            Loader.load_config_file(
+                [os.path.abspath("tests/configs/broken.yaml")])
+            self.assertTrue(patched_sysexit.called)
 
     def test_git_clone(self):
         with mock.patch.object(subprocess, 'Popen') as mock_subproc_popen:
@@ -283,27 +284,27 @@ class TestLoader(unittest.TestCase):
 
     def test_load_minimal_config_file(self):
         opsdroid, loader = self.setup()
-        config = loader.load_config_file(
+        config = Loader.load_config_file(
             [os.path.abspath("tests/configs/minimal.yaml")])
         loader._install_module = mock.MagicMock()
         loader.import_module = mock.MagicMock()
-        connectors, databases, skills = loader.load_modules_from_config(config)
-        self.assertIsNotNone(connectors)
-        self.assertIsNone(databases)
-        self.assertIsNotNone(skills)
+        modules = loader.load_modules_from_config(config)
+        self.assertIsNotNone(modules["connectors"])
+        self.assertIsNone(modules["databases"])
+        self.assertIsNotNone(modules["skills"])
         self.assertIsNotNone(config)
 
     def test_load_minimal_config_file_2(self):
         opsdroid, loader = self.setup()
         loader._install_module = mock.MagicMock()
         loader.import_module = mock.MagicMock()
-        config = loader.load_config_file(
+        config = Loader.load_config_file(
             [os.path.abspath("tests/configs/minimal_2.yaml")])
-        connectors, databases, skills = loader.load_modules_from_config(config)
+        modules = loader.load_modules_from_config(config)
+        self.assertIsNotNone(modules["connectors"])
+        self.assertIsNone(modules["databases"])
+        self.assertIsNotNone(modules["skills"])
         self.assertIsNotNone(config)
-        self.assertIsNotNone(connectors)
-        self.assertIsNone(databases)
-        self.assertIsNotNone(skills)
 
     def test_load_modules(self):
         opsdroid, loader = self.setup()

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -2,8 +2,10 @@
 import asynctest
 import asynctest.mock as mock
 
+import asyncio
 import aiohttp.web
 
+from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.web import Web
 from opsdroid import matchers
@@ -12,91 +14,92 @@ from opsdroid import matchers
 class TestMatchers(asynctest.TestCase):
     """Test the opsdroid matcher decorators."""
 
+    async def setUp(self):
+        configure_lang({})
+
+    async def getMockSkill(self):
+        async def mockedskill(opsdroid, config, message):
+            pass
+        return mockedskill
+
     async def test_match_regex(self):
         with OpsDroid() as opsdroid:
             regex = r"(.*)"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_regex(regex)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["regex"]["expression"], regex)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["regex"]["expression"], regex)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
 
     async def test_match_apiai(self):
         with OpsDroid() as opsdroid:
             action = "myaction"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_apiai_action(action)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["dialogflow_action"], action)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["dialogflow_action"], action)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
             intent = "myIntent"
             decorator = matchers.match_apiai_intent(intent)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 2)
-            self.assertEqual(opsdroid.skills[1]["dialogflow_intent"], intent)
-            self.assertIsInstance(opsdroid.skills[1]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[1].matchers[0]["dialogflow_intent"], intent)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[1]))
             with mock.patch('opsdroid.matchers._LOGGER.warning') as logmock:
                 decorator = matchers.match_apiai_intent(intent)
-                decorator(mockedskill)
+                opsdroid.skills.append(decorator(await self.getMockSkill()))
                 self.assertTrue(logmock.called)
 
     async def test_match_dialogflow(self):
         with OpsDroid() as opsdroid:
             action = "myaction"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_dialogflow_action(action)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["dialogflow_action"], action)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["dialogflow_action"], action)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
             intent = "myIntent"
             decorator = matchers.match_dialogflow_intent(intent)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 2)
-            self.assertEqual(opsdroid.skills[1]["dialogflow_intent"], intent)
-            self.assertIsInstance(opsdroid.skills[1]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[1].matchers[0]["dialogflow_intent"], intent)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[1]))
 
     async def test_match_luisai(self):
         with OpsDroid() as opsdroid:
             intent = "myIntent"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_luisai_intent(intent)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["luisai_intent"], intent)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["luisai_intent"], intent)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
 
     async def test_match_witai(self):
         with OpsDroid() as opsdroid:
             intent = "myIntent"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_witai(intent)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["witai_intent"], intent)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["witai_intent"], intent)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
 
     async def test_match_rasanu(self):
         with OpsDroid() as opsdroid:
             intent = "myIntent"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_rasanlu(intent)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["rasanlu_intent"], intent)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["rasanlu_intent"], intent)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
 
     async def test_match_crontab(self):
         with OpsDroid() as opsdroid:
             crontab = "* * * * *"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_crontab(crontab)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["crontab"], crontab)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["crontab"], crontab)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
 
     async def test_match_webhook(self):
         with OpsDroid() as opsdroid:
@@ -104,12 +107,13 @@ class TestMatchers(asynctest.TestCase):
             opsdroid.web_server = Web(opsdroid)
             opsdroid.web_server.web_app = mock.Mock()
             webhook = "test"
-            mockedskill = mock.MagicMock()
             decorator = matchers.match_webhook(webhook)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
+            opsdroid.skills[0].config = {"name": "mockedskill"}
+            opsdroid.setup_webhooks()
             self.assertEqual(len(opsdroid.skills), 1)
-            self.assertEqual(opsdroid.skills[0]["webhook"], webhook)
-            self.assertIsInstance(opsdroid.skills[0]["skill"], mock.MagicMock)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["webhook"], webhook)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
             self.assertEqual(
                 opsdroid.web_server.web_app.router.add_post.call_count, 2)
 
@@ -119,9 +123,10 @@ class TestMatchers(asynctest.TestCase):
             opsdroid.web_server = Web(opsdroid)
             opsdroid.web_server.web_app = mock.Mock()
             webhook = "test"
-            mockedskill = mock.CoroutineMock()
             decorator = matchers.match_webhook(webhook)
-            decorator(mockedskill)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
+            opsdroid.skills[0].config = {"name": "mockedskill"}
+            opsdroid.setup_webhooks()
             postcalls, _ = \
                 opsdroid.web_server.web_app.router.add_post.call_args_list[0]
             wrapperfunc = postcalls[1]

--- a/tests/test_parser_crontab.py
+++ b/tests/test_parser_crontab.py
@@ -2,6 +2,7 @@
 import asynctest
 import asynctest.mock as amock
 
+from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.matchers import match_crontab
 from opsdroid.parsers.crontab import parse_crontab
@@ -11,6 +12,21 @@ class TestParserCrontab(asynctest.TestCase):
     """Test the opsdroid crontab parser."""
 
     not_first_run_flag = True
+
+    async def setup(self):
+        configure_lang({})
+
+    async def getMockSkill(self):
+        async def mockedskill(opsdroid, config, message):
+            pass
+        mockedskill.config = {}
+        return mockedskill
+
+    async def getRaisingMockSkill(self):
+        async def mockedskill(opsdroid, config, message):
+            raise Exception()
+        mockedskill.config = {}
+        return mockedskill
 
     def true_once(self):
         if self.not_first_run_flag:
@@ -23,37 +39,46 @@ class TestParserCrontab(asynctest.TestCase):
         with OpsDroid() as opsdroid:
             self.not_first_run_flag = True
             opsdroid.eventloop.is_running = self.true_once
+            opsdroid.run_skill = amock.CoroutineMock()
             with amock.patch('asyncio.sleep'):
-                mock_skill = amock.CoroutineMock()
-                match_crontab("* * * * *")(mock_skill)
+                mock_skill = await self.getMockSkill()
+                mock_skill.config = {
+                    "name": "greetings"
+                }
+                opsdroid.skills.append(match_crontab("* * * * *")(mock_skill))
 
                 await parse_crontab(opsdroid)
-                self.assertTrue(mock_skill.called)
+                self.assertTrue(opsdroid.run_skill.called)
 
     async def test_parse_crontab_timezone(self):
         with OpsDroid() as opsdroid:
             self.not_first_run_flag = True
             opsdroid.eventloop.is_running = self.true_once
+            opsdroid.run_skill = amock.CoroutineMock()
             with amock.patch('asyncio.sleep'):
-                mock_skill = amock.CoroutineMock()
-                match_crontab("* * * * *",
-                              timezone="Europe/London")(mock_skill)
+                mock_skill = await self.getMockSkill()
+                mock_skill.config = {
+                    "name": "greetings"
+                }
+                opsdroid.skills.append(
+                    match_crontab("* * * * *",
+                                  timezone="Europe/London")(mock_skill))
 
                 await parse_crontab(opsdroid)
-                self.assertTrue(mock_skill.called)
+                self.assertTrue(opsdroid.run_skill.called)
 
     async def test_parse_crontab_raises(self):
         with OpsDroid() as opsdroid:
             self.not_first_run_flag = True
             opsdroid.eventloop.is_running = self.true_once
             with amock.patch('asyncio.sleep'):
-                mock_skill = amock.CoroutineMock()
-                mock_skill.side_effect = Exception()
-                opsdroid.loader.current_import_config = {
-                    "name": "mocked-skill"
+                mock_skill = await self.getRaisingMockSkill()
+                mock_skill.config = {
+                    "name": "greetings"
                 }
-                match_crontab("* * * * *")(mock_skill)
+                opsdroid.skills.append(match_crontab("* * * * *")(mock_skill))
                 self.assertEqual(len(opsdroid.skills), 1)
 
-                await parse_crontab(opsdroid)
-                self.assertTrue(mock_skill.called)
+                with amock.patch('opsdroid.core._LOGGER.exception') as logmock:
+                    await parse_crontab(opsdroid)
+                    self.assertTrue(logmock.called)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -76,7 +76,7 @@ class TestWeb(asynctest.TestCase):
             opsdroid.config["web"] = {}
             app = web.Web(opsdroid)
             self.assertEqual(
-                type(app.web_index_handler(None)), aiohttp.web.Response)
+                type(await app.web_index_handler(None)), aiohttp.web.Response)
 
     async def test_web_stats_handler(self):
         """Check the stats handler."""
@@ -84,7 +84,7 @@ class TestWeb(asynctest.TestCase):
             opsdroid.config["web"] = {}
             app = web.Web(opsdroid)
             self.assertEqual(
-                type(app.web_stats_handler(None)), aiohttp.web.Response)
+                type(await app.web_stats_handler(None)), aiohttp.web.Response)
 
     async def test_web_start(self):
         """Check the stats handler."""


### PR DESCRIPTION
# Description
This is going to be quite a major PR where I am rewriting the way modules are loaded. This is partly in preparation for adding constraints and context and partly to tackle a number of issues.

Changes in this PR:
 - [x] Change the main entry point to simplify the opsdroid context manager
 - [x] Update matchers to annotate skill functions instead of registering them with opsdroid
 - [x] Update the opsdroid setup to discover annotated functions from loaded modules
 - [x] Update aiohttp server code to resolve deprecation warnings
 - [ ] Split `Loader` into `Loader` and `Installer` to simplify the class
 - [ ] Add unload function which reverses what `opsdroid.load` does
 - [ ] Reinstate the reload functionality

Fixes #683 

Also addresses #709, #655, #643, 


## Status
**UNDER DEVELOPMENT**

# How Has This Been Tested?

Tests have been added and updated as the changes are being made.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

