### PR TITLE
Update release docs with conda info and releae notes script

### DIFF
--- a/docs/project/making-a-release.md
+++ b/docs/project/making-a-release.md
@@ -9,8 +9,9 @@ When releasing, there are a couple of release artifacts which are built and dist
 
 Currently opsdroid builds:
 
- * A python distribution on pypi
- * A container image on Docker Hub
+- A Python distribution on [pypi](https://pypi.org/project/opsdroid/)
+- A Python distribution on [Conda Forge](https://github.com/conda-forge/opsdroid-feedstock)
+- A container image on [Docker Hub](https://hub.docker.com/r/opsdroid/opsdroid/)
 
 The building and distributing is automated by Travis CI and run when a [release is created](https://help.github.com/articles/creating-releases/) on GitHub.
 
@@ -20,17 +21,16 @@ The building and distributing is automated by Travis CI and run when a [release 
 
 Before creating the release do some final local testing:
 
- * Checkout master and run the `tox` suite locally.
- * Run opsdroid and do some manual testing to ensure there are no glaring issues.
-
+- Checkout master and run the `tox` suite locally.
+- Run opsdroid and do some manual testing to ensure there are no glaring issues.
 
 ### Increment the version number
 
 As opsdroid follows [SemVer 2.0](http://semver.org/) (`major.minor.patch`) the version number increase will depend on what has changed since the previous release.
 
- * If the release includes only bug fixes then only the `patch` will be incremented.
- * If the release includes new features then the `minor` will be incremented and the `patch` will be reverted to `0`.
- * If the release includes changes which break backward compatibility then the `major` will be incremented with the `minor` and `patch` being reverted to `0`. However this only applies once opsdroid is above `v1.0.0`.
+- If the release includes only bug fixes then only the `patch` will be incremented.
+- If the release includes new features then the `minor` will be incremented and the `patch` will be reverted to `0`.
+- If the release includes changes which break backward compatibility then the `major` will be incremented with the `minor` and `patch` being reverted to `0`. However this only applies once opsdroid is above `v1.0.0`.
 
 To increment the version create a new PR which updates `__version__` in the `const.py` file. When you are ready to cut the release then you can merge this PR.
 
@@ -38,13 +38,13 @@ To increment the version create a new PR which updates `__version__` in the `con
 
 The release description to be posted on GitHub should be a bulleted list of changes separated into sections for **Enhancements**, **Bug fixes**, **Breaking changes** and **Documentation updates**. Each bullet should be the PR name and number which introduced the change.
 
-It is possible to partially automatically generate this using `make`:
+It is possible to partially automatically generate this using a utility script:
 
 ```shell
 # Pull the tags from opsdroid/opsdroid so that only commits since the last tag are listed
 git pull upstream master --tags
 # List the commits
-make release-notes
+python scripts/release_notes/release_notes.py
 ```
 
 This will print a list of all the commits in the history since the last release, which due to the "squash and merge" feature in GitHub will be correctly formatted into one commit per PR with the title and number.
@@ -65,10 +65,14 @@ Once you are happy with the release notes click "Publish release".
 
 This will result in a number of automated actions:
 
- - The new [release tag](https://github.com/opsdroid/opsdroid/tags) will be created on GitHub.
- - [Travis CI](https://travis-ci.org/opsdroid/opsdroid) will build the [pypi distribution](https://pypi.python.org/pypi/opsdroid) and upload it.
- - [Docker Hub](https://hub.docker.com/r/opsdroid/opsdroid/) will build a new container image, create the [new release tag](https://hub.docker.com/r/opsdroid/opsdroid/tags/) and also update `latest` to point to this release.
- - The @opsdroid [twitter account](https://twitter.com/opsdroid) will tweet that the release has been generated (via [IFTTT](https://ifttt.com)).
+- The new [release tag](https://github.com/opsdroid/opsdroid/tags) will be created on GitHub.
+- [Travis CI](https://travis-ci.org/opsdroid/opsdroid) will build the [pypi distribution](https://pypi.python.org/pypi/opsdroid) and upload it.
+- [Docker Hub](https://hub.docker.com/r/opsdroid/opsdroid/) will build a new container image, create the [new release tag](https://hub.docker.com/r/opsdroid/opsdroid/tags/) and also update `latest` to point to this release.
+- The @opsdroid [twitter account](https://twitter.com/opsdroid) will tweet that the release has been generated (via [IFTTT](https://ifttt.com)).
+
+There are also the following manual actions which need to be performed:
+
+- A PR will automatically be raised on the [opsdroid feedstock on Conda Forge](https://github.com/conda-forge/opsdroid-feedstock). This needs to be reviewed and merged.
 
 ### Announce the release
 


### PR DESCRIPTION
A while ago we removed `make` but didn't update the docs, this covers that.

Also now that we are publishing to conda forge we are required to perform a manual PR merge as part of the release (see #660 for info). Updating the docs to describe that.