### PR TITLE
Issue #725 Refactor connector opsdroid pointer

### DIFF
--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -98,7 +98,7 @@ class Connector():
         _LOGGER.debug(_("%s connector can't react to messages"), self.name)
         return False
 
-    async def user_typing(self, opsdroid, trigger):
+    async def user_typing(self, trigger):
         """Signals that opsdroid is typing.
 
         Args:

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -14,7 +14,7 @@ class Connector():
 
     """
 
-    def __init__(self, config):
+    def __init__(self, config, *, opsdroid):
         """Create the connector.
 
         Set some basic properties from the connector config such as the name
@@ -29,21 +29,19 @@ class Connector():
         self.name = ""
         self.config = config
         self.default_room = None
+        self.opsdroid = opsdroid
 
     @property
     def configuration(self):
         """Class property used to access the connector config."""
         return self.config
 
-    async def connect(self, opsdroid):
+    async def connect(self):
         """Connect to chat service.
 
         This method should create a connection to the desired chat service.
         It should also be possible to call it multiple times in the event of
         being disconnected.
-
-        Args:
-            opsdroid (OpsDroid): An instance of the opsdroid core.
 
         """
         raise NotImplementedError
@@ -112,14 +110,11 @@ class Connector():
         """
         pass
 
-    async def disconnect(self, opsdroid):
+    async def disconnect(self):
         """Disconnect from the chat service.
 
         This method is called when opsdroid is exiting, it can be used to close
         connections or do other cleanup.
-
-        Args:
-            opsdroid (OpsDroid): An instance of the opsdroid core.
 
         """
         pass

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -14,7 +14,7 @@ class Connector():
 
     """
 
-    def __init__(self, config, *, opsdroid):
+    def __init__(self, config, opsdroid=None):
         """Create the connector.
 
         Set some basic properties from the connector config such as the name

--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -30,19 +30,17 @@ class ConnectorFacebook(Connector):
 
     """
 
-    def __init__(self, config):
+    def __init__(self, config, *, opsdroid):
         """Connector Setup."""
-        super().__init__(config)
+        super().__init__(config, opsdroid)
         _LOGGER.debug("Starting facebook connector")
         self.config = config
         self.name = self.config.get("name", "facebook")
-        self.opsdroid = None
         self.default_room = None
         self.bot_name = config.get("bot-name", 'opsdroid')
 
-    async def connect(self, opsdroid):
+    async def connect(self):
         """Connect to the chat service."""
-        self.opsdroid = opsdroid
 
         self.opsdroid.web_server.web_app.router.add_post(
             "/connector/{}".format(self.name),

--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -32,7 +32,7 @@ class ConnectorFacebook(Connector):
 
     def __init__(self, config, *, opsdroid):
         """Connector Setup."""
-        super().__init__(config, opsdroid)
+        super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting facebook connector")
         self.config = config
         self.name = self.config.get("name", "facebook")
@@ -41,7 +41,6 @@ class ConnectorFacebook(Connector):
 
     async def connect(self):
         """Connect to the chat service."""
-
         self.opsdroid.web_server.web_app.router.add_post(
             "/connector/{}".format(self.name),
             self.facebook_message_handler)

--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -30,7 +30,7 @@ class ConnectorFacebook(Connector):
 
     """
 
-    def __init__(self, config, *, opsdroid):
+    def __init__(self, config, opsdroid=None):
         """Connector Setup."""
         super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting facebook connector")

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -14,7 +14,7 @@ API_PATH = '/api/v1/'
 class RocketChat(Connector):
     """A connector for the chat service Rocket.Chat."""
 
-    def __init__(self, config, *, opsdroid):
+    def __init__(self, config, opsdroid=None):
         """Create the connector.
 
         Sets up logic for the Connector class, gets data from

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -14,7 +14,7 @@ API_PATH = '/api/v1/'
 class RocketChat(Connector):
     """A connector for the chat service Rocket.Chat."""
 
-    def __init__(self, config):
+    def __init__(self, config, *, opsdroid):
         """Create the connector.
 
         Sets up logic for the Connector class, gets data from
@@ -25,7 +25,7 @@ class RocketChat(Connector):
                 file config.yaml.
 
         """
-        super().__init__(config)
+        super().__init__(config, opsdroid)
         self.name = "rocket.chat"
         self.config = config
         self.default_room = config.get("default-room", "general")
@@ -64,7 +64,7 @@ class RocketChat(Connector):
         """
         return "{}{}{}".format(self.url, API_PATH, method)
 
-    async def connect(self, opsdroid):
+    async def connect(self):
         """Connect to the chat service.
 
         This method is used to text if the connection to the chat
@@ -72,9 +72,6 @@ class RocketChat(Connector):
         the response is a JSON format containing information
         about the user. Other than the user username, the
         information is not used.
-
-        Args:
-            opsdroid (OpsDroid): An instance of opsdroid core.
 
         """
         _LOGGER.info("Connecting to Rocket.Chat")

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -25,7 +25,7 @@ class RocketChat(Connector):
                 file config.yaml.
 
         """
-        super().__init__(config, opsdroid)
+        super().__init__(config, opsdroid=opsdroid)
         self.name = "rocket.chat"
         self.config = config
         self.default_room = config.get("default-room", "general")

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -18,13 +18,12 @@ _LOGGER = logging.getLogger(__name__)
 class ConnectorSlack(Connector):
     """A connector for Slack."""
 
-    def __init__(self, config):
+    def __init__(self, config, *, opsdroid):
         """Create the connector."""
-        super().__init__(config)
+        super().__init__(config, opsdroid)
         _LOGGER.debug("Starting Slack connector")
         self.name = "slack"
         self.config = config
-        self.opsdroid = None
         self.default_room = config.get("default-room", "#general")
         self.icon_emoji = config.get("icon-emoji", ':robot_face:')
         self.token = config["api-token"]
@@ -37,10 +36,8 @@ class ConnectorSlack(Connector):
         self.listening = True
         self._message_id = 0
 
-    async def connect(self, opsdroid=None):
+    async def connect(self):
         """Connect to the chat service."""
-        if opsdroid is not None:
-            self.opsdroid = opsdroid
 
         _LOGGER.info("Connecting to Slack")
 

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -20,7 +20,7 @@ class ConnectorSlack(Connector):
 
     def __init__(self, config, *, opsdroid):
         """Create the connector."""
-        super().__init__(config, opsdroid)
+        super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting Slack connector")
         self.name = "slack"
         self.config = config
@@ -38,7 +38,6 @@ class ConnectorSlack(Connector):
 
     async def connect(self):
         """Connect to the chat service."""
-
         _LOGGER.info("Connecting to Slack")
 
         try:

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 class ConnectorSlack(Connector):
     """A connector for Slack."""
 
-    def __init__(self, config, *, opsdroid):
+    def __init__(self, config, opsdroid=None):
         """Create the connector."""
         super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting Slack connector")

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -23,7 +23,7 @@ class ConnectorTelegram(Connector):
 
         """
         _LOGGER.debug("Loaded telegram connector")
-        super().__init__(config, opsdroid)
+        super().__init__(config, opsdroid=opsdroid)
         self.name = "telegram"
         self.latest_update = None
         self.default_room = None

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 class ConnectorTelegram(Connector):
     """A connector the the char service Telegram."""
 
-    def __init__(self, config):
+    def __init__(self, config, *, opsdroid):
         """Create the connector.
 
         Args:
@@ -23,7 +23,7 @@ class ConnectorTelegram(Connector):
 
         """
         _LOGGER.debug("Loaded telegram connector")
-        super().__init__(config)
+        super().__init__(config, opsdroid)
         self.name = "telegram"
         self.latest_update = None
         self.default_room = None
@@ -50,15 +50,12 @@ class ConnectorTelegram(Connector):
         """
         return "https://api.telegram.org/bot{}/{}".format(self.token, method)
 
-    async def connect(self, opsdroid):
+    async def connect(self):
         """Connect to Telegram.
 
         This method is not an authorization call. It basically
         checks if the API token was provided and makes an API
         call to Telegram and evaluates the status of the call.
-
-        Args:
-            opsdroid (OpsDroid): An instance of opsdroid core.
 
         """
         _LOGGER.debug("Connecting to telegram")

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 class ConnectorTelegram(Connector):
     """A connector the the char service Telegram."""
 
-    def __init__(self, config, *, opsdroid):
+    def __init__(self, config, opsdroid=None):
         """Create the connector.
 
         Args:

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -18,13 +18,12 @@ _LOGGER = logging.getLogger(__name__)
 class ConnectorWebsocket(Connector):
     """A connector which allows websocket connections."""
 
-    def __init__(self, config, *, opsdroid):
+    def __init__(self, config, opsdroid=None):
         """Create the connector."""
         super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting Websocket connector")
         self.name = "websocket"
         self.config = config
-        self.opsdroid = opsdroid
         self.default_room = None
         self.max_connections = self.config.get("max-connections", 10)
         self.connection_timeout = self.config.get("connection-timeout", 60)

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -18,13 +18,12 @@ _LOGGER = logging.getLogger(__name__)
 class ConnectorWebsocket(Connector):
     """A connector which allows websocket connections."""
 
-    def __init__(self, config):
+    def __init__(self, config, *, opsdroid):
         """Create the connector."""
-        super().__init__(config)
+        super().__init__(config, opsdroid)
         _LOGGER.debug("Starting Websocket connector")
         self.name = "websocket"
         self.config = config
-        self.opsdroid = None
         self.default_room = None
         self.max_connections = self.config.get("max-connections", 10)
         self.connection_timeout = self.config.get("connection-timeout", 60)
@@ -33,9 +32,8 @@ class ConnectorWebsocket(Connector):
         self.available_connections = []
         self.bot_name = self.config.get("bot-name", 'opsdroid')
 
-    async def connect(self, opsdroid):
+    async def connect(self):
         """Connect to the chat service."""
-        self.opsdroid = opsdroid
         self.accepting_connections = True
 
         self.opsdroid.web_server.web_app.router.add_get(
@@ -46,7 +44,7 @@ class ConnectorWebsocket(Connector):
             "/connector/websocket",
             self.new_websocket_handler)
 
-    async def disconnect(self, opsdroid):
+    async def disconnect(self):
         """Disconnect from current sessions."""
         self.accepting_connections = False
         connections_to_close = self.active_connections.copy()

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -20,10 +20,11 @@ class ConnectorWebsocket(Connector):
 
     def __init__(self, config, *, opsdroid):
         """Create the connector."""
-        super().__init__(config, opsdroid)
+        super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting Websocket connector")
         self.name = "websocket"
         self.config = config
+        self.opsdroid = opsdroid
         self.default_room = None
         self.max_connections = self.config.get("max-connections", 10)
         self.connection_timeout = self.config.get("connection-timeout", 60)

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -243,9 +243,9 @@ class OpsDroid():
         if connectors:
             for connector in self.connectors:
                 if self.eventloop.is_running():
-                    self.eventloop.create_task(connector.connect(self))
+                    self.eventloop.create_task(connector.connect())
                 else:
-                    self.eventloop.run_until_complete(connector.connect(self))
+                    self.eventloop.run_until_complete(connector.connect())
             for connector in self.connectors:
                 task = self.eventloop.create_task(connector.listen(self))
                 self.connector_tasks.append(task)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2,7 +2,10 @@ import unittest
 import asyncio
 
 import asynctest
+import asynctest.mock as amock
 
+from opsdroid.__main__ import configure_lang
+from opsdroid.core import OpsDroid
 from opsdroid.connector import Connector
 
 
@@ -14,47 +17,50 @@ class TestConnectorBaseClass(unittest.TestCase):
 
     def test_init(self):
         config = {"example_item": "test"}
-        connector = Connector(config)
+        connector = Connector(config, opsdroid=OpsDroid())
         self.assertEqual(None, connector.default_room)
         self.assertEqual("", connector.name)
         self.assertEqual("test", connector.config["example_item"])
 
     def test_property(self):
-        connector = Connector({"name": "shell"})
+        opsdroid = amock.CoroutineMock()
+        connector = Connector({"name": "shell"}, opsdroid=opsdroid)
         self.assertEqual("shell", connector.configuration.get("name"))
 
     def test_connect(self):
-        connector = Connector({})
+        connector = Connector({}, opsdroid=OpsDroid())
         with self.assertRaises(NotImplementedError):
-            self.loop.run_until_complete(connector.connect({}))
+            self.loop.run_until_complete(connector.connect())
 
     def test_listen(self):
-        connector = Connector({})
+        connector = Connector({}, opsdroid=OpsDroid())
         with self.assertRaises(NotImplementedError):
             self.loop.run_until_complete(connector.listen({}))
 
     def test_respond(self):
-        connector = Connector({})
+        connector = Connector({}, opsdroid=OpsDroid())
         with self.assertRaises(NotImplementedError):
             self.loop.run_until_complete(connector.respond({}))
 
     def test_react(self):
-        connector = Connector({})
+        connector = Connector({}, opsdroid=OpsDroid())
         reacted = self.loop.run_until_complete(connector.react({}, 'emoji'))
         self.assertFalse(reacted)
 
     def test_user_typing(self):
         opsdroid = 'opsdroid'
-        connector = Connector({})
+        connector = Connector({}, opsdroid=OpsDroid())
         user_typing = self.loop.run_until_complete(
-            connector.user_typing(opsdroid, trigger=True))
+            connector.user_typing(trigger=True))
         assert user_typing is None
 
 
 class TestConnectorAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid connector base class."""
+    async def setup(self):
+        configure_lang({})
 
     async def test_disconnect(self):
-        connector = Connector({})
-        res = await connector.disconnect(None)
+        connector = Connector({}, opsdroid=OpsDroid())
+        res = await connector.disconnect()
         assert res is None

--- a/tests/test_connector_facebook.py
+++ b/tests/test_connector_facebook.py
@@ -4,6 +4,7 @@ import asyncio
 import asynctest
 import asynctest.mock as amock
 
+from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.connector.facebook import ConnectorFacebook
 from opsdroid.message import Message
@@ -16,29 +17,34 @@ class TestConnectorFacebook(unittest.TestCase):
         self.loop = asyncio.new_event_loop()
 
     def test_init(self):
-        connector = ConnectorFacebook({})
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorFacebook({}, opsdroid=opsdroid)
         self.assertEqual(None, connector.default_room)
         self.assertEqual("facebook", connector.name)
 
     def test_property(self):
-        connector = ConnectorFacebook({})
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorFacebook({}, opsdroid=opsdroid)
         self.assertEqual("facebook", connector.name)
 
 
 class TestConnectorFacebookAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid Facebook connector class."""
 
+    async def setUp(self):
+        configure_lang({})
+
     async def test_connect(self):
         """Test the connect method adds the handlers."""
-        connector = ConnectorFacebook({})
         opsdroid = amock.CoroutineMock()
+        connector = ConnectorFacebook({}, opsdroid=opsdroid)
         opsdroid.web_server = amock.CoroutineMock()
         opsdroid.web_server.web_app = amock.CoroutineMock()
         opsdroid.web_server.web_app.router = amock.CoroutineMock()
         opsdroid.web_server.web_app.router.add_get = amock.CoroutineMock()
         opsdroid.web_server.web_app.router.add_post = amock.CoroutineMock()
 
-        await connector.connect(opsdroid)
+        await connector.connect()
 
         self.assertTrue(opsdroid.web_server.web_app.router.add_get.called)
         self.assertTrue(opsdroid.web_server.web_app.router.add_post.called)
@@ -46,7 +52,8 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
     async def test_facebook_message_handler(self):
         """Test the new facebook message handler."""
         import aiohttp
-        connector = ConnectorFacebook({})
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorFacebook({}, opsdroid=opsdroid)
         req_ob = {
             "object": "page",
             "entry": [{
@@ -72,7 +79,8 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
     async def test_facebook_message_handler_invalid(self):
         """Test the new facebook message handler for invalid message."""
         import aiohttp
-        connector = ConnectorFacebook({})
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorFacebook({}, opsdroid=opsdroid)
         req_ob = {
             "object": "page",
             "entry": [{
@@ -101,7 +109,8 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
     async def test_facebook_challenge_handler(self):
         """Test the facebook challenge handler."""
         import aiohttp
-        connector = ConnectorFacebook({'verify-token': 'token_123'})
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorFacebook({'verify-token': 'token_123'}, opsdroid=opsdroid)
         mock_request = amock.Mock()
         mock_request.query = {
             "hub.verify_token": 'token_123',
@@ -123,7 +132,8 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
 
     async def test_listen(self):
         """Test that listen does nothing."""
-        connector = ConnectorFacebook({})
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorFacebook({}, opsdroid=opsdroid)
         await connector.listen(None)
 
     async def test_respond(self):
@@ -135,7 +145,7 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
                 amock.patch('aiohttp.ClientSession.post',
                             new=asynctest.CoroutineMock()) as patched_request:
             self.assertTrue(opsdroid.__class__.instances)
-            connector = ConnectorFacebook({})
+            connector = ConnectorFacebook({}, opsdroid=opsdroid)
             room = "a146f52c-548a-11e8-a7d1-28cfe949e12d"
             test_message = Message(text="Hello world",
                                    user="Alice",
@@ -157,7 +167,7 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
                 amock.patch('aiohttp.ClientSession.post',
                             new=asynctest.CoroutineMock()) as patched_request:
             self.assertTrue(opsdroid.__class__.instances)
-            connector = ConnectorFacebook({})
+            connector = ConnectorFacebook({}, opsdroid=opsdroid)
             room = "a146f52c-548a-11e8-a7d1-28cfe949e12d"
             test_message = Message(text="Hello world",
                                    user="Alice",

--- a/tests/test_connector_rocketchat.py
+++ b/tests/test_connector_rocketchat.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 import asynctest
 import asynctest.mock as amock
 
+from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.connector.rocketchat import RocketChat
 from opsdroid.message import Message
@@ -22,7 +23,7 @@ class TestRocketChat(unittest.TestCase):
             'name': 'rocket.chat',
             'access-token': 'test',
             'user-id': 'userID'
-        })
+        }, opsdroid=OpsDroid())
         self.assertEqual("general", connector.default_room)
         self.assertEqual("rocket.chat", connector.name)
 
@@ -30,7 +31,7 @@ class TestRocketChat(unittest.TestCase):
         """Test that attempt to connect without info raises an error."""
         with mock.patch('opsdroid.connector.rocketchat._LOGGER.error') \
                 as logmock:
-            RocketChat({})
+            RocketChat({}, opsdroid=OpsDroid())
             self.assertTrue(logmock.called)
 
 
@@ -38,12 +39,13 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid Slack connector class."""
 
     def setUp(self):
+        configure_lang({})
         self.connector = RocketChat({
                 'name': 'rocket.chat',
                 'token': 'test',
                 'user-id': 'userID',
                 'default_room': "test"
-            })
+            }, opsdroid=OpsDroid)
         self.connector.latest_update = '2018-10-08T12:57:37.126Z'
 
     async def test_connect(self):
@@ -80,7 +82,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(connect_response)
 
-            await self.connector.connect(opsdroid)
+            await self.connector.connect()
 
             self.assertTrue(logmock.called)
             self.assertNotEqual(200, patched_request.status)
@@ -98,7 +100,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
 
-            await self.connector.connect(opsdroid)
+            await self.connector.connect()
             self.assertTrue(logmock.called)
 
     async def test_get_message(self):
@@ -107,7 +109,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
                 'token': 'test',
                 'user-id': 'userID',
                 'group': "test"
-            })
+            }, opsdroid=OpsDroid())
         response = amock.Mock()
         response.status = 200
         response.json = amock.CoroutineMock()

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 import asynctest
 import asynctest.mock as amock
 
+from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.connector.telegram import ConnectorTelegram
 from opsdroid.message import Message
@@ -21,13 +22,13 @@ class TestConnectorTelegram(unittest.TestCase):
         connector = ConnectorTelegram({
             'name': 'telegram',
             'token': 'test',
-        })
+        }, opsdroid=OpsDroid())
         self.assertEqual(None, connector.default_room)
         self.assertEqual("telegram", connector.name)
 
     def test_missing_token(self):
         """Test that attempt to connect without info raises an error."""
-        ConnectorTelegram({})
+        ConnectorTelegram({}, opsdroid=OpsDroid())
         self.assertLogs('_LOGGER', 'error')
 
 
@@ -35,11 +36,12 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid Telegram connector class."""
 
     def setUp(self):
+        configure_lang({})
         self.connector = ConnectorTelegram({
                 'name': 'telegram',
                 'token': 'bot:765test',
                 'whitelisted-users': ['user', 'test']
-            })
+            }, opsdroid=OpsDroid())
 
     async def test_connect(self):
         connect_response = amock.Mock()
@@ -60,7 +62,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
 
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(connect_response)
-            await self.connector.connect(opsdroid)
+            await self.connector.connect()
             self.assertLogs('_LOGGER', 'debug')
             self.assertNotEqual(200, patched_request.status)
             self.assertTrue(patched_request.called)
@@ -75,7 +77,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
 
-            await self.connector.connect(opsdroid)
+            await self.connector.connect()
             self.assertLogs('_LOGGER', 'error')
 
     async def test_parse_message(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -184,18 +184,19 @@ class TestCore(unittest.TestCase):
 
     def test_default_connector(self):
         with OpsDroid() as opsdroid:
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             opsdroid.connectors.append(mock_connector)
             self.assertEqual(opsdroid.default_connector, mock_connector)
 
-            mock_default_connector = Connector({"default": True})
+            mock_default_connector = Connector({"default": True}, opsdroid=opsdroid)
             opsdroid.connectors.append(mock_default_connector)
             self.assertEqual(opsdroid.default_connector,
                              mock_default_connector)
 
     def test_default_room(self):
-        mock_connector = Connector({})
-        self.assertEqual(None, mock_connector.default_room)
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({}, opsdroid=opsdroid)
+            self.assertEqual(None, mock_connector.default_room)
 
     def test_train_rasanlu(self):
         with OpsDroid() as opsdroid:
@@ -229,7 +230,7 @@ class TestCoreAsync(asynctest.TestCase):
 
     async def test_unload(self):
         with OpsDroid() as opsdroid:
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             mock_connector.disconnect = amock.CoroutineMock()
             opsdroid.connectors = [mock_connector]
 
@@ -271,7 +272,7 @@ class TestCoreAsync(asynctest.TestCase):
     async def test_parse_regex(self):
         with OpsDroid() as opsdroid:
             regex = r"Hello .*"
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             mock_connector.respond = amock.CoroutineMock()
             skill = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex)(skill))
@@ -284,7 +285,7 @@ class TestCoreAsync(asynctest.TestCase):
     async def test_parse_regex_insensitive(self):
         with OpsDroid() as opsdroid:
             regex = r"Hello .*"
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             mock_connector.respond = amock.CoroutineMock()
             skill = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex, case_sensitive=False)(skill))
@@ -299,7 +300,7 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.config["parsers"] = [{"name": "dialogflow"}]
             dialogflow_action = ""
             skill = amock.CoroutineMock()
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             match_dialogflow_action(dialogflow_action)(skill)
             message = Message("Hello world", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.dialogflow.parse_dialogflow'):
@@ -321,7 +322,7 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.config["parsers"] = [{"name": "luisai"}]
             luisai_intent = ""
             skill = amock.CoroutineMock()
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             match_luisai_intent(luisai_intent)(skill)
             message = Message("Hello world", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.luisai.parse_luisai'):
@@ -335,7 +336,7 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.config["parsers"] = [{"name": "rasanlu"}]
             rasanlu_intent = ""
             skill = amock.CoroutineMock()
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             match_rasanlu(rasanlu_intent)(skill)
             message = Message("Hello", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.rasanlu.parse_rasanlu'):
@@ -349,7 +350,7 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.config["parsers"] = [{"name": "recastai"}]
             recastai_intent = ""
             skill = amock.CoroutineMock()
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             match_recastai(recastai_intent)(skill)
             message = Message("Hello", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.recastai.parse_recastai'):
@@ -363,7 +364,7 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.config["parsers"] = [{"name": "witai"}]
             witai_intent = ""
             skill = amock.CoroutineMock()
-            mock_connector = Connector({})
+            mock_connector = Connector({}, opsdroid=opsdroid)
             match_witai(witai_intent)(skill)
             message = Message("Hello world", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.witai.parse_witai'):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -10,7 +10,8 @@ class TestMessage(asynctest.TestCase):
     """Test the opsdroid message class."""
 
     async def test_message(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         raw_message = {
             'text': 'Hello world',
             'user': 'user',
@@ -37,7 +38,8 @@ class TestMessage(asynctest.TestCase):
 
     async def test_response_effects(self):
         """Responding to a message shouldn't change the message."""
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message_text = "Hello world"
         message = Message(message_text, "user", "default", mock_connector)
         with self.assertRaises(NotImplementedError):
@@ -45,12 +47,13 @@ class TestMessage(asynctest.TestCase):
         self.assertEqual(message_text, message.text)
 
     async def test_thinking_delay(self):
+        opsdroid = amock.CoroutineMock()
         mock_connector = Connector({
             'name': 'shell',
             'thinking-delay': 3,
             'type': 'connector',
             'module_path': 'opsdroid-modules.connector.shell'
-        })
+        }, opsdroid=opsdroid)
 
         with amock.patch(
                 'opsdroid.message.Message._thinking_delay') as logmock:
@@ -61,12 +64,13 @@ class TestMessage(asynctest.TestCase):
             self.assertTrue(logmock.called)
 
     async def test_thinking_sleep(self):
+        opsdroid = amock.CoroutineMock()
         mock_connector_int = Connector({
             'name': 'shell',
             'thinking-delay': 3,
             'type': 'connector',
             'module_path': 'opsdroid-modules.connector.shell'
-        })
+        }, opsdroid=opsdroid)
 
         with amock.patch('asyncio.sleep') as mocksleep_int:
             message = Message("hi", "user", "default", mock_connector_int)
@@ -82,7 +86,7 @@ class TestMessage(asynctest.TestCase):
             'thinking-delay': [1, 4],
             'type': 'connector',
             'module_path': 'opsdroid-modules.connector.shell'
-        })
+        }, opsdroid=opsdroid)
 
         with amock.patch('asyncio.sleep') as mocksleep_list:
             message = Message("hi", "user", "default", mock_connector_list)
@@ -92,12 +96,13 @@ class TestMessage(asynctest.TestCase):
             self.assertTrue(mocksleep_list.called)
 
     async def test_typing_delay(self):
+        opsdroid = amock.CoroutineMock()
         mock_connector = Connector({
             'name': 'shell',
             'typing-delay': 0.3,
             'type': 'connector',
             'module_path': 'opsdroid-modules.connector.shell'
-        })
+        }, opsdroid=opsdroid)
         with amock.patch(
                 'opsdroid.message.Message._typing_delay') as logmock:
             with amock.patch('asyncio.sleep') as mocksleep:
@@ -115,7 +120,7 @@ class TestMessage(asynctest.TestCase):
             'typing-delay': [1, 4],
             'type': 'connector',
             'module_path': 'opsdroid-modules.connector.shell'
-        })
+        }, opsdroid=opsdroid)
 
         with amock.patch('asyncio.sleep') as mocksleep_list:
             message = Message("hi", "user", "default", mock_connector_list)
@@ -125,12 +130,13 @@ class TestMessage(asynctest.TestCase):
             self.assertTrue(mocksleep_list.called)
 
     async def test_typing_sleep(self):
+        opsdroid = amock.CoroutineMock()
         mock_connector = Connector({
             'name': 'shell',
             'typing-delay': 6,
             'type': 'connector',
             'module_path': 'opsdroid-modules.connector.shell'
-        })
+        }, opsdroid=opsdroid)
         with amock.patch('asyncio.sleep') as mocksleep:
             message = Message("hi", "user", "default", mock_connector)
             with self.assertRaises(NotImplementedError):
@@ -139,11 +145,12 @@ class TestMessage(asynctest.TestCase):
             self.assertTrue(mocksleep.called)
 
     async def test_react(self):
+        opsdroid = amock.CoroutineMock()
         mock_connector = Connector({
             'name': 'shell',
             'thinking-delay': 2,
             'type': 'connector',
-        })
+        }, opsdroid=opsdroid)
         with amock.patch('asyncio.sleep') as mocksleep:
             message = Message("Hello world", "user", "default", mock_connector)
             reacted = await message.react("emoji")

--- a/tests/test_parser_dialogflow.py
+++ b/tests/test_parser_dialogflow.py
@@ -32,7 +32,8 @@ class TestParserDialogflow(asynctest.TestCase):
         return mockedskill
 
     async def test_call_dialogflow(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("Hello world", "user", "default", mock_connector)
         config = {'name': 'dialogflow', 'access-token': 'test'}
         result = amock.Mock()

--- a/tests/test_parser_luisai.py
+++ b/tests/test_parser_luisai.py
@@ -32,7 +32,8 @@ class TestParserLuisai(asynctest.TestCase):
         return mockedskill
 
     async def test_call_luisai(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("schedule meeting", "user", "default",
                           mock_connector)
         config = {'name': 'luisai',

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -32,7 +32,8 @@ class TestParserRasaNLU(asynctest.TestCase):
         return mockedskill
 
     async def test_call_rasanlu(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("how's the weather outside", "user",
                           "default", mock_connector)
         config = {'name': 'rasanlu',
@@ -75,7 +76,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             self.assertTrue(patched_request.called)
 
     async def test_call_rasanlu_bad_response(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("how's the weather outside", "user",
                           "default", mock_connector)
         config = {'name': 'rasanlu', 'access-token': 'test', 'min-score': 0.3}
@@ -91,7 +93,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             self.assertEqual(response, result.text.return_value)
 
     async def test_call_rasanlu_raises(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("how's the weather outside", "user",
                           "default", mock_connector)
         config = {'name': 'rasanlu', 'access-token': 'test', 'min-score': 0.3}

--- a/tests/test_parser_recastai.py
+++ b/tests/test_parser_recastai.py
@@ -31,7 +31,8 @@ class TestParserRecastAi(asynctest.TestCase):
         return mockedskill
 
     async def test_call_recastai(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("Hello", "user", "default", mock_connector)
         config = {'name': 'recastai', 'access-token': 'test'}
         result = amock.Mock()

--- a/tests/test_parser_witai.py
+++ b/tests/test_parser_witai.py
@@ -31,7 +31,8 @@ class TestParserWitai(asynctest.TestCase):
         return mockedskill
 
     async def test_call_witai(self):
-        mock_connector = Connector({})
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("how's the weather outside", "user",
                           "default", mock_connector)
         config = {'name': 'witai', 'access-token': 'test', 'min-score': 0.3}


### PR DESCRIPTION
# Description

re: Issue #725 I refactored the `Connector` classes to take a pointer to the `OpsDroid` object at initialization, instead of when calling `Connector.connect()` and `.disconnect()`

Fixes #725 


## Status
**READY** 


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (possibly, although I changed the method docstrings along the way)


# How Has This Been Tested?

Passing all tests through Tox


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have updated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

