### PR TITLE
Cancel pending tasks

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -187,10 +187,9 @@ class OpsDroid():
 
         _LOGGER.info(_("Stopping pending tasks..."))
         tasks = asyncio.Task.all_tasks()
-        for task in tasks:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+        for task in list(tasks):
+            if not task.done() and task is not asyncio.Task.current_task():
+                task.cancel()
         _LOGGER.info(_("Stopped pending tasks"))
 
     async def reload(self):

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -185,6 +185,12 @@ class OpsDroid():
         self.cron_task = None
         _LOGGER.info(_("Stopped cron"))
 
+        _LOGGER.info(_("Stopping pending tasks..."))
+        tasks = asyncio.Task.all_tasks()
+        for task in tasks:
+            task.cancel()
+        _LOGGER.info(_("Stopped pending tasks"))
+
     async def reload(self):
         """Reload opsdroid."""
         await self.unload()

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -189,6 +189,8 @@ class OpsDroid():
         tasks = asyncio.Task.all_tasks()
         for task in tasks:
             task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
         _LOGGER.info(_("Stopped pending tasks"))
 
     async def reload(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -247,11 +247,14 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.cron_task.cancel = amock.CoroutineMock()
             mock_cron_task = opsdroid.cron_task
 
-            task = asyncio.Task(amock.CoroutineMock, loop=self.loop)
+            async def task():
+                await asyncio.sleep(.5)
+
+            t = asyncio.Task(task(), loop=self.loop)
 
             await opsdroid.unload()
 
-            self.assertTrue(task.cancel())
+            self.assertTrue(t.cancel())
             self.assertTrue(mock_connector.disconnect.called)
             self.assertTrue(mock_database.disconnect.called)
             self.assertTrue(mock_web_server.stop.called)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -247,8 +247,11 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.cron_task.cancel = amock.CoroutineMock()
             mock_cron_task = opsdroid.cron_task
 
+            task = asyncio.Task(amock.CoroutineMock, loop=self.loop)
+
             await opsdroid.unload()
 
+            self.assertTrue(task.cancel())
             self.assertTrue(mock_connector.disconnect.called)
             self.assertTrue(mock_database.disconnect.called)
             self.assertTrue(mock_web_server.stop.called)


### PR DESCRIPTION
# Description

This is not the right way that the issue 723 suggests we should approach this issue. But I was unsure how to get running tasks because `asyncio.Task.all_tasks` seems to return all tasks not only pending but also the ones that have been set as done or finished.

I tried to search how to get only the pending tasks but couldn't figure out the best way to do this, since I couldn't figure out I couldn't create a condition to make opsdroid sleep for `x` amount of seconds before cancelling the task.

This solution does cancel the task but I'm not sure if this is the best way to do things like I said before. Would like to get some more feedback on how to approach the issue in a better way 👍 

Fixes #723


## Status
~~**READY**~~ | ~~**UNDER DEVELOPMENT**~~ | **ON HOLD**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox passes
- Ran opsdroid, killed it and no exception was raised


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
