### PR TITLE
Update tests setup with config_lang

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -4,6 +4,7 @@ import asyncio
 import asynctest
 
 from opsdroid.connector import Connector
+from opsdroid.__main__ import configure_lang
 
 
 class TestConnectorBaseClass(unittest.TestCase):
@@ -11,6 +12,7 @@ class TestConnectorBaseClass(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        configure_lang({})
 
     def test_init(self):
         config = {"example_item": "test"}

--- a/tests/test_connector_facebook.py
+++ b/tests/test_connector_facebook.py
@@ -7,6 +7,7 @@ import asynctest.mock as amock
 from opsdroid.core import OpsDroid
 from opsdroid.connector.facebook import ConnectorFacebook
 from opsdroid.message import Message
+from opsdroid.__main__ import configure_lang
 
 
 class TestConnectorFacebook(unittest.TestCase):
@@ -14,6 +15,7 @@ class TestConnectorFacebook(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        configure_lang({})
 
     def test_init(self):
         connector = ConnectorFacebook({})

--- a/tests/test_connector_rocketchat.py
+++ b/tests/test_connector_rocketchat.py
@@ -8,6 +8,7 @@ import asynctest.mock as amock
 from opsdroid.core import OpsDroid
 from opsdroid.connector.rocketchat import RocketChat
 from opsdroid.message import Message
+from opsdroid.__main__ import configure_lang
 
 
 class TestRocketChat(unittest.TestCase):
@@ -15,6 +16,7 @@ class TestRocketChat(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        configure_lang({})
 
     def test_init(self):
         """Test that the connector is initialised properly."""

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -8,6 +8,7 @@ import asynctest.mock as amock
 
 from opsdroid.connector.slack import ConnectorSlack
 from opsdroid.message import Message
+from opsdroid.__main__ import configure_lang
 
 
 class TestConnectorSlack(unittest.TestCase):
@@ -15,6 +16,7 @@ class TestConnectorSlack(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        configure_lang({})
 
     def test_init(self):
         """Test that the connector is initialised properly."""

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -8,6 +8,7 @@ import asynctest.mock as amock
 from opsdroid.core import OpsDroid
 from opsdroid.connector.telegram import ConnectorTelegram
 from opsdroid.message import Message
+from opsdroid.__main__ import configure_lang
 
 
 class TestConnectorTelegram(unittest.TestCase):
@@ -15,6 +16,7 @@ class TestConnectorTelegram(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        configure_lang({})
 
     def test_init(self):
         """Test that the connector is initialised properly."""

--- a/tests/test_connector_websocket.py
+++ b/tests/test_connector_websocket.py
@@ -7,6 +7,7 @@ import asynctest.mock as amock
 from opsdroid.core import OpsDroid
 from opsdroid.connector.websocket import ConnectorWebsocket
 from opsdroid.message import Message
+from opsdroid.__main__ import configure_lang
 
 
 class TestConnectorWebsocket(unittest.TestCase):
@@ -14,6 +15,7 @@ class TestConnectorWebsocket(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        configure_lang({})
 
     def test_init(self):
         connector = ConnectorWebsocket({})

--- a/tests/test_database_sqlite.py
+++ b/tests/test_database_sqlite.py
@@ -10,6 +10,7 @@ import asynctest.mock as amock
 
 from opsdroid.database.sqlite import DatabaseSqlite, JSONEncoder, JSONDecoder
 from opsdroid.database.sqlite import register_json_type
+from opsdroid.__main__ import configure_lang
 
 
 class TestDatabaseSqlite(unittest.TestCase):
@@ -21,6 +22,7 @@ class TestDatabaseSqlite(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        configure_lang({})
 
     def test_init(self):
         """Test initialisation of database class.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@ import click
 from click.testing import CliRunner
 
 import opsdroid.__main__ as opsdroid
+from opsdroid.__main__ import configure_lang
 import opsdroid.web as web
 from opsdroid.const import __version__
 from opsdroid.core import OpsDroid
@@ -26,6 +27,7 @@ class TestMain(unittest.TestCase):
         self._tmp_dir = os.path.join(tempfile.gettempdir(), "opsdroid_tests")
         with contextlib.suppress(FileExistsError):
             os.makedirs(self._tmp_dir, mode=0o777)
+        configure_lang({})
 
     def tearDown(self):
         with contextlib.suppress(PermissionError):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -4,10 +4,14 @@ import asynctest.mock as amock
 
 from opsdroid.message import Message
 from opsdroid.connector import Connector
+from opsdroid.__main__ import configure_lang
 
 
 class TestMessage(asynctest.TestCase):
     """Test the opsdroid message class."""
+
+    async def setup(self):
+        configure_lang({})
 
     async def test_message(self):
         mock_connector = Connector({})


### PR DESCRIPTION
# Description

As discussed in gitter yesterday, the `config_lang({})` should be added to the tests setup in order to get them passing locally without using tox instead of getting an exception of NameError.

I tested this locally with pycharm and everything was working fine now 👍 


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Ran tests locally from within pycharm, all passed - no NameError exception raised



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

