### PR TITLE
Make it possible to create class-based skills

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -11,13 +11,15 @@ The constraint `constrain_rooms(rooms)` allows you to restrict a skill to a spec
 The following skill will respond with 'Hey' if a user says 'hi' in either the `#general` or `#random` rooms but not in `#public`.
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 from opsdroid.constraints import constrain_rooms
 
-@match_regex(r'hi')
-@constrain_rooms(['#general', '#random'])
-async def hello(opsdroid, config, message):
-    await message.respond('Hey')
+class MySkill(Skill):
+    @match_regex(r'hi')
+    @constrain_rooms(['#general', '#random'])
+    async def hello(self, message):
+        await message.respond('Hey')
 ```
 
 ## Constrain users
@@ -29,13 +31,15 @@ The constraint `constrain_users(users)` allows you to restrict a skill to a spec
 The following skill will respond with 'Hey' if the users `alice` or `bob` say 'hi' but not if `charlie` says it.
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 from opsdroid.constraints import constrain_users
 
-@match_regex(r'hi')
-@constrain_users(['alice', 'bob'])
-async def hello(opsdroid, config, message):
-    await message.respond('Hey')
+class MySkill(Skill):
+    @match_regex(r'hi')
+    @constrain_users(['alice', 'bob'])
+    async def hello(self, message):
+        await message.respond('Hey')
 ```
 
 ## Constrain connectors
@@ -47,11 +51,13 @@ The constraint `constrain_connectors(connectors)` allows you to restrict a skill
 The following skill will respond with 'Hey' via the `websocket` connector but not the `slack` connector.
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 from opsdroid.constraints import constrain_connectors
 
-@match_regex(r'hi')
-@constrain_connectors(['websocket'])
-async def hello(opsdroid, config, message):
-    await message.respond('Hey')
+class MySkill(Skill):
+    @match_regex(r'hi')
+    @constrain_connectors(['websocket'])
+    async def hello(self, message):
+        await message.respond('Hey')
 ```

--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -14,7 +14,7 @@ from opsdroid.matchers import match_regex
 
 class HelloSkill(Skill):
     @match_regex(r'hi')
-    async def hello(message):
+    async def hello(self, message):
         await message.respond('Hey')
 ```
 
@@ -78,13 +78,13 @@ from opsdroid.matchers import match_regex
 
 class RememberSkill(Skill):
     @match_regex(r'remember (.*)')
-    async def remember(message):
+    async def remember(self, message):
         remember = message.regex.group(1)
         await self.opsdroid.memory.put("remember", remember)
         await message.respond("OK I'll remember that")
 
     @match_regex(r'remind me')
-    async def remember(message):
+    async def remember(self, message):
         information = await self.opsdroid.memory.get("remember")
         await message.respond(information)
 ```

--- a/docs/matchers/always.md
+++ b/docs/matchers/always.md
@@ -13,9 +13,11 @@ When a message is parsed all skills are ranked by the parsers in order of how co
 ## Example
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_always
 
-@match_always
-async def keep_track(opsdroid, config, message):
-    # Put message.user into a database along with a timestamp
+class TrackingSkill(Skill):
+    @match_always
+    async def keep_track(self, message):
+        # Put message.user into a database along with a timestamp
 ```

--- a/docs/matchers/crontab.md
+++ b/docs/matchers/crontab.md
@@ -17,23 +17,25 @@ The crontab matcher is a bit different to other matchers. This matcher doesn't t
 ## Example
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_crontab
 from opsdroid.message import Message
 
-@match_crontab('* * * * *', timezone="Europe/London")
-async def mycrontabskill(opsdroid, config, message):
+class CrontabSkill(Skill):
+    @match_crontab('* * * * *', timezone="Europe/London")
+    async def mycrontabskill(self, message):
 
-    # Get the default connector
-    connector = opsdroid.default_connector
+        # Get the default connector
+        connector = opsdroid.default_connector
 
-    # Get the default room for that connector
-    room = connector.default_room
+        # Get the default room for that connector
+        room = connector.default_room
 
-    # Create an empty message to respond to
-    message = Message("", None, room, connector)
+        # Create an empty message to respond to
+        message = Message("", None, room, connector)
 
-    # Respond
-    await message.respond('Hey')
+        # Respond
+        await message.respond('Hey')
 ```
 
 The above skill would be called every minute. As the skill is being triggered by something other than a message the `message` argument being passed in will be set to `None`, this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_room` properties to get some sensible defaults.

--- a/docs/matchers/dialogflow.md
+++ b/docs/matchers/dialogflow.md
@@ -21,11 +21,13 @@ parsers:
 ## Example 1
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_dialogflow_action
 
-@match_dialogflow_action('mydomain.myaction')
-async def my_skill(opsdroid, config, message):
-    await message.respond('An appropriate response!')
+class MySkill(Skill):
+  @match_dialogflow_action('mydomain.myaction')
+  async def my_skill(self, message):
+      await message.respond('An appropriate response!')
 ```
 
 The above skill would be called on any intent which has an action of `'mydomain.myaction'`.
@@ -33,11 +35,13 @@ The above skill would be called on any intent which has an action of `'mydomain.
 ## Example 2
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_dialogflow_intent
 
-@match_dialogflow_intent('myIntent')
-async def my_skill(opsdroid, config, message):
-    await message.respond('An appropriate response!')
+class MySkill(Skill):
+  @match_dialogflow_intent('myIntent')
+  async def my_skill(self, message):
+      await message.respond('An appropriate response!')
 ```
 
 The above skill would be called on any intent which has a name of `'myIntent'`.
@@ -58,12 +62,13 @@ An http response object which has been returned by the Dialogflow API. This allo
 
 ```python
 import json
-
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_dialogflow_action
 
-@match_dialogflow_action('smalltalk.greetings')
-async def dump_response(opsdroid, config, message):
-    print(json.dumps(message.dialogflow))
+class MySkill(Skill):
+  @match_dialogflow_action('smalltalk.greetings')
+  async def dump_response(self, message):
+      print(json.dumps(message.dialogflow))
 ```
 
 This example skill will print the following on the message "whats up?".

--- a/docs/matchers/luis.ai.md
+++ b/docs/matchers/luis.ai.md
@@ -21,12 +21,14 @@ parsers:
 ## Example 1
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_luisai_intent
 
-@match_luisai_intent('Calendar.Add')
-async def passthrough(opsdroid, config, message):
-    if message.luisai["topScoringIntent"]["intent"]=="Calendar.Add":
-        await message.respond(str(message.luisai))
+class MySkill(Skill):
+   @match_luisai_intent('Calendar.Add')
+   async def passthrough(self, message):
+      if message.luisai["topScoringIntent"]["intent"]=="Calendar.Add":
+         await message.respond(str(message.luisai))
 ```
 
 The above skill would be called on any intent which has an action of `'Calendar.Add'`
@@ -46,12 +48,14 @@ _Note: "Each LUIS app has a unique app ID, and endpoint log." [Multi-language LU
 An http response object which has been returned by the luis.ai API. This allows you to access any information from the matched intent including the query, top scoring intent, intents etc.
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_luisai_intent
 
-@match_luisai_intent('Calendar.Add')
-async def passthrough(opsdroid, config, message):
-    if message.luisai["topScoringIntent"]["intent"]=="Calendar.Add":
-        await message.respond(str(message.luisai))
+class MySkill(Skill):
+   @match_luisai_intent('Calendar.Add')
+   async def passthrough(self, message):
+      if message.luisai["topScoringIntent"]["intent"]=="Calendar.Add":
+         await message.respond(str(message.luisai))
 ```
 
 This example skill will print the following on the message "schedule meeting"

--- a/docs/matchers/rasanlu.md
+++ b/docs/matchers/rasanlu.md
@@ -32,14 +32,16 @@ Rasa NLU is also trained via the API and so opsdroid can do the training for you
 
 Skill file (`__init__.py`).
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_rasanlu
 
-@match_rasanlu('greetings')
-async def hello(opsdroid, config, message):
-    """Replies to user when any 'greetings' 
-    intent is returned by Rasa NLU
-    """
-    await message.respond("Hello there!")
+class MySkill(Skill):
+    @match_rasanlu('greetings')
+    async def hello(self, message):
+        """Replies to user when any 'greetings'
+        intent is returned by Rasa NLU
+        """
+        await message.respond("Hello there!")
 ```
 
 Intents file (`intents.md`).
@@ -57,18 +59,20 @@ Intents file (`intents.md`).
 
 > **Note** - Rasa NLU requires an intent to have at least three training examples in the list. There must also be a minimum of two intents in your file for Rasa to train.
 
-The above skill would be called on any intent which has a name of `'greetings'`. 
+The above skill would be called on any intent which has a name of `'greetings'`.
 
 ## Example 2
 
 Skill file (`__init__.py`).
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_rasanlu
 
-@match_rasanlu('ask-joke')
-async def my_skill(opsdroid, config, message):
-    """Returns a joke if asked by the user"""
-    await message.respond('What do you call a bear with no teeth? -- A gummy bear!')
+class MySkill(Skill):
+    @match_rasanlu('ask-joke')
+    async def my_skill(self, message):
+        """Returns a joke if asked by the user"""
+        await message.respond('What do you call a bear with no teeth? -- A gummy bear!')
 ```
 
 Intents file (`intents.md`).
@@ -94,14 +98,15 @@ An http response object which has been returned by the Rasa NLU API. This allows
 ## Example Skill
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_rasanlu
 
 import json
 
-
-@match_rasanlu('restaurants')
-async def dumpResponse(opsdroid, config, message):
-    print(json.dumps(message.rasanlu))
+class MySkill(Skill):
+    @match_rasanlu('restaurants')
+    async def dumpResponse(self, message):
+        print(json.dumps(message.rasanlu))
 ```
 
 ### Return Value on "I am looking for a Mexican restaurant in the center of town"

--- a/docs/matchers/recast.ai.md
+++ b/docs/matchers/recast.ai.md
@@ -2,8 +2,8 @@
 
 ## Configuring opsdroid
 
-In order to enable Recast.AI skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file. 
-You can find this `access-token` in the settings of your bot under the name: `'Request access token'`. 
+In order to enable Recast.AI skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file.
+You can find this `access-token` in the settings of your bot under the name: `'Request access token'`.
 
 You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
 
@@ -22,27 +22,31 @@ parsers:
 ## [Example 1](#example1)
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_recastai
 
-@match_recastai('greetings')
-async def hello(opsdroid, config, message):
-    """Replies to user when any 'greetings' 
-    intent is returned by Recast.AI
-    """
-    await message.respond("Hello there!")
+class MySkill(Skill):
+    @match_recastai('greetings')
+    async def hello(self, message):
+        """Replies to user when any 'greetings'
+        intent is returned by Recast.AI
+        """
+        await message.respond("Hello there!")
 ```
 
-The above skill would be called on any intent which has a name of `'greetings'`. 
+The above skill would be called on any intent which has a name of `'greetings'`.
 
 ## Example 2
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_recastai
 
-@match_recastai('ask-joke')
-async def my_skill(opsdroid, config, message):
-    """Returns a joke if asked by the user"""
-    await message.respond('What do you call a bear with no teeth? -- A gummy bear!')
+class MySkill(Skill):
+    @match_recastai('ask-joke')
+    async def my_skill(self, message):
+        """Returns a joke if asked by the user"""
+        await message.respond('What do you call a bear with no teeth? -- A gummy bear!')
 ```
 
 The above skill would be called on any intent which has a name of `'ask-joke'`.
@@ -67,14 +71,15 @@ An http response object which has been returned by the Recast.AI API. This allow
 ## Example Skill
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_recastai
 
 import json
 
-
-@match_recastai('ask-feeling')
-async def dumpResponse(opsdroid, config, message):
-    print(json.dumps(message.recastai))
+class MySkill(Skill):
+    @match_recastai('ask-feeling')
+    async def dumpResponse(self, message):
+        print(json.dumps(message.recastai))
 ```
 
 ### Return Value on "How are you?"
@@ -83,36 +88,36 @@ The example skill will print the following on the message "how are you?".
 
 ```json
 {
-    "results": 
+    "results":
       {
-        "uuid": "cab86e23-caaf-4131-9b83-a564887203da", 
-        "source": "how are you?", 
+        "uuid": "cab86e23-caaf-4131-9b83-a564887203da",
+        "source": "how are you?",
         "intents": [
           {
-            "slug": "ask-feeling", 
-            "confidence": 0.99 
+            "slug": "ask-feeling",
+            "confidence": 0.99
            }
-        ], 
-        "act": "wh-query", 
-        "type": "desc:manner", 
-        "sentiment": "neutral", 
-        "entities": 
+        ],
+        "act": "wh-query",
+        "type": "desc:manner",
+        "sentiment": "neutral",
+        "entities":
           {
             "pronoun": [
               {
-                "person": 2, 
-                "number": "singular", 
-                "gender": "unknown", 
-                "raw": "you", 
+                "person": 2,
+                "number": "singular",
+                "gender": "unknown",
+                "raw": "you",
                 "confidence": 0.99
               }
             ]
-          }, 
-        "language": "en", 
-        "processing_language": "en", 
-        "version": "2.10.1", 
-        "timestamp": "2017-11-15T11:50:51.478057+00:00", 
-        "status": 200}, 
+          },
+        "language": "en",
+        "processing_language": "en",
+        "version": "2.10.1",
+        "timestamp": "2017-11-15T11:50:51.478057+00:00",
+        "status": 200},
         "message": "Requests rendered with success"
       }
 }

--- a/docs/matchers/webhook.md
+++ b/docs/matchers/webhook.md
@@ -16,20 +16,22 @@ Similar to the crontab matcher this matcher doesn't take a message as an input, 
 ```python
 from aiohttp.web import Request
 
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_webhook
 from opsdroid.message import Message
 
-@match_webhook('examplewebhook')
-async def mywebhookskill(opsdroid, config, message):
+class MySkill(Skill):
+    @match_webhook('examplewebhook')
+    async def mywebhookskill(self, message):
 
-    if type(message) is not Message and type(message) is Request:
-      # Capture the request POST data and set message to a default message
-      request = await message.post()
-      message = Message("", None, connector.default_room,
-                        opsdroid.default_connector)
+        if type(message) is not Message and type(message) is Request:
+          # Capture the request POST data and set message to a default message
+          request = await message.post()
+          message = Message("", None, self.opsdroid.connector.default_room,
+                            self.opsdroid.default_connector)
 
-    # Respond
-    await message.respond('Hey')
+        # Respond
+        await message.respond('Hey')
 ```
 
 ## Custom Responses
@@ -39,19 +41,21 @@ You can also return a custom `Response` object from your skill if you need to gi
 ```python
 from aiohttp.web import Request, Response
 
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_webhook
 from opsdroid.message import Message
 
-@match_webhook('examplewebhook')
-async def mywebhookskill(opsdroid, config, message):
+class MySkill(Skill):
+    @match_webhook('examplewebhook')
+    async def mywebhookskill(self, message):
 
-    if type(message) is not Message and type(message) is Request:
-      # Capture the request POST data and set message to a default message
-      request = await message.post()
-      message = Message("", None, connector.default_room,
-                        opsdroid.default_connector)
+        if type(message) is not Message and type(message) is Request:
+          # Capture the request POST data and set message to a default message
+          request = await message.post()
+          message = Message("", None, self.opsdroid.connector.default_room,
+                            self.opsdroid.default_connector)
 
-    # Respond
-    await message.respond('Hey')
-    return Response(body='my custom response', status=201)
+        # Respond
+        await message.respond('Hey')
+        return Response(body='my custom response', status=201)
 ```

--- a/docs/matchers/webhook.md
+++ b/docs/matchers/webhook.md
@@ -9,8 +9,6 @@ skills:
 
 The above skill would be called if you send a POST to `http://localhost:8080/skill/exampleskill/examplewebhook`. As the skill is being triggered by a webhook the `message` argument being passed in will be set to the [aiohttp Request](http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.BaseRequest), this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_room` properties to get some sensible defaults.
 
-##
-
 Similar to the crontab matcher this matcher doesn't take a message as an input, it takes a webhook instead. It allows you to trigger the skill by calling a specific URL endpoint.
 
 ## Example
@@ -22,7 +20,7 @@ from opsdroid.matchers import match_webhook
 from opsdroid.message import Message
 
 @match_webhook('examplewebhook')
-async def mycrontabskill(opsdroid, config, message):
+async def mywebhookskill(opsdroid, config, message):
 
     if type(message) is not Message and type(message) is Request:
       # Capture the request POST data and set message to a default message
@@ -34,3 +32,26 @@ async def mycrontabskill(opsdroid, config, message):
     await message.respond('Hey')
 ```
 
+## Custom Responses
+
+You can also return a custom `Response` object from your skill if you need to given a certain body or status code back to the service that called the webhook. If you do not do this then opsdroid will respond with a 200 by default and a json body of `{"called_skill": "<webhook name>"}`.
+
+```python
+from aiohttp.web import Request, Response
+
+from opsdroid.matchers import match_webhook
+from opsdroid.message import Message
+
+@match_webhook('examplewebhook')
+async def mywebhookskill(opsdroid, config, message):
+
+    if type(message) is not Message and type(message) is Request:
+      # Capture the request POST data and set message to a default message
+      request = await message.post()
+      message = Message("", None, connector.default_room,
+                        opsdroid.default_connector)
+
+    # Respond
+    await message.respond('Hey')
+    return Response(body='my custom response', status=201)
+```

--- a/docs/matchers/wit.ai.md
+++ b/docs/matchers/wit.ai.md
@@ -2,8 +2,8 @@
 
 ## Configuring opsdroid
 
-In order to enable wit.ai skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file. 
-You can find this `access-token` in the settings of your App under the name: `'Server Access Token: '`. 
+In order to enable wit.ai skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file.
+You can find this `access-token` in the settings of your App under the name: `'Server Access Token: '`.
 
 You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
 
@@ -22,21 +22,23 @@ parsers:
 ## [Example 1](#example1)
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_witai
 
-@match_witai('get_weather')
-async def weather(opsdroid, config, message):
-    """Hard Coded version of weather function"""
-    temp = 10
-    humidity = "80%"
-    city = message.witai['entities']['location'][0]['value']
-    status = "Clouds"
+class MySkill(Skill):
+    @match_witai('get_weather')
+    async def weather(self, message):
+        """Hard Coded version of weather function"""
+        temp = 10
+        humidity = "80%"
+        city = message.witai['entities']['location'][0]['value']
+        status = "Clouds"
 
-    await message.respond("It's currently {} degrees, {}% humidity in {} and {} is forecasted "
-                          "for today".format(temp, humidity, city, status))
+        await message.respond("It's currently {} degrees, {}% humidity in {} and {} is forecasted "
+                              "for today".format(temp, humidity, city, status))
 ```
 
-The above skill would be called on any intent which has a name of `'get_weather'`. 
+The above skill would be called on any intent which has a name of `'get_weather'`.
 
 #### Usage example
 
@@ -61,14 +63,15 @@ An http response object which has been returned by the wit.ai API. This allows y
 ## Example Skill
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_witai
 
 import json
 
-
-@match_witai('get_weather')
-async def dumpResponse(opsdroid, config, message):
-    print(json.dumps(message.witai))
+class MySkill(Skill):
+    @match_witai('get_weather')
+    async def dumpResponse(self, message):
+        print(json.dumps(message.witai))
 ```
 
 ### Return Value on "How's the weather?"
@@ -77,15 +80,15 @@ The example skill will print the following on the message "how's the weather?".
 
 ```json
 {
-  "msg_id": "0zTl3L16kFW4PwtSt", 
-  "_text": "how's the weather", 
+  "msg_id": "0zTl3L16kFW4PwtSt",
+  "_text": "how's the weather",
   "entities": {
      "intent": [
        {
-         "confidence": 0.77586417870417, 
+         "confidence": 0.77586417870417,
          "value": "get_weather"
-       } 
-     ]    
+       }
+     ]
   }
 }
 ```
@@ -96,20 +99,20 @@ The example skill will print the following on the message "What's the weather li
 
 ```json
 {
-   "msg_id": "0zrCQ5LEkWd0MoHYM", 
-   "_text": "What's the weather like in London?", 
+   "msg_id": "0zrCQ5LEkWd0MoHYM",
+   "_text": "What's the weather like in London?",
    "entities": {
       "location": [
         {
-          "suggested": true, 
-          "confidence": 0.74044071131585, 
-          "value": "London", 
+          "suggested": true,
+          "confidence": 0.74044071131585,
+          "value": "London",
           "type": "value"
         }
-      ], 
+      ],
       "intent": [
         {
-          "confidence": 0.99979499373014, 
+          "confidence": 0.99979499373014,
           "value": "get_weather"
         }
       ]
@@ -118,7 +121,7 @@ The example skill will print the following on the message "What's the weather li
 
 ```
 
-Since Wit.ai can recognise locations, you can use this values on your skills to return different things. 
+Since Wit.ai can recognise locations, you can use this values on your skills to return different things.
 On our weather skill([example 1](#example1)) we changed the city param to get the temperature related to any city passed on the message.
 
 

--- a/docs/tutorials/basic-skill.md
+++ b/docs/tutorials/basic-skill.md
@@ -14,9 +14,17 @@ Opsdroid skills are located inside a folder with the name `skill-<skillname>`. I
 You will write all of your python functions in the `__init__.py` file, but you can also include any other helpful files inside your skill folder.
 
 ## Building the Skill
-We are now ready to start writing the 'how are you' skill. We will be using opsdroid regex matcher to write our function. The first thing to do inside our `__ini__.py` will be importing the matcher.
+We are now ready to start writing the 'how are you' skill. We will be using opsdroid regex matcher to write our function. The first thing to do inside our `__init__.py` will be importing the `Skill` class from opsdroid to inherit from.
+
+#### Importing the skill class
+
+```python
+from opsdroid.skill import Skill
+```
 
 #### Importing Regex Matcher
+
+We also need a matcher to use to connect a method of our skill class to a phrase or sentence that the user will say.
 
 ```python
 from opsdroid.matchers import match_regex
@@ -28,9 +36,12 @@ All the matchers available in opsdroid can be imported from `opsdroid.matchers`.
 A matcher is meant to be used as a function decorator. The decorator allows opsdroid to understand the function, so we need to use this decorator and use the regex, that we wish opsdroid to react to.
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 
-@match_regex('how are you?')
+class MySkill(Skill):
+
+    @match_regex('how are you?')
 ```
 
 The [regex matcher](/matchers/regex.md) takes a regular expression and searches for it on every message sent by a user. So if the user types `how are you?` opsdroid will trigger the function underneath the `match_regex` decorator.
@@ -38,31 +49,37 @@ The [regex matcher](/matchers/regex.md) takes a regular expression and searches 
 _Note: Opsdroid won't trigger with the text `how are you` because the question mark is missing._
 
 #### Functions
-Skills in opsdroid are just Python Functions. As seen before, a decorator and a function together will allow opsdroid to do pretty much everything that you can imagine.
+Skills in opsdroid are just Python methods on a class. As seen before, a decorator and a method together will allow opsdroid to do pretty much everything that you can imagine.
 
 Let's write our function, so opsdroid knows what to trigger when a user writes the words `how are you?`
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 
-@match_regex('how are you?')
-async def how_are_you(opsdroid, config, message):
-    pass
+class MySkill(Skill):
+
+    @match_regex('how are you?')
+    async def how_are_you(self, message):
+        pass
 ```
 
 Opsdroid is build with asyncio. That means every function that you wish opsdroid to react to, should be an asynchronous function.
 
-_Note: that every function will take these three parameters: `opsdroid`, `config` and `message`._
+_Note: that every function will take these two parameters: `self`, `message`._
 
 #### Opsdroid Answer
 So far our opsdroid can match something that a user said and can trigger a skill. But nothing will happen yet, let's make opsdroid answer to the text, with a message of its own.
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 
-@match_regex('how are you?')
-async def how_are_you(opsdroid, config, message):
-    await message.respond('Good thanks! My load average is 0.2, 0.1, 0.1.')
+class MySkill(Skill):
+
+    @match_regex('how are you?')
+    async def how_are_you(self, message):
+        await message.respond('Good thanks! My load average is 0.2, 0.1, 0.1.')
 ```
 
 Our skill is done and opsdroid will be able to answer like in the [Opsdroid main page](https://opsdroid.github.io). The next thing that is left to do is to add the skill to the opsdroid configuration file.

--- a/docs/tutorials/create-weather-skill.md
+++ b/docs/tutorials/create-weather-skill.md
@@ -14,12 +14,12 @@ Our `__init__.py` init file will contain two functions, one that interacts with 
 ## Building the Skill
 We are ready to start working on our skill. First, you need to create a folder for the weather skill. Choose a location and name it weather-skill.
 
-Now, let's open opsdroid `configuration.yaml` file and add our weather skill to the skills section. 
+Now, let's open opsdroid `configuration.yaml` file and add our weather skill to the skills section.
 
 ```yaml
 skills:
   - name: weather
-    city: < Your city, your country >     # For accuracy use {city},{country code}          
+    city: < Your city, your country >     # For accuracy use {city},{country code}
     units: < metric/imperial >       # Choose metric/imperial
     api-key: < Your Api Key >
     # Developing the skill
@@ -31,9 +31,10 @@ _Note: We will need to set `no-cache` to true, in order to tell opsdroid to inst
 #### Weather Skill
 Now that our skill has all the configuration details set up in the `configuration.yaml` file, let's create the `__init__.py` inside our weather-skill folder and start working on the skill.
 
-The first thing we need to do, is to import the regex_matcher from opsdroid and the aiohttp module. Your `__init__.py` file should look like this:
+The first thing we need to do, is to import the skill class and the regex_matcher from opsdroid and the aiohttp module. Your `__init__.py` file should look like this:
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 
 import aiohttp
@@ -47,6 +48,7 @@ If you read the [current weather data](https://openweathermap.org/current) docum
 Make your `__init__.py` file look like this:
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 
 import aiohttp
@@ -54,14 +56,14 @@ import aiohttp
 
 async def get_weather(config):
     api_url = "http://api.openweathermap.org/data/2.5/weather?q="
-``` 
+```
 
 We will need to pass the following things to OpenWeatherMap:
 - City
 - Units
 - API-key
 
-Since these details are already in our opsdroid `configuration.yaml` we can simply get them from the config. 
+Since these details are already in our opsdroid `configuration.yaml` we can simply get them from the config.
 
 Make your function look like this:
 
@@ -80,7 +82,7 @@ async def get_weather(config):
     api_url = "http://api.openweathermap.org/data/2.5/weather?q="
     parameters = "{}&units={}&appid={}".format(
         config['city'], config['units'], config['api-key'])
-    
+
     async with aiohttp.ClientSession() as session:
         response = await session.get(api_url + parameters)
 ```
@@ -94,62 +96,62 @@ async def get_weather(config):
     api_url = "http://api.openweathermap.org/data/2.5/weather?q="
     parameters = "{}&units={}&appid={}".format(
         config['city'], config['units'], config['api-key'])
-    
+
     async with aiohttp.ClientSession() as session:
         response = await session.get(api_url + parameters)
     return response.json()
 ```
-Now when we call our `get_weather` function, aiohttp will get all the data from the OpenWeatherMap API and return it to us in a json format. 
+Now when we call our `get_weather` function, aiohttp will get all the data from the OpenWeatherMap API and return it to us in a json format.
 
 `response.json()` will give us something that looks like this:
 
 ```json
 {
-     'coord': 
+     'coord':
          {
-             'lon': -0.13, 
+             'lon': -0.13,
              'lat': 51.51
-         }, 
-     'weather': 
+         },
+     'weather':
          [
              {
-                 'id': 800, 
-                 'main': 'Clear', 
-                 'description': 'clear sky', 
+                 'id': 800,
+                 'main': 'Clear',
+                 'description': 'clear sky',
                  'icon': '01n'
              }
-         ], 
-     'base': 'stations', 
-     'main': 
+         ],
+     'base': 'stations',
+     'main':
          {
-             'temp': 3.37, 
-             'pressure': 1022, 
-             'humidity': 86, 
-             'temp_min': 2, 
+             'temp': 3.37,
+             'pressure': 1022,
+             'humidity': 86,
+             'temp_min': 2,
              'temp_max': 5
-         }, 
-     'visibility': 10000, 
-     'wind': 
+         },
+     'visibility': 10000,
+     'wind':
          {
-             'speed': 2.1, 
+             'speed': 2.1,
              'deg': 310
-         }, 
-     'clouds': 
+         },
+     'clouds':
          {
              'all': 0
-         }, 
-     'dt': 1511076000, 
-     'sys': 
+         },
+     'dt': 1511076000,
+     'sys':
          {
-             'type': 1, 
-             'id': 5089, 
-             'message': 0.1668, 
-             'country': 'GB', 
-             'sunrise': 1511076308, 
+             'type': 1,
+             'id': 5089,
+             'message': 0.1668,
+             'country': 'GB',
+             'sunrise': 1511076308,
              'sunset': 1511107601
-         }, 
-     'id': 2639545, 
-     'name': 'London', 
+         },
+     'id': 2639545,
+     'name': 'London',
      'cod': 200
  }
 ```
@@ -157,7 +159,7 @@ Now when we call our `get_weather` function, aiohttp will get all the data from 
 
 That's all we need to do. Now if we call our function we will be able to get our weather data. The next step is to make opsdroid tell us the current weather.
 
-#### Tell the Weather 
+#### Tell the Weather
 This skill is quite easy to understand and it will simply call our `get_weather` function and then get the details from our weather data.
 
 We also need to decorate the skill with our chosen matcher (regex in this case).
@@ -165,6 +167,7 @@ We also need to decorate the skill with our chosen matcher (regex in this case).
 Make your `__init__.py` file look like this:
 
 ```python
+from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
 
 import aiohttp
@@ -174,23 +177,27 @@ async def get_weather(config):
     api_url = "http://api.openweathermap.org/data/2.5/weather?q="
     parameters = "{}&units={}&appid={}".format(
         config['city'], config['units'], config['api-key'])
-    
+
     async with aiohttp.ClientSession() as session:
         response = await session.get(api_url + parameters)
     return response.json()
-    
 
-@match_regex()
-async def tell_weather(opsdroid, config, message):
-    pass
+
+class MySkill(Skill):
+
+    @match_regex()
+    async def tell_weather(self, message):
+        pass
 ```
 
 We need to chose what should trigger opsdroid to tell us the weather. Let's make opsdroid trigger when we type `How's the weather`.
 
 ```python
-@match_regex("How's the weather?")
-async def tell_weather(opsdroid, config, message):
-    pass
+class MySkill(Skill):
+
+    @match_regex("How's the weather?")
+    async def tell_weather(self, message):
+        pass
 ```
 
 Now that we have a way to trigger the skill we will use our `get_weather` function to get the weather data. For the sake of readability, we will create some variables to hold some of the weather data as well.
@@ -198,26 +205,64 @@ Now that we have a way to trigger the skill we will use our `get_weather` functi
 Make your function look like this:
 
 ```python
-async def tell_weather(opsdroid, config, message):
-    weather_data = await get_weather(config)
-    temp = weather_data['main']['temp']
-    humidity = weather_data['main']['humidity']
-    city = weather_data['name']
+class MySkill(Skill):
+
+    @match_regex("How's the weather?")
+    async def tell_weather(self, message):
+        weather_data = await get_weather(self.config)
+        temp = weather_data['main']['temp']
+        humidity = weather_data['main']['humidity']
+        city = weather_data['name']
 ```
 
-What's left to do is to make opsdroid say the temperature in your city. We can do that by calling `message.respond()` 
+What's left to do is to make opsdroid say the temperature in your city. We can do that by calling `message.respond()`
 
 Change `tell_weather` function to the following:
 
 ```python
-async def tell_weather(opsdroid, config, message):
-    weather_data = await get_weather(config)
-    temp = weather_data['main']['temp']
-    humidity = weather_data['main']['humidity']
-    city = weather_data['name']
-    
-    await message.respond("It's {} and {}% humidity in {}.".format(temp, humidity, city))
+class MySkill(Skill):
+
+    @match_regex("How's the weather?")
+    async def tell_weather(self, message):
+        weather_data = await get_weather(self.config)
+        temp = weather_data['main']['temp']
+        humidity = weather_data['main']['humidity']
+        city = weather_data['name']
+
+        await message.respond("It's {} and {}% humidity in {}.".format(temp, humidity, city))
 ```
 
-Now every time you type `How's the weather` opsdroid will tell you the current weather. Hopefully this tutorial was helpful to you.
+Now every time you type `How's the weather` opsdroid will tell you the current weather.
+
+Finally we could move our `get_weather` function into the skill class as a private method, which would allow us to not have to pass the config through as an argument. This would leave us with a final skill that looks like this.
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
+
+import aiohttp
+
+
+class MySkill(Skill):
+
+    async def _get_weather(self):
+        api_url = "http://api.openweathermap.org/data/2.5/weather?q="
+        parameters = "{}&units={}&appid={}".format(
+            self.config['city'], self.config['units'], self.config['api-key'])
+
+        async with aiohttp.ClientSession() as session:
+            response = await session.get(api_url + parameters)
+        return response.json()
+
+    @match_regex("How's the weather?")
+    async def tell_weather(self, message):
+        weather_data = await self._get_weather()
+        temp = weather_data['main']['temp']
+        humidity = weather_data['main']['humidity']
+        city = weather_data['name']
+
+        await message.respond("It's {} and {}% humidity in {}.".format(temp, humidity, city))
+```
+
+Hopefully this tutorial was helpful to you.
 

--- a/docs/tutorials/create-weather-skill.md
+++ b/docs/tutorials/create-weather-skill.md
@@ -183,7 +183,7 @@ async def get_weather(config):
     return response.json()
 
 
-class MySkill(Skill):
+class WeatherSkill(Skill):
 
     @match_regex()
     async def tell_weather(self, message):
@@ -193,7 +193,7 @@ class MySkill(Skill):
 We need to chose what should trigger opsdroid to tell us the weather. Let's make opsdroid trigger when we type `How's the weather`.
 
 ```python
-class MySkill(Skill):
+class WeatherSkill(Skill):
 
     @match_regex("How's the weather?")
     async def tell_weather(self, message):
@@ -205,7 +205,7 @@ Now that we have a way to trigger the skill we will use our `get_weather` functi
 Make your function look like this:
 
 ```python
-class MySkill(Skill):
+class WeatherSkill(Skill):
 
     @match_regex("How's the weather?")
     async def tell_weather(self, message):
@@ -220,7 +220,7 @@ What's left to do is to make opsdroid say the temperature in your city. We can d
 Change `tell_weather` function to the following:
 
 ```python
-class MySkill(Skill):
+class WeatherSkill(Skill):
 
     @match_regex("How's the weather?")
     async def tell_weather(self, message):
@@ -243,7 +243,7 @@ from opsdroid.matchers import match_regex
 import aiohttp
 
 
-class MySkill(Skill):
+class WeatherSkill(Skill):
 
     async def _get_weather(self):
         api_url = "http://api.openweathermap.org/data/2.5/weather?q="

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -215,14 +215,18 @@ class OpsDroid():
         """
         for skill in skills:
             for func in skill["module"].__dict__.values():
-                if isinstance(func, type) and issubclass(func, Skill) and func != Skill:
+                if (isinstance(func, type) and
+                        issubclass(func, Skill) and
+                        func != Skill):
                     skill_obj = func(self, skill['config'])
 
                     for name in skill_obj.__dir__():
-                        # pylint: disable=broad-except Getting an attribute of an object might
-                        # raise any type of exceptions, for example within an external library
-                        # called from an object property.  Since we are only interested in skill
-                        # methods, we can safely ignore these.
+                        # pylint: disable=broad-except
+                        # Getting an attribute of
+                        # an object might raise any type of exceptions, for
+                        # example within an external library called from an
+                        # object property.  Since we are only interested in
+                        # skill methods, we can safely ignore these.
                         try:
                             method = getattr(skill_obj, name)
                         except Exception:

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -249,7 +249,7 @@ class Loader:
         try:
             with open(config_path, 'r') as stream:
                 _LOGGER.info(_("Loaded config from %s."), config_path)
-                return yaml.load(stream)
+                return yaml.load(stream, Loader=yaml.SafeLoader)
         except yaml.YAMLError as error:
             _LOGGER.critical(error)
             sys.exit(1)

--- a/opsdroid/skill/__init__.py
+++ b/opsdroid/skill/__init__.py
@@ -1,5 +1,4 @@
-"""Base class for class-based skills
-"""
+"""Base class for class-based skills."""
 from functools import wraps
 
 
@@ -12,18 +11,32 @@ def _skill_decorator(func):
 
     return decorated_skill
 
+
 class Skill:
+    """A skill prototype to use when creating classy skills."""
+
+    # pylint: disable=too-few-public-methods
     def __init__(self, opsdroid, config, *args, **kwargs):
+        """Create the skill.
+
+        Set some basic properties from the skill.
+
+        Args:
+            opsdroid (OpsDroid): The running opsdroid instance pointer.
+            config (dict): The config for this database specified in the
+                           `configuration.yaml` file.
+        """
         super(Skill, self).__init__()
 
         self.opsdroid = opsdroid
         self.config = config
 
         for name in self.__dir__():
-            # pylint: disable=broad-except Getting an attribute of an object might raise any type
-            # of exceptions, for example within an external library called from an object
-            # property.  Since we are only interested in skill methods, we can safely ignore
-            # these.
+            # pylint: disable=broad-except
+            # Getting an attribute of an object
+            # might raise any type of exceptions, for example within an
+            # external library called from an object  property.  Since we are
+            # only interested in skill methods, we can safely ignore these.
             try:
                 method = getattr(self, name)
             except Exception:

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -127,7 +127,9 @@ class Web:
             _LOGGER.info(_("Running skill %s via webhook"), webhook)
             opsdroid.stats["webhooks_called"] = \
                 opsdroid.stats["webhooks_called"] + 1
-            await skill(opsdroid, config, req)
+            resp = await skill(opsdroid, config, req)
+            if isinstance(resp, web.Response):
+                return resp
             return Web.build_response(200, {"called_skill": webhook})
 
         self.web_app.router.add_post(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.5.1
 aioslacker==0.0.11
 aiosqlite==0.8.1
 asyncio_redis==0.15.1
-arrow==0.12.1
+arrow==0.13.0
 Babel==2.6.0
 click==7.0
 emoji==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ emoji==0.5.1
 nbconvert==5.4.0
 nbformat==4.4.0
 pycron==1.0.0
-pyyaml==3.13
+pyyaml==4.2b1
 websockets==7.0
 appdirs==1.4.3
 multidict==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.5.1
+aiohttp==3.5.2
 aioslacker==0.0.11
 aiosqlite==0.8.1
 asyncio_redis==0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.5.3
+aiohttp==3.5.4
 aioslacker==0.0.11
 aiosqlite==0.8.1
 asyncio_redis==0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.5.2
+aiohttp==3.5.3
 aioslacker==0.0.11
 aiosqlite==0.8.1
 asyncio_redis==0.15.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ Jinja2==2.10
 Pygments==2.3.1
 docutils==0.14
 mock==2.0.0
-pillow==5.3.0
+pillow==5.4.1
 alabaster==0.7.12
 commonmark==0.8.1
 recommonmark==0.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,5 +6,5 @@ mock==2.0.0
 pillow==5.4.1
 alabaster==0.7.12
 commonmark==0.8.1
-recommonmark==0.4.0
+recommonmark==0.5.0
 mkdocs==1.0.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@ flake8==3.6.0
 pylint==2.2.2
 coveralls==1.5.1
 astroid==2.1.0
-pytest==4.0.2
+pytest==4.1.0
 pytest-cov==2.6.1
 pytest-timeout==1.3.3
 pydocstyle==3.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@ pylint==2.2.2
 coveralls==1.5.1
 astroid==2.1.0
 pytest==4.0.2
-pytest-cov==2.6.0
+pytest-cov==2.6.1
 pytest-timeout==1.3.3
 pydocstyle==3.0.0
 asynctest==0.12.2

--- a/tests/mockmodules/skills/skill/skilltest/__init__.py
+++ b/tests/mockmodules/skills/skill/skilltest/__init__.py
@@ -8,7 +8,7 @@ class TestSkill(Skill):
     """A mocked skill."""
 
     @match_regex("test")
-    def test_method(self, opsdroid, config, message):
+    def test_method(self, message):
         """A test method skill."""
         pass
 

--- a/tests/mockmodules/skills/skill/skilltest/__init__.py
+++ b/tests/mockmodules/skills/skill/skilltest/__init__.py
@@ -1,9 +1,18 @@
 """A mocked skill."""
 
 from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
 
 
 class TestSkill(Skill):
     """A mocked skill."""
 
-    pass
+    @match_regex("test")
+    def test_method(self, opsdroid, config, message):
+        """A test method skill."""
+        pass
+
+    @property
+    def bad_property(self):
+        """Bad property which raises exceptions."""
+        raise Exception

--- a/tests/mockmodules/skills/skill/skilltest/__init__.py
+++ b/tests/mockmodules/skills/skill/skilltest/__init__.py
@@ -1,5 +1,9 @@
+"""A mocked skill."""
+
 from opsdroid.skill import Skill
 
 
 class TestSkill(Skill):
+    """A mocked skill."""
+
     pass

--- a/tests/mockmodules/skills/temp_skill.py
+++ b/tests/mockmodules/skills/temp_skill.py
@@ -1,5 +1,9 @@
+"""A mocked skill."""
+
 from opsdroid.skill import Skill
 
 
 class TestSkill(Skill):
+    """A mocked skill."""
+
     pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -169,16 +169,23 @@ class TestCore(unittest.TestCase):
 
     def test_setup_modules(self):
         with OpsDroid() as opsdroid:
-            example_modules = []
+
             mockskill = lambda x: x * 2
             mockskill.skill = True
             mockmodule = mock.Mock(setup=mock.MagicMock(), mockskill=mockskill)
-            example_modules.append({"module": mockmodule, "config": {}})
+            example_modules = [{"module": mockmodule, "config": {}}]
             opsdroid.setup_skills(example_modules)
             self.assertEqual(len(mockmodule.setup.mock_calls), 1)
             self.assertEqual(mockmodule.method_calls[0][0], 'setup')
             self.assertEqual(len(mockmodule.method_calls[0][1]), 2)
             self.assertEqual(mockmodule.method_calls[0][1][1], {})
+            self.assertEqual(len(opsdroid.skills), 2)
+
+            mockclassmodule = importlib.import_module(
+                "tests.mockmodules.skills.skill.skilltest")
+            example_modules = [{"module": mockclassmodule, "config": {}}]
+            opsdroid.setup_skills(example_modules)
+            self.assertEqual(len(opsdroid.skills), 3)
 
     def test_default_connector(self):
         with OpsDroid() as opsdroid:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,4 @@
-
+import sys
 import os
 import shutil
 import subprocess
@@ -9,6 +9,7 @@ import unittest.mock as mock
 from types import ModuleType
 
 import pkg_resources
+from yaml import YAMLError
 from opsdroid.__main__ import configure_lang
 from opsdroid import loader as ld
 from opsdroid.loader import Loader
@@ -44,6 +45,24 @@ class TestLoader(unittest.TestCase):
         config = loader.load_config_file(
             [os.path.abspath("tests/configs/minimal_2.yaml")])
         self.assertIsNotNone(config)
+
+    def test_load_exploit(self):
+        """This will test if you can run python code from
+        config.yaml. The expected result should be:
+        - Yaml.YAMLError exception raised
+        - _LOGGER.critical message
+        - sys.exit
+
+        Note: the unittest.main(exit=False) is important so
+        other tests won't fail when sys.exit is called.
+        """
+        opsdroid, loader = self.setup()
+        with self.assertRaises(SystemExit):
+            config = loader.load_config_file(
+                [os.path.abspath("tests/configs/include_exploit.yaml")])
+            self.assertLogs('_LOGGER', 'critical')
+            self.assertRaises(YAMLError)
+            unittest.main(exit=False)
 
     def test_load_config_file_with_include(self):
         opsdroid, loader = self.setup()

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -49,4 +49,4 @@ class TestSkill(unittest.TestCase):
         message = Mock()
         skill.hello_skill(message)
 
-        message.respond.assert_called_once()
+        self.assertTrue(message.respond.called_once)


### PR DESCRIPTION
# Description

Make it possible to create class-based skills.  This can be very useful when the skill needs a helper object, like an SDK for an external API.


## Status
**UNDER DEVELOPMENT**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


# How Has This Been Tested?

I created a very basic skill class for initial testing, but generic tests are still yet to come.

```python
from opsdroid.matchers import match_regex
from opsdroid.skill import Skill


class TestSkill(Skill):
    @match_regex(r'number [0-9]')
    async def describe_project(self, opsdroid, config, message):
        await message.respond('Yes, that’s a number.')
```


# Checklist:

- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

