### PR TITLE
Fix a typo in the skills documentation

### DIFF
--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -106,7 +106,7 @@ async def remember(opsdroid, config, message):
     await message.respond(information)
 ```
 
-In the above example we have defined two skill functions. The first takes whatever the user says after the work "remember" and stores it in the database.
+In the above example we have defined two skill functions. The first takes whatever the user says after the word "remember" and stores it in the database.
 
 The second retrieves and prints out that text when the user says "remind me".
 


### PR DESCRIPTION
# Description

Fix a typo (“work” instead of “word”) in the skills documentation.

## Status
**READY**


## Type of change

- Documentation (fix or adds documentation)


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

