### PR TITLE
Fix the signature of Database.disconnect

### DIFF
--- a/opsdroid/database/__init__.py
+++ b/opsdroid/database/__init__.py
@@ -40,7 +40,7 @@ class Database():
         """
         raise NotImplementedError
 
-    async def disconnect(self):
+    async def disconnect(self, opsdroid):
         """Disconnect from the database.
 
         This method should disconnect from the given database using a native

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -26,7 +26,7 @@ class TestDatabaseBaseClassAsync(asynctest.TestCase):
     async def test_disconnect(self):
         database = Database({})
         try:
-            await database.disconnect()
+            await database.disconnect(None)
         except NotImplementedError:
             self.fail("disconnect() raised NotImplementedError unexpectedly!")
 


### PR DESCRIPTION
# Description

`Database.disconnect()` is called with `opsdroid` as an argument, but the method signature doesn’t allow this.

Fixes #732

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
