### PR TITLE
Add reactions to slack connector

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ aiosqlite==0.8.0
 arrow==0.12.1
 Babel==2.6.0
 click==7.0
+emoji==0.5.1
 nbconvert==5.4.0
 nbformat==4.4.0
 pycron==1.0.0

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -196,6 +196,30 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         await connector.respond(Message("test", "user", "room", connector))
         self.assertTrue(connector.slacker.chat.post_message.called)
 
+    async def test_react(self):
+        connector = ConnectorSlack({"api-token": "abc123"})
+        connector.slacker.reactions.post = amock.CoroutineMock()
+        await connector.react(Message("test", "user", "room", connector, {'ts': 0}), "😀")
+        self.assertTrue(connector.slacker.reactions.post)
+        self.assertEqual(
+            connector.slacker.reactions.post.call_args[1]['data']['name'],
+            ':grinning_face:')
+
+    async def test_react_invalid_name(self):
+        import slacker
+        connector = ConnectorSlack({"api-token": "abc123"})
+        connector.slacker.reactions.post = amock.CoroutineMock(side_effect=slacker.Error('invalid_name'))
+        with amock.patch('opsdroid.connector.slack._LOGGER.warning',) as logmock:
+            await connector.react(Message("test", "user", "room", connector, {'ts': 0}), "😀")
+        self.assertTrue(logmock.called)
+
+    async def test_react_unknown_error(self):
+        import slacker
+        connector = ConnectorSlack({"api-token": "abc123"})
+        connector.slacker.reactions.post = amock.CoroutineMock(side_effect=slacker.Error('unknown'))
+        with self.assertRaises(slacker.Error):
+            await connector.react(Message("test", "user", "room", connector, {'ts': 0}), "😀")
+
     async def test_reconnect(self):
         connector = ConnectorSlack({"api-token": "abc123"})
         connector.connect = amock.CoroutineMock()


### PR DESCRIPTION
# Description

The slack connector doesn't support the `react` method yet. This PR adds that functionality.


## Status
**READY**


## Type of change

_Please delete options that are not relevant._

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Manually tested with Slack and [this skill gist](https://gist.github.com/jacobtomlinson/f55c536c42671799815793e89893ca1d).


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

