### PR TITLE
Add basic constraints

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -1,0 +1,57 @@
+# Constraints
+
+As well as matchers opsdroid also has constraints. There are decorators for your functions which prevent the skill from being called even if it is matched by a matcher.
+
+## Constrain rooms
+
+The constraint `constrain_rooms(rooms)` allows you restrict a skill to a specific set of rooms in your chat client.
+
+### Example
+
+The following skill will respond with 'Hey' if a user says 'hi' in either the `#general` or `#random` rooms but not in `#public`.
+
+```python
+from opsdroid.matchers import match_regex
+from opsdroid.constraints import constrain_rooms
+
+@match_regex(r'hi')
+@constrain_rooms(['#general', '#random'])
+async def hello(opsdroid, config, message):
+    await message.respond('Hey')
+```
+
+## Constrain users
+
+The constraint `constrain_users(users)` allows you restrict a skill to a specific set of users in your chat client.
+
+### Example
+
+The following skill will respond with 'Hey' if the users `alice` or `bob` say 'hi' but not if `charlie` says it.
+
+```python
+from opsdroid.matchers import match_regex
+from opsdroid.constraints import constrain_users
+
+@match_regex(r'hi')
+@constrain_users(['alice', 'bob'])
+async def hello(opsdroid, config, message):
+    await message.respond('Hey')
+```
+
+## Constrain connectors
+
+The constraint `constrain_connectors(connectors)` allows you restrict a skill to a specific connector. Useful if you are configuring opsdroid with more than one connector.
+
+### Example
+
+The following skill will respond with 'Hey' via the `websocket` connector but not the `slack` connector.
+
+```python
+from opsdroid.matchers import match_regex
+from opsdroid.constraints import constrain_connectors
+
+@match_regex(r'hi')
+@constrain_connectors(['websocket'])
+async def hello(opsdroid, config, message):
+    await message.respond('Hey')
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ pages:
       - 'Crontab': 'matchers/crontab.md'
       - 'Webhook': 'matchers/webhook.md'
       - 'Always': 'matchers/always.md'
+  - 'Constraints': 'constraints.md'
   - 'Contributing': 'contributing.md'
   - 'Releasing': 'project/making-a-release.md'
   - 'Maintainers': 'maintainers.md'

--- a/opsdroid/constraints.py
+++ b/opsdroid/constraints.py
@@ -1,0 +1,53 @@
+"""Decorator functions to use when creating skill modules.
+
+These decorators are for specifying when a skill should not be called despite
+having a matcher which matches the current message.
+"""
+
+import logging
+
+from opsdroid.helper import add_skill_attributes
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def constrain_rooms(rooms):
+    """Return room constraint decorator."""
+    def constraint_decorator(func):
+        """Add room constraint to skill."""
+        def constraint_callback(message, rooms=rooms):
+            """Check if the room is correct."""
+            return message.room in rooms
+        func = add_skill_attributes(func)
+        func.constraints.append(constraint_callback)
+        return func
+    return constraint_decorator
+
+
+def constrain_users(users):
+    """Return user constraint decorator."""
+    def constraint_decorator(func):
+        """Add user constraint to skill."""
+        def constraint_callback(message, users=users):
+            """Check if the user is correct."""
+            return message.user in users
+        func = add_skill_attributes(func)
+        func.constraints.append(constraint_callback)
+        return func
+    return constraint_decorator
+
+
+def constrain_connectors(connectors):
+    """Return connector constraint decorator."""
+    def constraint_decorator(func):
+        """Add connectors constraint to skill."""
+        def constraint_callback(message, connectors=connectors):
+            """Check if the connectors is correct."""
+            print(message.connector.name)
+            print(connectors)
+            return message.connector.name in connectors
+        func = add_skill_attributes(func)
+        func.constraints.append(constraint_callback)
+        return func
+    return constraint_decorator

--- a/opsdroid/helper.py
+++ b/opsdroid/helper.py
@@ -129,3 +129,22 @@ def extract_gist_id(gist_string):
 
     """
     return gist_string.split("/")[-1]
+
+
+def add_skill_attributes(func):
+    """Add the attributes which makes a function a skill.
+
+    Args:
+        func (func): Skill function.
+
+    Returns:
+        func: The skill function with the new attributes.
+
+    """
+    if not hasattr(func, 'skill'):
+        func.skill = True
+    if not hasattr(func, 'matchers'):
+        func.matchers = []
+    if not hasattr(func, 'constraints'):
+        func.constraints = []
+    return func

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -3,18 +3,10 @@
 import logging
 
 from opsdroid.const import REGEX_SCORE_FACTOR
+from opsdroid.helper import add_skill_attributes
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def add_skill_attributes(func):
-    """Add the attributes which makes a function a skill."""
-    if not hasattr(func, 'skill'):
-        func.skill = True
-    if not hasattr(func, 'matchers'):
-        func.matchers = []
-    return func
 
 
 def match_regex(regex, case_sensitive=True, score_factor=None):

--- a/opsdroid/parsers/dialogflow.py
+++ b/opsdroid/parsers/dialogflow.py
@@ -35,7 +35,7 @@ async def call_dialogflow(message, config, lang=DEFAULT_LANGUAGE):
         return result
 
 
-async def parse_dialogflow(opsdroid, message, config):
+async def parse_dialogflow(opsdroid, skills, message, config):
     """Parse a message against all Dialogflow skills."""
     matched_skills = []
     if 'access-token' in config:
@@ -61,7 +61,7 @@ async def parse_dialogflow(opsdroid, message, config):
 
         if result:
 
-            for skill in opsdroid.skills:
+            for skill in skills:
                 for matcher in skill.matchers:
 
                     if "dialogflow_action" in matcher or \

--- a/opsdroid/parsers/luisai.py
+++ b/opsdroid/parsers/luisai.py
@@ -29,7 +29,7 @@ async def call_luisai(message, config):
         return result
 
 
-async def parse_luisai(opsdroid, message, config):
+async def parse_luisai(opsdroid, skills, message, config):
     """Parse a message against all luisai skills."""
     matched_skills = []
     if 'appid' in config and 'appkey' in config:
@@ -55,7 +55,7 @@ async def parse_luisai(opsdroid, message, config):
                 _LOGGER.debug(_("luis.ai score lower than min-score"))
                 return matched_skills
 
-            for skill in opsdroid.skills:
+            for skill in skills:
                 for matcher in skill.matchers:
                     if "luisai_intent" in matcher:
                         try:

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -151,7 +151,7 @@ async def call_rasanlu(text, config):
         return result
 
 
-async def parse_rasanlu(opsdroid, message, config):
+async def parse_rasanlu(opsdroid, skills, message, config):
     """Parse a message against all Rasa NLU skills."""
     matched_skills = []
     try:
@@ -176,7 +176,7 @@ async def parse_rasanlu(opsdroid, message, config):
         return matched_skills
 
     if result:
-        for skill in opsdroid.skills:
+        for skill in skills:
             for matcher in skill.matchers:
                 if "rasanlu_intent" in matcher:
                     if matcher['rasanlu_intent'] == result['intent']['name']:

--- a/opsdroid/parsers/recastai.py
+++ b/opsdroid/parsers/recastai.py
@@ -31,7 +31,7 @@ async def call_recastai(message, config, lang=DEFAULT_LANGUAGE):
         return result
 
 
-async def parse_recastai(opsdroid, message, config):
+async def parse_recastai(opsdroid, skills, message, config):
     """Parse a message against all recastai intents."""
     matched_skills = []
     if 'access-token' in config:
@@ -60,7 +60,7 @@ async def parse_recastai(opsdroid, message, config):
             return matched_skills
 
         if result:
-            for skill in opsdroid.skills:
+            for skill in skills:
                 for matcher in skill.matchers:
                     if "recastai_intent" in matcher:
                         if (matcher["recastai_intent"] in

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -13,10 +13,10 @@ async def calculate_score(regex, score_factor):
     return (1 - (1 / ((len(regex) + 1) ** 2))) * score_factor
 
 
-async def parse_regex(opsdroid, message):
+async def parse_regex(opsdroid, skills, message):
     """Parse a message against all regex skills."""
     matched_skills = []
-    for skill in opsdroid.skills:
+    for skill in skills:
         for matcher in skill.matchers:
             if "regex" in matcher:
                 opts = matcher["regex"]

--- a/opsdroid/parsers/witai.py
+++ b/opsdroid/parsers/witai.py
@@ -28,7 +28,7 @@ async def call_witai(message, config):
         return result
 
 
-async def parse_witai(opsdroid, message, config):
+async def parse_witai(opsdroid, skills, message, config):
     """Parse a message against all witai skills."""
     matched_skills = []
     if 'access-token' in config:
@@ -57,7 +57,7 @@ async def parse_witai(opsdroid, message, config):
             return matched_skills
 
         if result:
-            for skill in opsdroid.skills:
+            for skill in skills:
                 for matcher in skill.matchers:
                     if "witai_intent" in matcher:
                         if (matcher['witai_intent'] in

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,105 @@
+
+import asynctest
+import asynctest.mock as mock
+
+from opsdroid.__main__ import configure_lang
+from opsdroid.core import OpsDroid
+from opsdroid.message import Message
+from opsdroid.matchers import match_regex
+from opsdroid import constraints
+
+
+class TestConstraints(asynctest.TestCase):
+    """Test the opsdroid constraint decorators."""
+
+    async def setUp(self):
+        configure_lang({})
+
+    async def getMockSkill(self):
+        async def mockedskill(opsdroid, config, message):
+            pass
+        mockedskill.config = {}
+        return mockedskill
+
+    async def test_constrain_rooms_constrains(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.eventloop = mock.CoroutineMock()
+            skill = await self.getMockSkill()
+            skill = match_regex(r'.*')(skill)
+            skill = constraints.constrain_rooms(['#general'])(skill)
+            opsdroid.skills.append(skill)
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'user', '#random', None)
+            )
+            self.assertEqual(len(tasks), 1) # Just match_always
+
+    async def test_constrain_rooms_skips(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.eventloop = mock.CoroutineMock()
+            skill = await self.getMockSkill()
+            skill = match_regex(r'.*')(skill)
+            skill = constraints.constrain_rooms(['#general'])(skill)
+            opsdroid.skills.append(skill)
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'user', '#general', None)
+            )
+            self.assertEqual(len(tasks), 2) # match_always and the skill
+
+
+    async def test_constrain_users_constrains(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.eventloop = mock.CoroutineMock()
+            skill = await self.getMockSkill()
+            skill = match_regex(r'.*')(skill)
+            skill = constraints.constrain_users(['user'])(skill)
+            opsdroid.skills.append(skill)
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'otheruser', '#general', None)
+            )
+            self.assertEqual(len(tasks), 1) # Just match_always
+
+    async def test_constrain_users_skips(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.eventloop = mock.CoroutineMock()
+            skill = await self.getMockSkill()
+            skill = match_regex(r'.*')(skill)
+            skill = constraints.constrain_users(['user'])(skill)
+            opsdroid.skills.append(skill)
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'user', '#general', None)
+            )
+            self.assertEqual(len(tasks), 2) # match_always and the skill
+
+    async def test_constrain_connectors_constrains(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.eventloop = mock.CoroutineMock()
+            skill = await self.getMockSkill()
+            skill = match_regex(r'.*')(skill)
+            skill = constraints.constrain_connectors(['slack'])(skill)
+            opsdroid.skills.append(skill)
+            connector = mock.Mock()
+            connector.configure_mock(name='twitter')
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'user', '#random', connector)
+            )
+            self.assertEqual(len(tasks), 1) # Just match_always
+
+    async def test_constrain_connectors_skips(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.eventloop = mock.CoroutineMock()
+            skill = await self.getMockSkill()
+            skill = match_regex(r'.*')(skill)
+            skill = constraints.constrain_connectors(['slack'])(skill)
+            opsdroid.skills.append(skill)
+            connector = mock.Mock()
+            connector.configure_mock(name='slack')
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'user', '#general', connector)
+            )
+            self.assertEqual(len(tasks), 2) # match_always and the skill

--- a/tests/test_parser_dialogflow.py
+++ b/tests/test_parser_dialogflow.py
@@ -81,7 +81,7 @@ class TestParserDialogflow(asynctest.TestCase):
                         }
                     }
                 skills = await dialogflow.parse_dialogflow(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
     async def test_parse_dialogflow_raises(self):
@@ -112,7 +112,7 @@ class TestParserDialogflow(asynctest.TestCase):
                         }
                     }
                 skills = await dialogflow.parse_dialogflow(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
             with amock.patch('opsdroid.core._LOGGER.exception') as logmock:
@@ -144,7 +144,7 @@ class TestParserDialogflow(asynctest.TestCase):
                         }
                     }
                 skills = await dialogflow.parse_dialogflow(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertFalse(skills)
 
     async def test_parse_dialogflow_low_score(self):
@@ -175,7 +175,7 @@ class TestParserDialogflow(asynctest.TestCase):
                         }
                     }
                 await dialogflow.parse_dialogflow(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
 
@@ -197,7 +197,7 @@ class TestParserDialogflow(asynctest.TestCase):
                     as mocked_call:
                 mocked_call.side_effect = ClientOSError()
                 await dialogflow.parse_dialogflow(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
             self.assertTrue(mocked_call.called)

--- a/tests/test_parser_luisai.py
+++ b/tests/test_parser_luisai.py
@@ -96,7 +96,7 @@ class TestParserLuisai(asynctest.TestCase):
                         "entities": []
                     }
                 skills = await luisai.parse_luisai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
     async def test_parse_luisai_nointents(self):
@@ -128,7 +128,7 @@ class TestParserLuisai(asynctest.TestCase):
                         "entities": []
                     }
                 skills = await luisai.parse_luisai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertFalse(skills)
 
     async def test_parse_luisai_raises(self):
@@ -167,7 +167,7 @@ class TestParserLuisai(asynctest.TestCase):
                         "entities": []
                     }
                 skills = await luisai.parse_luisai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
             with amock.patch('opsdroid.core._LOGGER.exception') as logmock:
@@ -196,7 +196,7 @@ class TestParserLuisai(asynctest.TestCase):
                         "statusCode": 401
                     }
                 skills = await luisai.parse_luisai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertFalse(skills)
 
     async def test_parse_luisai_low_score(self):
@@ -231,7 +231,7 @@ class TestParserLuisai(asynctest.TestCase):
                         ],
                         "entities": []
                     }
-                await luisai.parse_luisai(opsdroid, message,
+                await luisai.parse_luisai(opsdroid, opsdroid.skills, message,
                                           opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
@@ -255,7 +255,7 @@ class TestParserLuisai(asynctest.TestCase):
             with amock.patch.object(luisai, 'call_luisai') as \
                     mocked_call:
                 mocked_call.side_effect = ClientOSError()
-                await luisai.parse_luisai(opsdroid, message,
+                await luisai.parse_luisai(opsdroid, opsdroid.skills, message,
                                           opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -147,7 +147,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                     "text": "how's the weather outside"
                 }
                 skills = await rasanlu.parse_rasanlu(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
     async def test_parse_rasanlu_raises(self):
@@ -195,7 +195,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                     "text": "how's the weather outside"
                 }
                 skills = await rasanlu.parse_rasanlu(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
             with amock.patch('opsdroid.core._LOGGER.exception') as logmock:
@@ -219,7 +219,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                     as mocked_call_rasanlu:
                 mocked_call_rasanlu.return_value = "unauthorized"
                 skills = await rasanlu.parse_rasanlu(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertFalse(skills)
 
     async def test_parse_rasanlu_low_score(self):
@@ -262,7 +262,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                     ],
                     "text": "how's the weather outside"
                 }
-                await rasanlu.parse_rasanlu(opsdroid, message,
+                await rasanlu.parse_rasanlu(opsdroid, opsdroid.skills, message,
                                             opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
@@ -287,7 +287,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                     "intent_ranking": [],
                     "text": "hi"
                 }
-                await rasanlu.parse_rasanlu(opsdroid, message,
+                await rasanlu.parse_rasanlu(opsdroid, opsdroid.skills, message,
                                             opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
@@ -312,7 +312,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                     "intent_ranking": [],
                     "text": "hi"
                 }
-                await rasanlu.parse_rasanlu(opsdroid, message,
+                await rasanlu.parse_rasanlu(opsdroid, opsdroid.skills, message,
                                             opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
@@ -331,7 +331,7 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             with amock.patch.object(rasanlu, 'call_rasanlu') as mocked_call:
                 mocked_call.side_effect = ClientOSError()
-                await rasanlu.parse_rasanlu(opsdroid, message,
+                await rasanlu.parse_rasanlu(opsdroid, opsdroid.skills, message,
                                             opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)

--- a/tests/test_parser_recastai.py
+++ b/tests/test_parser_recastai.py
@@ -104,7 +104,7 @@ class TestParserRecastAi(asynctest.TestCase):
                         }
                 }
                 skills = await recastai.parse_recastai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
     async def test_parse_recastai_raises(self):
@@ -148,7 +148,7 @@ class TestParserRecastAi(asynctest.TestCase):
                 }
 
                 skills = await recastai.parse_recastai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
             with amock.patch('opsdroid.core._LOGGER.exception') as logmock:
@@ -177,7 +177,7 @@ class TestParserRecastAi(asynctest.TestCase):
                     'message': 'Text is empty'
                 }
                 skills = await recastai.parse_recastai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertFalse(skills)
 
     async def test_parse_recastai_no_intent(self):
@@ -218,7 +218,7 @@ class TestParserRecastAi(asynctest.TestCase):
                 with amock.patch(
                         'opsdroid.parsers.recastai._LOGGER.error') as logmock:
                     skills = await recastai.parse_recastai(
-                        opsdroid, message, opsdroid.config['parsers'][0])
+                        opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                     self.assertTrue(logmock.called)
                     self.assertFalse(skills)
 
@@ -265,7 +265,7 @@ class TestParserRecastAi(asynctest.TestCase):
                         }
                 }
                 await recastai.parse_recastai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
 
     async def test_parse_recastai_raise_ClientOSError(self):
         with OpsDroid() as opsdroid:
@@ -288,6 +288,6 @@ class TestParserRecastAi(asynctest.TestCase):
                     as mocked_call:
                 mocked_call.side_effect = ClientOSError()
                 await recastai.parse_recastai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
 
             self.assertTrue(mocked_call.called)

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -35,7 +35,7 @@ class TestParserRegex(asynctest.TestCase):
             mock_connector = amock.CoroutineMock()
             message = Message("Hello world", "user", "default", mock_connector)
 
-            skills = await parse_regex(opsdroid, message)
+            skills = await parse_regex(opsdroid, opsdroid.skills, message)
             self.assertEqual(mock_skill, skills[0]["skill"])
 
     async def test_parse_regex_priority(self):
@@ -51,7 +51,7 @@ class TestParserRegex(asynctest.TestCase):
             mock_connector = amock.CoroutineMock()
             message = Message("Hello world", "user", "default", mock_connector)
 
-            skills = await opsdroid.get_ranked_skills(message)
+            skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
             self.assertEqual(mock_skill_high, skills[0]["skill"])
 
     async def test_parse_regex_raises(self):
@@ -66,5 +66,5 @@ class TestParserRegex(asynctest.TestCase):
             message = Message("Hello world", "user",
                               "default", mock_connector)
 
-            skills = await parse_regex(opsdroid, message)
+            skills = await parse_regex(opsdroid, opsdroid.skills, message)
             self.assertEqual(mock_skill, skills[0]["skill"])

--- a/tests/test_parser_witai.py
+++ b/tests/test_parser_witai.py
@@ -79,7 +79,7 @@ class TestParserWitai(asynctest.TestCase):
                         ]
                     }}
                 skills = await witai.parse_witai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
     async def test_parse_witai_raises(self):
@@ -111,7 +111,7 @@ class TestParserWitai(asynctest.TestCase):
                         ]
                     }}
                 skills = await witai.parse_witai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]['skill'])
 
 
@@ -138,7 +138,7 @@ class TestParserWitai(asynctest.TestCase):
                     "error": "missing or wrong auth token"
                     }
                 skills = await witai.parse_witai(
-                    opsdroid, message, opsdroid.config['parsers'][0])
+                    opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertFalse(skills)
 
     async def test_parse_witai_low_score(self):
@@ -165,7 +165,7 @@ class TestParserWitai(asynctest.TestCase):
                             }
                         ]
                     }}
-                await witai.parse_witai(opsdroid, message,
+                await witai.parse_witai(opsdroid, opsdroid.skills, message,
                                         opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
@@ -187,7 +187,7 @@ class TestParserWitai(asynctest.TestCase):
                     'msg_id': '0MDw4dxgcoIyBZeVx',
                     '_text': "hi",
                     'entities': {}}
-                await witai.parse_witai(opsdroid, message,
+                await witai.parse_witai(opsdroid, opsdroid.skills, message,
                                         opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
@@ -215,7 +215,7 @@ class TestParserWitai(asynctest.TestCase):
                             }
                         ]
                     }}
-                await witai.parse_witai(opsdroid, message,
+                await witai.parse_witai(opsdroid, opsdroid.skills, message,
                                         opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)
@@ -234,7 +234,7 @@ class TestParserWitai(asynctest.TestCase):
 
             with amock.patch.object(witai, 'call_witai') as mocked_call:
                 mocked_call.side_effect = ClientOSError()
-                await witai.parse_witai(opsdroid, message,
+                await witai.parse_witai(opsdroid, opsdroid.skills, message,
                                         opsdroid.config['parsers'][0])
 
             self.assertFalse(mock_skill.called)


### PR DESCRIPTION
# Description

This PR adds some constraint decorators for use when writing skills. These allow you to restrict when skills are run even if they are matched. The initial constraints I've added are `constrain_rooms`, `constrain_users` and `constrain_connectors` which allow you to restrict a skill to a set of rooms, users or connectors respectively.

This is the precursor to adding context for #156.

## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Added new tests and run locally.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

