### PR TITLE
Removing a line of dead code in the tests

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -541,8 +541,7 @@ class TestLoader(unittest.TestCase):
                   "repo": "https://github.com/rmccue/test-repository.git",
                   "branch": "master"}
         os.mkdir(config["install_path"])
-        with mock.patch('opsdroid.loader._LOGGER.debug'), \
-                mock.patch.object(loader, 'git_pull') as mockpull:
+        with mock.patch.object(loader, 'git_pull') as mockpull:
             loader._update_module(config)
             mockpull.assert_called_with(config["install_path"])
 


### PR DESCRIPTION
# Description

`mock.patch('opsdroid.loader._LOGGER.debug')` generates a logger mock which is not really used for anything. Cleaning it up.

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Ran Tox tests locally. All passing.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

