### PR TITLE
fix slack error on connect

### DIFF
--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -63,7 +63,7 @@ class ConnectorSlack(Connector):
             _LOGGER.error("Failed to connect to Slack, retrying in 10")
             await self.reconnect(10)
         except Exception:
-            await self.slacker.close()
+            await self.disconnect()
             raise
 
     async def reconnect(self, delay=None):
@@ -75,6 +75,10 @@ class ConnectorSlack(Connector):
             await self.connect()
         finally:
             self.reconnecting = False
+
+    async def disconnect(self, opsdroid=None):
+        """Disconnect from Slack."""
+        await self.slacker.close()
 
     async def listen(self, opsdroid):
         """Listen for and parse new messages."""

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -62,6 +62,9 @@ class ConnectorSlack(Connector):
             _LOGGER.error(error)
             _LOGGER.error("Failed to connect to Slack, retrying in 10")
             await self.reconnect(10)
+        except Exception:
+            await self.slacker.close()
+            raise
 
     async def reconnect(self, delay=None):
         """Reconnect to the websocket."""

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -78,6 +78,16 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         await connector.connect()
         self.assertTrue(connector.reconnect.called)
 
+    async def test_abort_on_connection_error(self):
+        connector = ConnectorSlack({"api-token": "abc123"})
+        connector.slacker.rtm.start = amock.CoroutineMock()
+        connector.slacker.rtm.start.side_effect = Exception()
+        connector.slacker.close = amock.CoroutineMock()
+
+        with self.assertRaises(Exception):
+            await connector.connect()
+        self.assertTrue(connector.slacker.close.called)
+
     async def test_listen_loop(self):
         """Test that listening consumes from the socket."""
         connector = ConnectorSlack({"api-token": "abc123"})


### PR DESCRIPTION
# Description

When the slack client has an error on connecting, the `close` method on slacker is never called, leading to a very long string of tracebacks reporting that `open` is undefined and `_` cannot be found.  The actual issue is hidden several thousand lines at the top.

This PR fixes this.

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally: try starting opsdroid with an invalid token for Slack, for example.  Before this change, it spews out a thousand lines of tracebacks; after this change, it prints the error and shuts down cleanly.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

