### PR TITLE
load module from pythonpath

### DIFF
--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -1,7 +1,7 @@
 # Skills
 
-Skills are modules which define what actions opsdroid should perform based on different chat messages. They can be referenced in your `configuration.yaml`, [Config](../configuration-reference.md#config-file) file.
-Skills can be specified from opsdroid github repository, your own github, or from local path.
+Skills are modules which define what actions opsdroid should perform based on different chat messages. They can be referenced in your `configuration.yaml` [Config](../configuration-reference.md#config-file) file.
+Skills can be specified from the opsdroid github repository, your own github, from the local path, or imported directly from your PYTHONPATH.
 
 
 ```yaml
@@ -15,6 +15,9 @@ skills:
   ## From custom repository
   - name: mygithubskill
     path: https://github.com/me/mygithubskill.git
+  ## From PYTHONPATH
+  - name: myimportedskill
+    module: 'my.imported.skill'
   ## Hello world (https://github.com/opsdroid/skill-hello)
   - name: hello
 ```

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -241,6 +241,7 @@ class TestLoader(unittest.TestCase):
         config["module_path"] = "os"
         config["name"] = "path"
         config["type"] = "system"
+        config["module"] = ""
 
         module = ld.Loader.import_module(config)
         self.assertIsInstance(module, ModuleType)
@@ -250,6 +251,7 @@ class TestLoader(unittest.TestCase):
         config["module_path"] = "os"
         config["name"] = ""
         config["type"] = "system"
+        config["module"] = ""
 
         module = ld.Loader.import_module(config)
         self.assertIsInstance(module, ModuleType)
@@ -259,9 +261,21 @@ class TestLoader(unittest.TestCase):
         config["module_path"] = "nonexistant"
         config["name"] = "module"
         config["type"] = "broken"
+        config["module"] = ""
 
         module = ld.Loader.import_module(config)
         self.assertEqual(module, None)
+
+    def test_import_module_from_path(self):
+        config = {}
+        config["module_path"] = ""
+        config["name"] = "module"
+        config["type"] = ""
+        config["module"] = "os.path"
+
+        module = ld.Loader.import_module(config)
+        self.assertIsInstance(module, ModuleType)
+
 
     def test_load_config(self):
         opsdroid, loader = self.setup()


### PR DESCRIPTION
# Description

This allows users to specify a skill module to import from your PYTHONPATH, by adding the "module" key to their configuration.yaml.

Fixes #661 

## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

Added new tests, and tested locally.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

