### PR TITLE
setuptools entry points support for loading contributed extensions (issue #767)

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -5,7 +5,6 @@ import importlib.util
 import json
 import logging
 import os
-import pkg_resources
 import re
 import shutil
 import subprocess
@@ -13,7 +12,7 @@ import sys
 import tempfile
 import urllib.request
 from collections.abc import Mapping
-
+from pkg_resources import iter_entry_points
 import yaml
 
 from opsdroid.helper import (
@@ -57,7 +56,8 @@ class Loader:
         # 4. try to import the module_path itself
 
         if config.get("entrypoint"):
-            _LOGGER.debug("Loading entry point-defined module for %s" % config["name"])
+            _LOGGER.debug(_("Loading entry point-defined module for %s"),
+                          config["name"])
             return config["entrypoint"].load()
 
         module_spec = None
@@ -311,11 +311,13 @@ class Loader:
             os.makedirs(DEFAULT_MODULE_DEPS_PATH)
         sys.path.append(DEFAULT_MODULE_DEPS_PATH)
 
-        # entry point group naming scheme: opsdroid_ + module type plural, eg. "opsdroid_databases"
+        # entry point group naming scheme: opsdroid_ + module type plural,
+        # eg. "opsdroid_databases"
         epname = "opsdroid_%ss" % modules_type
-        entry_points = {ep.name: ep for ep in pkg_resources.iter_entry_points(group=epname)}
+        entry_points = {ep.name: ep for ep in iter_entry_points(group=epname)}
         for epname in entry_points:
-            _LOGGER.debug("Found installed external package for %s '%s' support" % (modules_type, epname))
+            _LOGGER.debug(_("Found installed package for %s '%s' support"),
+                          modules_type, epname)
 
         for module in modules:
 
@@ -343,7 +345,9 @@ class Loader:
 
             # If the module isn't builtin, or isn't already on the
             # python path, install it
-            if not (config["is_builtin"] or config["module"] or config.get("entrypoint")):
+            if not (config["is_builtin"]
+                    or config["module"]
+                    or config.get("entrypoint")):
                 # Remove module for reinstall if no-cache set
                 self.check_cache(config)
 

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -55,7 +55,7 @@ class Loader:
         # 3. try to import a module with the given name in the module_path
         # 4. try to import the module_path itself
 
-        if config.get("entrypoint"):
+        if config["entrypoint"]:
             _LOGGER.debug(_("Loading entry point-defined module for %s"),
                           config["name"])
             return config["entrypoint"].load()
@@ -313,7 +313,7 @@ class Loader:
 
         # entry point group naming scheme: opsdroid_ + module type plural,
         # eg. "opsdroid_databases"
-        epname = "opsdroid_%ss" % modules_type
+        epname = "opsdroid_{}s".format(modules_type)
         entry_points = {ep.name: ep for ep in iter_entry_points(group=epname)}
         for epname in entry_points:
             _LOGGER.debug(_("Found installed package for %s '%s' support"),
@@ -338,6 +338,8 @@ class Loader:
             config["is_builtin"] = self.is_builtin_module(config)
             if config["name"] in entry_points:
                 config["entrypoint"] = entry_points[config["name"]]
+            else:
+                config["entrypoint"] = None
             config["module_path"] = self.build_module_import_path(config)
             config["install_path"] = self.build_module_install_path(config)
             if "branch" not in config:
@@ -347,7 +349,7 @@ class Loader:
             # python path, install it
             if not (config["is_builtin"]
                     or config["module"]
-                    or config.get("entrypoint")):
+                    or config["entrypoint"]):
                 # Remove module for reinstall if no-cache set
                 self.check_cache(config)
 

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -55,7 +55,7 @@ class Loader:
         # 3. try to import a module with the given name in the module_path
         # 4. try to import the module_path itself
 
-        if config["entrypoint"]:
+        if config.get("entrypoint"):
             _LOGGER.debug(_("Loading entry point-defined module for %s"),
                           config["name"])
             return config["entrypoint"].load()

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -1,5 +1,7 @@
 """Class for loading in modules to OpsDroid."""
 
+# pylint: disable=too-many-branches
+
 import importlib
 import importlib.util
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ websockets==7.0
 appdirs==1.4.3
 multidict==4.5.1
 motor==2.0.0
+setuptools==39.0.1

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -8,6 +8,7 @@ import unittest
 import unittest.mock as mock
 from types import ModuleType
 
+import pkg_resources
 from opsdroid.__main__ import configure_lang
 from opsdroid import loader as ld
 from opsdroid.loader import Loader
@@ -276,6 +277,19 @@ class TestLoader(unittest.TestCase):
         module = ld.Loader.import_module(config)
         self.assertIsInstance(module, ModuleType)
 
+    def test_import_module_from_entrypoint(self):
+        distro = pkg_resources.Distribution()
+        ep = pkg_resources.EntryPoint("myep", "os.path", dist=distro)
+        fake = mock.MagicMock(return_value=(ep,))
+        pkg_resources.iter_entry_points = fake
+        config = {}
+        config["module_path"] = ""
+        config["name"] = "myep"
+        config["type"] = ""
+        config["module"] = ""
+        config["entrypoint"] = ep
+        module = ld.Loader.import_module(config)
+        self.assertIsInstance(module, ModuleType)
 
     def test_load_config(self):
         opsdroid, loader = self.setup()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -278,18 +278,25 @@ class TestLoader(unittest.TestCase):
         self.assertIsInstance(module, ModuleType)
 
     def test_import_module_from_entrypoint(self):
-        distro = pkg_resources.Distribution()
-        ep = pkg_resources.EntryPoint("myep", "os.path", dist=distro)
-        fake = mock.MagicMock(return_value=(ep,))
-        pkg_resources.iter_entry_points = fake
+
         config = {}
         config["module_path"] = ""
         config["name"] = "myep"
         config["type"] = ""
         config["module"] = ""
+
+        distro = pkg_resources.Distribution()
+        ep = pkg_resources.EntryPoint("myep", "os.path", dist=distro)
         config["entrypoint"] = ep
-        module = ld.Loader.import_module(config)
-        self.assertIsInstance(module, ModuleType)
+
+        opsdroid, loader = self.setup()
+        loader.modules_directory = "."
+        modules = [{"name": "myep"}]
+
+        with mock.patch("opsdroid.loader.iter_entry_points") as mock_iter_entry_points:
+            mock_iter_entry_points.return_value = (ep,)
+            loaded = loader._load_modules("database", modules)
+            self.assertEqual(loaded[0]["config"]["name"], "myep")
 
     def test_load_config(self):
         opsdroid, loader = self.setup()


### PR DESCRIPTION
# Description

Implements #767 - setuptools entry points support for loading contributed extensions.

## Notes

 - entry point group name must be either `opsdroid_databases`, `opsdroid_skills` or `opsdroid_connectors`
- for an example definition, see [the example](https://github.com/koodaamo/opsdroid-zodb/blob/master/setup.py#L42-L46).

- The implementation currently prioritizes entry point based extensions.

# How Has This Been Tested?

A test was added to verify opsdroid loader now supports entry point mechanism. Tested also manually as working, using [opsdroid-zodb](https://pypi.org/project/opsdroid-zodb/).

To try it out, pull the implementation, do `pip install opsdroid-zodb`, create a skill that uses opsdroid memory, configure a 'zodb' database (yes just the name is enough) and try it out.