### PR TITLE
Remove self from disconnect() method when unload is called

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -165,13 +165,13 @@ class OpsDroid():
 
         for connector in self.connectors:
             _LOGGER.info(_("Stopping connector %s..."), connector.name)
-            await connector.disconnect(self)
+            await connector.disconnect()
             self.connectors.remove(connector)
             _LOGGER.info(_("Stopped connector %s"), connector.name)
 
         for database in self.memory.databases:
             _LOGGER.info(_("Stopping database %s..."), database.name)
-            await database.disconnect(self)
+            await database.disconnect()
             self.memory.databases.remove(database)
             _LOGGER.info(_("Stopped database %s"), database.name)
 


### PR DESCRIPTION
# Description

I was a bit excited with merging #749 into opsdroid. I was updating the connectors and see if the shell connector was working as expected with the changes and noticed that opsdroid would hang on `ctrl+c` because the `unload` method was calling `disconnect` on connectors and db with self as a param.

This PR fixes those two disconnect methods and makes it possible to terminate opsdroid properly.

Fixes #<issue>


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Started opsdroid, killed it, exited successfully. 


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

