### PR TITLE
Refactor database opsdroid pointer

### DIFF
--- a/docs/databases/mongo.md
+++ b/docs/databases/mongo.md
@@ -10,7 +10,7 @@ None.
 
 ```yaml
 databases:
-  mongo:
+  - name: mongo
     host:       "my host"     # (optional) default "localhost"
     port:       "12345"       # (optional) default "27017"
     database:   "mydatabase"  # (optional) default "opsdroid"

--- a/docs/databases/sqlite.md
+++ b/docs/databases/sqlite.md
@@ -6,7 +6,7 @@ A database module for opsdroid to persist memory in a [SQLite](https://www.sqlit
 
 ```yaml
 databases:
-  sqlite:
+  - name: sqlite
     file: "my_file.db"  # (optional) default "~/.opsdroid/sqlite.db"
     table: "my_table"  # (optional) default "opsdroid"
 ```

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -265,7 +265,7 @@ class OpsDroid():
                     _LOGGER.debug(_("Adding database: %s"), name)
                     database = cls(database_module["config"])
                     self.memory.databases.append(database)
-                    self.eventloop.run_until_complete(database.connect(self))
+                    self.eventloop.run_until_complete(database.connect())
 
     async def run_skill(self, skill, config, message):
         """Execute a skill."""

--- a/opsdroid/database/__init__.py
+++ b/opsdroid/database/__init__.py
@@ -1,14 +1,14 @@
 """A base class for databases to inherit from."""
 
 
-class Database():
+class Database:
     """A base database.
 
     Database classes are used to persist key/value pairs in a database.
 
     """
 
-    def __init__(self, config):
+    def __init__(self, config, opsdroid=None):
         """Create the database.
 
         Set some basic properties from the database config such as the name
@@ -23,10 +23,11 @@ class Database():
         """
         self.name = ""
         self.config = config
+        self.opsdroid = opsdroid
         self.client = None
         self.database = None
 
-    async def connect(self, opsdroid):
+    async def connect(self):
         """Connect to database service and store the connection object.
 
         This method should connect to the given database using a native
@@ -34,13 +35,10 @@ class Database():
         a connection object which will be used by the put and get methods.
         This object should be stored in self.
 
-        Args:
-            opsdroid (OpsDroid): An instance of the opsdroid core.
-
         """
         raise NotImplementedError
 
-    async def disconnect(self, opsdroid):
+    async def disconnect(self):
         """Disconnect from the database.
 
         This method should disconnect from the given database using a native

--- a/opsdroid/database/mongo/__init__.py
+++ b/opsdroid/database/mongo/__init__.py
@@ -13,7 +13,7 @@ class DatabaseMongo(Database):
 
     """
 
-    def __init__(self, config):
+    def __init__(self, config, opsdroid=None):
         """Create the connection.
 
         Set some basic properties from the database config such as the name
@@ -24,19 +24,15 @@ class DatabaseMongo(Database):
                            `configuration.yaml` file.
 
         """
-        super().__init__(config)
+        super().__init__(config, opsdroid=opsdroid)
         logging.debug("Loaded mongo database connector")
         self.name = "mongo"
         self.config = config
         self.client = None
         self.database = None
 
-    async def connect(self, opsdroid):
-        """Connect to the database.
-
-        Args:
-            obsdroid (object): the opsdroid instance
-        """
+    async def connect(self):
+        """Connect to the database."""
         host = self.config["host"] if "host" in self.config else "localhost"
         port = self.config["port"] if "port" in self.config else "27017"
         database = self.config["database"] \

--- a/opsdroid/database/sqlite/__init__.py
+++ b/opsdroid/database/sqlite/__init__.py
@@ -21,7 +21,7 @@ class DatabaseSqlite(Database):
 
     """
 
-    def __init__(self, config):
+    def __init__(self, config, opsdroid=None):
         """Initialise the sqlite database.
 
         Set basic properties of the database. Initialise properties like
@@ -33,7 +33,7 @@ class DatabaseSqlite(Database):
                            specified in `configuration.yaml` file.
 
         """
-        super().__init__(config)
+        super().__init__(config, opsdroid=opsdroid)
         self.name = "sqlite"
         self.config = config
         self.conn_args = {'isolation_level': None}
@@ -41,7 +41,7 @@ class DatabaseSqlite(Database):
         self.table = None
         _LOGGER.debug(_("Loaded sqlite database connector"))
 
-    async def connect(self, opsdroid):
+    async def connect(self):
         """Connect to the database.
 
         This method will connect to the sqlite database. It will create
@@ -162,7 +162,7 @@ class JSONEncoder(json.JSONEncoder):
         return marshaller(o)
 
 
-class JSONDecoder():
+class JSONDecoder:
     """A JSONDecoder class.
 
     This class will convert dict containing datetime values

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -21,12 +21,12 @@ class TestDatabaseBaseClassAsync(asynctest.TestCase):
     async def test_connect(self):
         database = Database({})
         with self.assertRaises(NotImplementedError):
-            await database.connect({})
+            await database.connect()
 
     async def test_disconnect(self):
         database = Database({})
         try:
-            await database.disconnect(None)
+            await database.disconnect()
         except NotImplementedError:
             self.fail("disconnect() raised NotImplementedError unexpectedly!")
 

--- a/tests/test_database_mongo.py
+++ b/tests/test_database_mongo.py
@@ -25,7 +25,7 @@ class TestDatabaseBaseMongoClassAsync(asynctest.TestCase):
         """test the method connect"""
         database = DatabaseMongo({})
         try:
-            await database.connect({})
+            await database.connect()
         except NotImplementedError:
             raise Exception
         else:

--- a/tests/test_database_sqlite.py
+++ b/tests/test_database_sqlite.py
@@ -59,7 +59,7 @@ class TestDatabaseSqliteAsync(asynctest.TestCase):
         opsdroid.eventloop = self.loop
 
         try:
-            await database.connect(opsdroid)
+            await database.connect()
         except NotImplementedError:
             raise Exception
         else:
@@ -79,7 +79,7 @@ class TestDatabaseSqliteAsync(asynctest.TestCase):
         opsdroid.eventloop = self.loop
 
         try:
-            await database.connect(opsdroid)
+            await database.connect()
             await database.put("hello", {})
             data = await database.get("hello")
         except NotImplementedError:


### PR DESCRIPTION
# Description

I'm not sure if this was something that we should have implement when #749 was merged into opsdroid, but @petri mentioned in gitter that _"There seems to be inconsistency in how opsdroid calls the extensions. Sometimes opsdroid is passed along and sometimes not when various methods of database or connector extensions can be called."_

This reminded me that on calling `disconnect()` on the databases it would break opsdroid after I merged #775 I thought that we were changing the pointer on the connectors and databases that's why I removed self from the disconnect, but I was wrong.

Perhaps we should apply the same work as we did on the connectors since opsdroid is only used on the `connect` method anyway.

If this is something that we don't really need to implement I will make another PR to restore the `database.disconnect(self)` so everything works okay.

Finally, I have updated the database documentation as I have encountered issues when using the `sqlite` database without any optional options. Like I said on gitter, I'm not sure if this should be changed or if I'm just missing something 😄 

## Status
**READY** |~~ **UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
