### PR TITLE
Remove requests_mock

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,5 +7,4 @@ pytest-cov==2.6.0
 pytest-timeout==1.3.3
 pydocstyle==3.0.0
 asynctest==0.12.2
-requests_mock==1.5.2
 mypy-lang==0.5.0


### PR DESCRIPTION
# Description

Travis seems to be broken because `requests_mock` couldn't be loaded. I checked our requirements and tests and it seems that this module is being loaded into `requirements_tests.txt` file but it seems we don't ever use this module on any of the tests since we don't use `requests`. 

This PR attempts to remove this module and see if anything breaks down on Travis since tox was happy with the changes.


## Status
**READY** 


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

