### PR TITLE
Update docs with new path. Adds docker service example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ docker pull opsdroid/opsdroid:latest
 docker run --rm -it -v /path/to/configuration.yaml:/root/.config/opsdroid/configuration.yaml:ro opsdroid/opsdroid:latest
 ```
 
+### Docker Service
+
+```bash
+# Create the opsdroid config file
+docker config create OpsdroidConfig /path/to/configuration.yaml
+
+# Create the service
+docker service create --name opsdroid --config source=OpsdroidConfig,target=/root/.config/opsdroid/configuration.yaml opsdroid/opsdroid:latest
+```
+
 ### Ubuntu 16.04 LTS
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Check out the [Getting Started](https://www.youtube.com/watch?v=7wyIi_cpodE&list
 docker pull opsdroid/opsdroid:latest
 
 # Run the container
-docker run --rm -it -v /path/to/configuration.yaml:/root/.config/opsdroid/configuration.yaml:ro opsdroid/opsdroid:latest
+docker run --rm -it -v /path/to/config_folder:/root/.config/opsdroid opsdroid/opsdroid:latest
 ```
 
 ### Docker Service
@@ -63,7 +63,7 @@ docker run --rm -it -v /path/to/configuration.yaml:/root/.config/opsdroid/config
 docker config create OpsdroidConfig /path/to/configuration.yaml
 
 # Create the service
-docker service create --name opsdroid --config source=OpsdroidConfig,target=/root/.config/opsdroid/configuration.yaml opsdroid/opsdroid:latest
+docker service create --name opsdroid --config source=OpsdroidConfig,target=/root/.config/opsdroid/configuration.yaml --mount 'type=volume,src=OpsdroidData,dst=/root/.config/opsdroid' opsdroid/opsdroid:latest
 ```
 
 ### Ubuntu 16.04 LTS

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Check out the [Getting Started](https://www.youtube.com/watch?v=7wyIi_cpodE&list
 docker pull opsdroid/opsdroid:latest
 
 # Run the container
-docker run --rm -it -v /path/to/configuration.yaml:/etc/opsdroid/configuration.yaml:ro opsdroid/opsdroid:latest
+docker run --rm -it -v /path/to/configuration.yaml:/root/.config/opsdroid/configuration.yaml:ro opsdroid/opsdroid:latest
 ```
 
 ### Ubuntu 16.04 LTS


### PR DESCRIPTION
# Description

Change docker run documentation for matching the new config path `/root/.config/opsdroid`.
Also adds a docker service deployment example.

Fixes #781 

## Status
**READY**


## Type of change

- Documentation (fix or adds documentation)


# How Has This Been Tested?

1. Run the changed/added commands in bash snippets.
2. Review that the configuration loaded is your custom config.


# Checklist:

- [x] I have made corresponding changes to the documentation (if applicable)

