### PR TITLE
Bump Pyyaml to avoid CVE-2017-18342

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -249,7 +249,7 @@ class Loader:
         try:
             with open(config_path, 'r') as stream:
                 _LOGGER.info(_("Loaded config from %s."), config_path)
-                return yaml.load(stream)
+                return yaml.load(stream, Loader=yaml.SafeLoader)
         except yaml.YAMLError as error:
             _LOGGER.critical(error)
             sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ emoji==0.5.1
 nbconvert==5.4.0
 nbformat==4.4.0
 pycron==1.0.0
-pyyaml==3.13
+pyyaml==4.2b1
 websockets==7.0
 appdirs==1.4.3
 multidict==4.5.2

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,4 @@
-
+import sys
 import os
 import shutil
 import subprocess
@@ -9,6 +9,7 @@ import unittest.mock as mock
 from types import ModuleType
 
 import pkg_resources
+from yaml import YAMLError
 from opsdroid.__main__ import configure_lang
 from opsdroid import loader as ld
 from opsdroid.loader import Loader
@@ -44,6 +45,24 @@ class TestLoader(unittest.TestCase):
         config = loader.load_config_file(
             [os.path.abspath("tests/configs/minimal_2.yaml")])
         self.assertIsNotNone(config)
+
+    def test_load_exploit(self):
+        """This will test if you can run python code from
+        config.yaml. The expected result should be:
+        - Yaml.YAMLError exception raised
+        - _LOGGER.critical message
+        - sys.exit
+
+        Note: the unittest.main(exit=False) is important so
+        other tests won't fail when sys.exit is called.
+        """
+        opsdroid, loader = self.setup()
+        with self.assertRaises(SystemExit):
+            config = loader.load_config_file(
+                [os.path.abspath("tests/configs/include_exploit.yaml")])
+            self.assertLogs('_LOGGER', 'critical')
+            self.assertRaises(YAMLError)
+            unittest.main(exit=False)
 
     def test_load_config_file_with_include(self):
         opsdroid, loader = self.setup()


### PR DESCRIPTION
GitHub has alerted to CVE-2017-18342. This is related to #580.

The GitHub alert included a suggestion of updating to 4.2b1. Not sure why pyup-bot hasn't done this already.