### PR TITLE
Fix broken websocket handler

### DIFF
--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -53,7 +53,7 @@ class ConnectorWebsocket(Connector):
                 code=WSCloseCode.GOING_AWAY,
                 message='Server shutdown')
 
-    async def new_websocket_handler(self):
+    async def new_websocket_handler(self, request):
         """Handle for aiohttp creating websocket connections."""
         if len(self.active_connections) + len(self.available_connections) \
                 < self.max_connections and self.accepting_connections:

--- a/tests/test_connector_websocket.py
+++ b/tests/test_connector_websocket.py
@@ -74,12 +74,12 @@ class TestConnectorWebsocketAsync(asynctest.TestCase):
         connector.max_connections = 1
         self.assertEqual(len(connector.available_connections), 0)
 
-        response = await connector.new_websocket_handler()
+        response = await connector.new_websocket_handler(None)
         self.assertTrue(isinstance(response, aiohttp.web.Response))
         self.assertEqual(len(connector.available_connections), 1)
         self.assertEqual(response.status, 200)
 
-        fail_response = await connector.new_websocket_handler()
+        fail_response = await connector.new_websocket_handler(None)
         self.assertTrue(isinstance(fail_response, aiohttp.web.Response))
         self.assertEqual(fail_response.status, 429)
 


### PR DESCRIPTION
Looks like the websocket handler was broken in #749.

 Weirdly the tests were also updated to pass the broken method, rather than highlighting the method had been broken.