### PR TITLE
Call skills correctly depending on function or class skills

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -8,6 +8,7 @@ import sys
 import weakref
 import asyncio
 import contextlib
+import inspect
 
 from opsdroid.const import DEFAULT_CONFIG_PATH
 from opsdroid.memory import Memory
@@ -312,7 +313,12 @@ class OpsDroid():
         # halt the application. If a skill throws an exception it just doesn't
         # give a response to the user, so an error response should be given.
         try:
-            await skill(self, config, message)
+            await skill(message)
+        except TypeError as error:
+            if 'positional arguments' in str(error):
+                await skill(self, config, message)
+            else:
+                raise error
         except Exception:
             if message:
                 await message.respond(_("Whoops there has been an error"))

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -8,7 +8,6 @@ import sys
 import weakref
 import asyncio
 import contextlib
-import inspect
 
 from opsdroid.const import DEFAULT_CONFIG_PATH
 from opsdroid.memory import Memory

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -313,7 +313,7 @@ class OpsDroid():
         # halt the application. If a skill throws an exception it just doesn't
         # give a response to the user, so an error response should be given.
         try:
-            if len(inspect.getargspec(skill)[0]) > 1:
+            if len(inspect.signature(skill).parameters.keys()) > 1:
                 await skill(self, config, message)
             else:
                 await skill(message)

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -8,6 +8,7 @@ import sys
 import weakref
 import asyncio
 import contextlib
+import inspect
 
 from opsdroid.const import DEFAULT_CONFIG_PATH
 from opsdroid.memory import Memory
@@ -312,12 +313,10 @@ class OpsDroid():
         # halt the application. If a skill throws an exception it just doesn't
         # give a response to the user, so an error response should be given.
         try:
-            await skill(message)
-        except TypeError as error:
-            if 'positional arguments' in str(error):
+            if len(inspect.getargspec(skill)[0]) > 1:
                 await skill(self, config, message)
             else:
-                raise error
+                await skill(message)
         except Exception:
             if message:
                 await message.respond(_("Whoops there has been an error"))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -224,6 +224,12 @@ class TestCoreAsync(asynctest.TestCase):
         mockedskill.config = {}
         return mockedskill
 
+    async def getMockMethodSkill(self):
+        async def mockedskill(message):
+            await message.respond("Test")
+        mockedskill.config = {}
+        return mockedskill
+
     async def test_handle_signal(self):
         with OpsDroid() as opsdroid:
             opsdroid._running = True
@@ -286,6 +292,19 @@ class TestCoreAsync(asynctest.TestCase):
             mock_connector = Connector({}, opsdroid=opsdroid)
             mock_connector.respond = amock.CoroutineMock()
             skill = await self.getMockSkill()
+            opsdroid.skills.append(match_regex(regex)(skill))
+            message = Message("user", "default", mock_connector, "Hello world")
+            tasks = await opsdroid.parse(message)
+            for task in tasks:
+                await task
+            self.assertTrue(mock_connector.respond.called)
+
+    async def test_parse_regex_method_skill(self):
+        with OpsDroid() as opsdroid:
+            regex = r"Hello .*"
+            mock_connector = Connector({}, opsdroid=opsdroid)
+            mock_connector.respond = amock.CoroutineMock()
+            skill = await self.getMockMethodSkill()
             opsdroid.skills.append(match_regex(regex)(skill))
             message = Message("user", "default", mock_connector, "Hello world")
             tasks = await opsdroid.parse(message)


### PR DESCRIPTION
# Description

After adding class based skills in #734 we forgot to change the skill call to pass different arguments to function skills and class method skills. This resulted in class based skills not actually working.

