### PR TITLE
To mitigate if 'message' is NoneType...

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -413,7 +413,7 @@ class OpsDroid():
         """Parse a string against all skills."""
         self.stats["messages_parsed"] = self.stats["messages_parsed"] + 1
         tasks = []
-        if message.text.strip() != "":
+        if message is not None and message.text.strip() != "":
             _LOGGER.debug(_("Parsing input: %s"), message.text)
 
             tasks.append(


### PR DESCRIPTION
To mitigate if 'message' is NoneType...

# Description

There was an issue when I run the opsdroid with matrix connector...

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

- [X ] I have performed a self-review of my own code