### PR TITLE
Event dispatch system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ ENV/
 
 .vscode/
 .idea/
+site/

--- a/docs/extending/connectors.md
+++ b/docs/extending/connectors.md
@@ -16,14 +16,27 @@ Connectors are a class which extends the base opsdroid Connector. The class has 
 #### user_typing
 *user_typing* triggers the event message *user is typing* if the connector allows it. This method uses a parameter `trigger` that takes in a boolean value to trigger the event on/off.
 
-#### respond
-*respond* will take a Message object and return the contents to the chat service.
-
-#### react
-*react* will take a Message object and an emoji name and add this emoji as a Message reaction (if the chat service supports this feature).
-
 #### disconnect
 *disconnect* there is also an optional disconnect method that will be called upon shutdown of opsdroid. This can be used to perform any disconnect operations for the connector.
+
+
+### Handling Events
+
+Opsdroid supports different types of events, which can both be sent and received via connectors, for more information on the different types of events see the [events documentation](./events.md).
+
+
+Connectors can implement support for sending different types of events using the `opsdroid.connector.register_event` decorator.
+This decorator is used to define a method (coroutine) on the connector class for each different event type the connector supports, for instance to add support for `Message` events you may define a method like this:
+
+```python
+
+@register_event(Message)
+async def send_message(self, message):
+    await myservice.send(message.text)
+    
+```
+
+This method will be called when `Connector.send` is called with a `Message` object as its first argument. Methods such as this can be defined for all event types supported by the connector.
 
 ```python
 
@@ -34,7 +47,7 @@ import time
 import chatlibrary
 
 # Import opsdroid dependencies
-from opsdroid.connector import Connector
+from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
 
 
@@ -66,10 +79,11 @@ class MyConnector(Connector):
       # Parse the message with opsdroid
       await opsdroid.parse(message)
 
-  async def respond(self, message):
+  @register_event(Message)
+  async def send_message(self, message):
     # Send message.text back to the chat service
-    await self.connection.send(raw_message.text, raw_message.user,
-                               raw_message.room)
+    await self.connection.send(message.text, message.user,
+                               message.target)
 
   async def disconnect(self, opsdroid):
     # Disconnect from the chat service

--- a/docs/extending/connectors.md
+++ b/docs/extending/connectors.md
@@ -22,7 +22,7 @@ Connectors are a class which extends the base opsdroid Connector. The class has 
 
 ### Handling Events
 
-Opsdroid supports different types of events, which can both be sent and received via connectors, for more information on the different types of events see the [events documentation](./events.md).
+Opsdroid supports different types of events, which can both be sent and received via connectors, for more information on the different types of events see the [events documentation](/events.md).
 
 
 Connectors can implement support for sending different types of events using the `opsdroid.connector.register_event` decorator.

--- a/docs/extending/connectors.md
+++ b/docs/extending/connectors.md
@@ -44,7 +44,7 @@ class MyConnector(Connector):
     # Init the config for the connector
     self.name = "MyConnector" # The name of your connector
     self.config = config # The config dictionary to be accessed later
-    self.default_room = "MyDefaultRoom" # The default room for messages to go
+    self.default_target = "MyDefaultRoom" # The default room for messages to go
 
   async def connect(self, opsdroid):
     # Create connection object with chat library

--- a/docs/extending/events.md
+++ b/docs/extending/events.md
@@ -1,0 +1,80 @@
+# Events
+
+Events in opsdroid represent things that happen on the services that opsdroid connects to.
+They are both sent and received by the connectors.
+
+All events are a subclass of the base `Event` class. Each event also defines its own set of attributes which are specific to that type of event.
+
+
+### `Event`
+
+The base `Event` class has the following attributes and methods:
+
+
+#### Attributes
+* `user`: A string containing the username of the user who wrote the message.
+
+* `target`: A string normally containing the name of the room or chat channel the message was sent in.
+
+* `connector`: A pointer to the opsdroid _connector object_ which receieved the message.
+
+* `linked_event`: Another event linked to this one, for example the event that a `Message` replies to.
+
+* `created`: A timestamp of when this event was instantiated.
+
+* `event_id`: A unique identifier for this event as provided by the connector.
+
+* `raw_event`: The raw event received by the connector (may be `None`).
+
+* `responded_to`: A boolean (True/False) flag indicating if this event has already had its `respond` method called.
+
+
+#### Methods
+* `respond(event)`: A method which takes another `Event` object responds using any attributes of the event which are not overridden in the response `event`. i.e. if the `target` attribute on the `event` argument is `None` then the `target` of the event being responded to will be used.
+
+### `Message`
+
+The `Message` object is the most common event type, it represents textual events, and has the following attributes in addition to the base `Event` attributes.
+
+
+#### Attributes
+
+* `text`: The textual content of the message.
+
+#### Methods
+* `respond(text)`: The same as the `Event.respond` method, with the addition of accepting a `str` argument, which will be converted into a `Message` event.
+
+### `Typing`
+
+An event to represent a typing indication.
+
+#### Attributes
+
+* `trigger`: Trigger typing on or off.
+* `timeout`: Timeout on typing event.
+
+### `Reaction`
+
+A reaction to a message, normally an emoji or a string representing one.
+
+#### Attributes
+
+* `emoji`: The emoji to use as a reaction.
+
+### `File`
+
+A file event. All files should be representable as bytes. A `File` can be constructed using either a url or a `bytes` object, if a url is specified the `File.file_bytes` property will retrieve the url and store the response as `bytes`.
+
+#### Attributes
+
+* `url`: The url of the file, can be `None`.
+* `file_bytes`: The file as a `bytes` object.
+
+### `Image`
+
+The `Image` event is a subclass of `File`, so in the same way `File` can an `Image` can be either a url or bytes, but should always be representable as `bytes`.
+
+#### Attributes
+
+* `url`: The url of the file, can be `None`.
+* `image_bytes`: The image as a `bytes` object.

--- a/docs/extending/events.md
+++ b/docs/extending/events.md
@@ -16,7 +16,7 @@ The base `Event` class has the following attributes and methods:
 
 * `target`: A string normally containing the name of the room or chat channel the message was sent in.
 
-* `connector`: A pointer to the opsdroid _connector object_ which receieved the message.
+* `connector`: A pointer to the opsdroid _connector object_ which received the message.
 
 * `linked_event`: Another event linked to this one, for example the event that a `Message` replies to.
 

--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -39,14 +39,14 @@ In opsdroid when events are received the connector emits `Event` objects which c
 _Note: Not all connectors support all event types. To find out which events a connector will emit you can access the `.events` attribute of a connector._
 
 
-The base `Event` class has the following attributes. Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](../tutorials/introduction.md#matchers-available) for more details.
+The base `Event` class has the following attributes. Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](tutorials/introduction.md#matchers-available) for more details.
 
 
 * `user`: A _string_ containing the username of the user who wrote the message.
 
 * `target`: A _string_ normally containing the name of the room or chat channel the message was sent in.
 
-* `connector`: A pointer to the opsdroid _connector object_ which receieved the message.
+* `connector`: A pointer to the opsdroid _connector object_ which received the message.
 
 * `raw_event`: The raw event received by the connector (may be `None`).
 

--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -28,32 +28,41 @@ If the message matches the regular expression then the decorated function is cal
 
 To ensure the bot is responsive the concurrency controls introduced in Python 3.5 are used. This means that all functions which will be executed should be defined as an `async` function, and calls to functions which may require IO (like a connector or database) should be awaited with the `await` keyword. For more information see [asyncio](https://docs.python.org/3/library/asyncio.html) and [event loops](https://docs.python.org/3/library/asyncio-eventloop.html).
 
-## Message object
+## Events
 
-The message object passed to the skill function is an instance of the opsdroid `Message` class which has the following properties and methods.
+In opsdroid when events are received the connector emits `Event` objects which can be matched by skills and processed. The most common event is the `Message` event but a number of other events are implemented including:
 
-Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](../tutorials/introduction.md#matchers-available) for more details.
+* Reaction
+* File
+* Image
 
-### `text`
+_Note: Not all connectors support all event types. To find out which events a connector will emit you can access the `.events` attribute of a connector._
 
-A _string_ containing the message from the user.
 
-### `user`
+The base `Event` class has the following attributes. Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](../tutorials/introduction.md#matchers-available) for more details.
 
-A _string_ containing the username of the user who wrote the message.
 
-### `room`
+* `user`: A _string_ containing the username of the user who wrote the message.
 
-A _string_ containing the name of the room or chat channel the message was sent in.
+* `target`: A _string_ normally containing the name of the room or chat channel the message was sent in.
 
-### `connector`
+* `connector`: A pointer to the opsdroid _connector object_ which receieved the message.
 
-A pointer to the opsdroid _connector object_ which receieved the message.
+* `raw_event`: The raw event received by the connector (may be `None`).
 
-### `respond(text, room=None)`
+* `responded_to`: A boolean (True/False) flag indicating if this event has already had its `respond` method called.
 
-A method which responds to the received message using the same connector.
-By default the response is sent to the same room, but arguments may be passed to `connector.respond()` using the `room` argument to change this behaviour, if the connector supports this.
+* `respond(text)`: A method which responds to the received message using the same connector.
+
+
+### `Message`
+
+In addition to the base properties listed above, the `Message` class has the following properties:
+
+* `text`: A _string_ containing the message from the user.
+
+
+For more information on the other types of events see the [events](events.md) documentation.
 
 ## Persisting data
 

--- a/docs/matchers/crontab.md
+++ b/docs/matchers/crontab.md
@@ -29,7 +29,7 @@ class CrontabSkill(Skill):
         connector = opsdroid.default_connector
 
         # Get the default room for that connector
-        room = connector.default_room
+        room = connector.default_target
 
         # Create an empty message to respond to
         message = Message("", None, room, connector)
@@ -38,6 +38,6 @@ class CrontabSkill(Skill):
         await message.respond('Hey')
 ```
 
-The above skill would be called every minute. As the skill is being triggered by something other than a message the `message` argument being passed in will be set to `None`, this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_room` properties to get some sensible defaults.
+The above skill would be called every minute. As the skill is being triggered by something other than a message the `message` argument being passed in will be set to `None`, this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_target` properties to get some sensible defaults.
 
 You can also set the timezone that the skill crontab is aligned with. This is useful if you want to have different time zones between skills. This kwarg is optional, if not set it will default to the timezone specified in the root of the configuration or failing that UTC.

--- a/docs/matchers/webhook.md
+++ b/docs/matchers/webhook.md
@@ -7,7 +7,7 @@ skills:
   - name: "exampleskill"
 ```
 
-The above skill would be called if you send a POST to `http://localhost:8080/skill/exampleskill/examplewebhook`. As the skill is being triggered by a webhook the `message` argument being passed in will be set to the [aiohttp Request](http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.BaseRequest), this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_room` properties to get some sensible defaults.
+The above skill would be called if you send a POST to `http://localhost:8080/skill/exampleskill/examplewebhook`. As the skill is being triggered by a webhook the `message` argument being passed in will be set to the [aiohttp Request](http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.BaseRequest), this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_target` properties to get some sensible defaults.
 
 Similar to the crontab matcher this matcher doesn't take a message as an input, it takes a webhook instead. It allows you to trigger the skill by calling a specific URL endpoint.
 
@@ -27,7 +27,7 @@ class MySkill(Skill):
         if type(message) is not Message and type(message) is Request:
           # Capture the request POST data and set message to a default message
           request = await message.post()
-          message = Message("", None, self.opsdroid.connector.default_room,
+          message = Message("", None, self.opsdroid.connector.default_target,
                             self.opsdroid.default_connector)
 
         # Respond
@@ -52,7 +52,7 @@ class MySkill(Skill):
         if type(message) is not Message and type(message) is Request:
           # Capture the request POST data and set message to a default message
           request = await message.post()
-          message = Message("", None, self.opsdroid.connector.default_room,
+          message = Message("", None, self.opsdroid.connector.default_target,
                             self.opsdroid.default_connector)
 
         # Respond

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ pages:
       - 'Adding skills': 'extending/skills.md'
       - 'Adding connectors': 'extending/connectors.md'
       - 'Adding databases': 'extending/databases.md'
+      - 'Using Events': 'extending/events.md'
       - 'Extension packaging': 'extending/packaging.md'
   - 'Connectors':
       - 'Slack': 'connectors/slack.md'

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -57,7 +57,7 @@ class Connector:
             if not issubclass(event_type, Event):
                 err_msg = ("The event type {event_type} is "
                            "not a valid OpsDroid event type")
-                raise TypeError(err_msg.format(event_type))
+                raise TypeError(err_msg.format(event_type=event_type))
             cls.events[event_type] = event_method
 
         return super().__new__(cls)

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -191,7 +191,8 @@ class Connector:
         return await self.events[type(event)](self, event)
 
     @property
-    def default_room(self):
+    def default_room(self):  # noqa: D401
+        """The room to send messages to if not specified."""
         warnings.warn(
             "Connector.default_room is deprecated. Use "
             "Connector.default_target instead.",
@@ -207,5 +208,3 @@ class Connector:
             DeprecationWarning)
 
         self.default_target = value
-
-

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -75,7 +75,7 @@ class Connector:
         """
         self.name = ""
         self.config = config
-        self.default_room = None
+        self.default_target = None
         self.opsdroid = opsdroid
 
     @property
@@ -127,7 +127,10 @@ class Connector:
         Returns:
             bool: True for event successfully sent. False otherwise.
         """
-        return await self.events[type(event)](self, event, target=target)
+        target = target if target else event.target if event.target else self.default_target
+        if target is None:
+            raise ValueError("No valid target for this event")
+        return await self.events[type(event)](self, event, target)
 
     async def disconnect(self):
         """Disconnect from the chat service.

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import warnings
 
-from opsdroid.events import Event, Reaction
+from opsdroid.events import Event, Reaction, Message
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -134,6 +134,9 @@ class Connector:
             "Connector.respond is deprecated. Use "
             "Connector.send instead.",
             DeprecationWarning)
+
+        if isinstance(message, str):
+            message = Message(message)
 
         if room:
             message.target = room

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -116,7 +116,7 @@ class Connector:
             " '{type(event).__name__}' event type.".format(self=self,
                                                            event=event))
 
-    async def send(self, event, target=None):
+    async def send(self, event):
         """Send a message to the chat service.
 
         Args:
@@ -127,10 +127,11 @@ class Connector:
         Returns:
             bool: True for event successfully sent. False otherwise.
         """
-        target = target if target else event.target if event.target else self.default_target
-        if target is None:
-            raise ValueError("No valid target for this event")
-        return await self.events[type(event)](self, event, target)
+
+        # If the event does not have a target, use the default.
+        event.target = event.target or self.default_target
+
+        return await self.events[type(event)](self, event)
 
     async def disconnect(self):
         """Disconnect from the chat service.

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -3,8 +3,9 @@
 import collections
 import inspect
 import logging
+import warnings
 
-from opsdroid.events import Event
+from opsdroid.events import Event, Reaction
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -114,6 +115,60 @@ class Connector:
             " '{eventt.__name__}' event type.".format(stype=type(self),
                                                       eventt=type(event)))
 
+    async def respond(self, message, room=None):
+        """Send a message back to the chat service.
+
+        The message object will have a `text` property which should be sent
+        back to the chat service. It may also have a `room` and `user` property
+        which gives information on where the message should be directed.
+
+        Args:
+            message (Message): A message received by the connector.
+            room (string): Name of the room to send the message to
+
+        Returns:
+            bool: True for message successfully sent. False otherwise.
+
+        """
+        warnings.warn(
+            "Connector.respond is deprecated. Use "
+            "Connector.send instead.",
+            DeprecationWarning)
+
+        if room:
+            message.target = room
+
+        return await self.send(message)
+
+    async def disconnect(self):
+        """Disconnect from the chat service.
+
+        This method is called when opsdroid is exiting, it can be used to close
+        connections or do other cleanup.
+        """
+
+    async def react(self, message, emoji):
+        """React to a message.
+
+        Not all connectors will have capabilities to react messages, so this
+        method don't have to be implemented and by default logs a debug message
+        and returns False.
+
+        Args:
+            message (Message): A message received by the connector.
+            emoji    (string): The emoji name with which opsdroid will react
+
+        Returns:
+            bool: True for message successfully sent. False otherwise.
+
+        """
+        warnings.warn(
+            "Connector.react is deprecated. Use "
+            "Connector.respond(events.Reaction(emoji)) instead.",
+            DeprecationWarning)
+
+        return await message.respond(Reaction(emoji))
+
     async def send(self, event):
         """Send a message to the chat service.
 
@@ -135,9 +190,22 @@ class Connector:
 
         return await self.events[type(event)](self, event)
 
-    async def disconnect(self):
-        """Disconnect from the chat service.
+    @property
+    def default_room(self):
+        warnings.warn(
+            "Connector.default_room is deprecated. Use "
+            "Connector.default_target instead.",
+            DeprecationWarning)
 
-        This method is called when opsdroid is exiting, it can be used to close
-        connections or do other cleanup.
-        """
+        return self.default_target
+
+    @default_room.setter
+    def default_room(self, value):
+        warnings.warn(
+            "Connector.default_room is deprecated. Use "
+            "Connector.default_target instead.",
+            DeprecationWarning)
+
+        self.default_target = value
+
+

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -32,12 +32,13 @@ class Connector:
     Connectors are used to interact with a given chat service.
 
     """
+
     def __new__(cls, *args, **kwargs):
-        """
+        """Create the class object.
+
         Before constructing the class parse all the methods that have been
         decorated with ``register_event``.
         """
-
         # Get all 'function' members as the wrapped methods are functions
         # This returns a tuple of (name, function) for each method.
         functions = inspect.getmembers(cls, predicate=inspect.isfunction)
@@ -54,9 +55,9 @@ class Connector:
             event_type = event_method.__opsdroid_event__
 
             if not issubclass(event_type, Event):
-                raise TypeError("The event type {event_type} is not"
-                                " a valid OpsDroid event type".format(event_type))
-
+                err_msg = ("The event type {event_type} is "
+                           "not a valid OpsDroid event type")
+                raise TypeError(err_msg.format(event_type))
             cls.events[event_type] = event_method
 
         return super().__new__(cls)
@@ -107,10 +108,7 @@ class Connector:
         raise NotImplementedError
 
     async def _unknown_event(self, event, target=None):
-        """
-        This is the fallback function that is called if the subclass can not
-        handle the event type.
-        """
+        """Fallback for when the subclass can not handle the event type."""
         raise TypeError(
             "Connector {stype} can not handle the"
             " '{eventt.__name__}' event type.".format(stype=type(self),
@@ -126,6 +124,7 @@ class Connector:
 
         Returns:
             bool: True for event successfully sent. False otherwise.
+
         """
         if not isinstance(event, Event):
             raise TypeError(

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -54,12 +54,12 @@ class Connector:
             event_type = event_method.__opsdroid_event__
 
             if not issubclass(event_type, Event):
-                raise TypeError(f"The event type {event_type} is not"
-                                " a valid OpsDroid event type")
+                raise TypeError("The event type {event_type} is not"
+                                " a valid OpsDroid event type".format(event_type))
 
             cls.events[event_type] = event_method
 
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls)
 
     def __init__(self, config, opsdroid=None):
         """Create the connector.
@@ -112,9 +112,9 @@ class Connector:
         handle the event type.
         """
         raise TypeError(
-            "Connector {type(self)} can not handle the"
-            " '{type(event).__name__}' event type.".format(self=self,
-                                                           event=event))
+            "Connector {stype} can not handle the"
+            " '{eventt.__name__}' event type.".format(stype=type(self),
+                                                      eventt=type(event)))
 
     async def send(self, event):
         """Send a message to the chat service.
@@ -127,6 +127,9 @@ class Connector:
         Returns:
             bool: True for event successfully sent. False otherwise.
         """
+        if not isinstance(event, Event):
+            raise TypeError(
+                "The event argument to send must be an opsdroid Event object")
 
         # If the event does not have a target, use the default.
         event.target = event.target or self.default_target

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -167,7 +167,7 @@ class Connector:
         """
         warnings.warn(
             "Connector.react is deprecated. Use "
-            "Connector.respond(events.Reaction(emoji)) instead.",
+            "Connector.send(events.Reaction(emoji)) instead.",
             DeprecationWarning)
 
         return await message.respond(Reaction(emoji))

--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 import aiohttp
 
-from opsdroid.connector import Connector
+from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
 
 
@@ -102,7 +102,8 @@ class ConnectorFacebook(Connector):
 
         """
 
-    async def respond(self, message, room=None):
+    @register_event(Message)
+    async def send_message(self, message, target=None):
         """Respond with a message."""
         _LOGGER.debug("Responding to facebook")
         url = _FACEBOOK_SEND_URL.format(self.config.get('page-access-token'))

--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -25,7 +25,7 @@ class ConnectorFacebook(Connector):
             `configuration.yaml` file.
         name: String name of the connector.
         opsdroid: opsdroid instance.
-        default_room: String name of default room for chat messages.
+        default_target: String name of default room for chat messages.
         bot_name: String name for bot.
 
     """
@@ -34,9 +34,7 @@ class ConnectorFacebook(Connector):
         """Connector Setup."""
         super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting facebook connector")
-        self.config = config
         self.name = self.config.get("name", "facebook")
-        self.default_room = None
         self.bot_name = config.get("bot-name", 'opsdroid')
 
     async def connect(self):
@@ -103,14 +101,14 @@ class ConnectorFacebook(Connector):
         """
 
     @register_event(Message)
-    async def send_message(self, message, target=None):
+    async def send_message(self, message, target):
         """Respond with a message."""
         _LOGGER.debug("Responding to facebook")
         url = _FACEBOOK_SEND_URL.format(self.config.get('page-access-token'))
         headers = {'content-type': 'application/json'}
         payload = {
             "recipient": {
-                "id": message.room
+                "id": target
             },
             "message": {
                 "text": message.text

--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -101,14 +101,14 @@ class ConnectorFacebook(Connector):
         """
 
     @register_event(Message)
-    async def send_message(self, message, target):
+    async def send_message(self, message):
         """Respond with a message."""
         _LOGGER.debug("Responding to facebook")
         url = _FACEBOOK_SEND_URL.format(self.config.get('page-access-token'))
         headers = {'content-type': 'application/json'}
         payload = {
             "recipient": {
-                "id": target
+                "id": message.target
             },
             "message": {
                 "text": message.text

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -81,10 +81,11 @@ class ConnectorGitHub(Connector):
             issue = "{}/{}#{}".format(payload["repository"]["owner"]["login"],
                                       payload["repository"]["name"],
                                       issue_number)
-            message = Message(payload["sender"]["login"],
+            message = Message(body,
+                              payload["sender"]["login"],
                               issue,
                               self,
-                              body)
+                              raw_event=payload)
             await self.opsdroid.parse(message)
         except KeyError as error:
             _LOGGER.error("Key %s not found in payload", error)

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -93,13 +93,13 @@ class ConnectorGitHub(Connector):
             text=json.dumps("Received"), status=201)
 
     @register_event(Message)
-    async def send_message(self, message, target):
+    async def send_message(self, message):
         """Respond with a message."""
         # stop immediately if the message is from the bot itself.
         if message.user == self.github_username:
             return True
         _LOGGER.debug("Responding via GitHub")
-        repo, issue = target.split('#')
+        repo, issue = message.target.split('#')
         url = "{}/repos/{}/issues/{}/comments".format(
             GITHUB_API_URL, repo, issue)
         headers = {'Authorization': ' token {}'.format(self.github_token)}

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -19,14 +19,12 @@ class ConnectorGitHub(Connector):
         """Create the connector."""
         super().__init__(config, opsdroid=opsdroid)
         logging.debug("Loaded GitHub connector")
-        self.config = config
         try:
             self.github_token = config["token"]
         except KeyError:
             _LOGGER.error("Missing auth token!"
                           "You must set 'token' in your config")
         self.name = self.config.get("name", "github")
-        self.default_room = None
         self.opsdroid = opsdroid
         self.github_username = None
 
@@ -95,13 +93,13 @@ class ConnectorGitHub(Connector):
             text=json.dumps("Received"), status=201)
 
     @register_event(Message)
-    async def send_message(self, message, target=None):
+    async def send_message(self, message, target):
         """Respond with a message."""
         # stop immediately if the message is from the bot itself.
         if message.user == self.github_username:
             return True
         _LOGGER.debug("Responding via GitHub")
-        repo, issue = message.room.split('#')
+        repo, issue = target.split('#')
         url = "{}/repos/{}/issues/{}/comments".format(
             GITHUB_API_URL, repo, issue)
         headers = {'Authorization': ' token {}'.format(self.github_token)}

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 import aiohttp
 
-from opsdroid.connector import Connector
+from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
 
 
@@ -94,7 +94,8 @@ class ConnectorGitHub(Connector):
         return aiohttp.web.Response(
             text=json.dumps("Received"), status=201)
 
-    async def respond(self, message, room=None):
+    @register_event(Message)
+    async def send_message(self, message, target=None):
         """Respond with a message."""
         # stop immediately if the message is from the bot itself.
         if message.user == self.github_username:

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -122,9 +122,11 @@ class ConnectorMatrix(Connector):
                     if event['content']['msgtype'] == 'm.text':
                         if event['sender'] != self.mxid:
                             return Message(
-                                await self._get_nick(roomid, event['sender']),
-                                roomid, self,
                                 event['content']['body'],
+                                await self._get_nick(roomid, event['sender']),
+                                roomid,
+                                self,
+                                event_id=event['event_id'],
                                 raw_event=event)
 
     async def listen(self):  # pragma: no cover

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -27,12 +27,11 @@ class ConnectorMatrix(Connector):
         super().__init__(config, opsdroid=opsdroid)
 
         self.name = "ConnectorMatrix"  # The name of your connector
-        self.config = config  # The config dictionary to be accessed later
         self.rooms = config.get('rooms', None)
         if not self.rooms:
             self.rooms = {'main': config['room']}
         self.room_ids = {}
-        self.default_room = self.rooms['main']
+        self.default_target = self.rooms['main']
         self.mxid = config['mxid']
         self.nick = config.get('nick', None)
         self.homeserver = config.get('homeserver', "https://matrix.org")
@@ -192,14 +191,12 @@ class ConnectorMatrix(Connector):
             }
 
     @register_event(Message)
-    async def send_message(self, message, target=None):
+    async def send_message(self, message, target):
         """Send `message.text` back to the chat service."""
-        if not room:
-            # Connector responds in the same room it received the original
-            # message
-            room_id = message.room
+        if not target.startswith(("!", "#")):
+            room_id = self.rooms[target]
         else:
-            room_id = self.rooms[room]
+            room_id = target
 
         # Ensure we have a room id not alias
         if not room_id.startswith('!'):

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -8,7 +8,7 @@ import aiohttp
 from matrix_api_async.api_asyncio import AsyncHTTPAPI
 from matrix_client.errors import MatrixRequestError
 
-from opsdroid.connector import Connector
+from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
 
 from .html_cleaner import clean
@@ -191,7 +191,8 @@ class ConnectorMatrix(Connector):
             "formatted_body": clean_html
             }
 
-    async def respond(self, message, room=None):
+    @register_event(Message)
+    async def send_message(self, message, target=None):
         """Send `message.text` back to the chat service."""
         if not room:
             # Connector responds in the same room it received the original

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -191,12 +191,12 @@ class ConnectorMatrix(Connector):
             }
 
     @register_event(Message)
-    async def send_message(self, message, target):
+    async def send_message(self, message):
         """Send `message.text` back to the chat service."""
-        if not target.startswith(("!", "#")):
-            room_id = self.rooms[target]
+        if not message.target.startswith(("!", "#")):
+            room_id = self.rooms[message.target]
         else:
-            room_id = target
+            room_id = message.target
 
         # Ensure we have a room id not alias
         if not room_id.startswith('!'):

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -155,7 +155,7 @@ class RocketChat(Connector):
             await asyncio.sleep(self.update_interval)
 
     @register_event(Message)
-    async def send_message(self, message, target):
+    async def send_message(self, message):
         """Respond with a message.
 
         The message argument carries both the text to reply with but
@@ -164,13 +164,12 @@ class RocketChat(Connector):
 
         Args:
             message (object): An instance of Message
-            target (string): Name of the room to respond to.
 
         """
         _LOGGER.debug("Responding with: %s", message.text)
         async with aiohttp.ClientSession() as session:
             data = {}
-            data['channel'] = target
+            data['channel'] = message.target
             data['alias'] = self.bot_name
             data['text'] = message.text
             data['avatar'] = ''

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -4,7 +4,7 @@ import logging
 import datetime
 import aiohttp
 
-from opsdroid.connector import Connector
+from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
 
 _LOGGER = logging.getLogger(__name__)
@@ -155,7 +155,8 @@ class RocketChat(Connector):
             await self._get_message()
             await asyncio.sleep(self.update_interval)
 
-    async def respond(self, message, room=None):
+    @register_event(Message)
+    async def send_message(self, message, target=None):
         """Respond with a message.
 
         The message argument carries both the text to reply with but
@@ -170,7 +171,7 @@ class RocketChat(Connector):
         _LOGGER.debug("Responding with: %s", message.text)
         async with aiohttp.ClientSession() as session:
             data = {}
-            data['channel'] = message.room
+            data['channel'] = target if target else message.target
             data['alias'] = self.bot_name
             data['text'] = message.text
             data['avatar'] = ''

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -124,18 +124,18 @@ class ConnectorSlack(Connector):
                                               raw_event=message))
 
     @register_event(Message)
-    async def send_message(self, message, target):
+    async def send_message(self, message):
         """Respond with a message."""
         _LOGGER.debug("Responding with: '%s' in room  %s",
-                      message.text, target)
-        await self.slacker.chat.post_message(target,
+                      message.text, message.target)
+        await self.slacker.chat.post_message(message.target,
                                              message.text,
                                              as_user=False,
                                              username=self.bot_name,
                                              icon_emoji=self.icon_emoji)
 
     @register_event(Reaction)
-    async def send_reaction(self, reaction, target):
+    async def send_reaction(self, reaction):
         """Send a reaction to a message, here the ``target`` is a Message."""
         """React to a message."""
         emoji = demojize(reaction.emoji)
@@ -143,8 +143,8 @@ class ConnectorSlack(Connector):
         try:
             await self.slacker.reactions.post('reactions.add', data={
                 'name': emoji,
-                'channel': target.target,
-                'timestamp': target.raw_event['ts']
+                'channel': reaction.target,
+                'timestamp': reaction.linked_event.raw_event['ts']
             })
         except slacker.Error as error:
             if str(error) == 'invalid_name':

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -136,7 +136,6 @@ class ConnectorSlack(Connector):
 
     @register_event(Reaction)
     async def send_reaction(self, reaction):
-        """Send a reaction to a message, here the ``target`` is a Message."""
         """React to a message."""
         emoji = demojize(reaction.emoji)
         _LOGGER.debug("Reacting with: %s", emoji)

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -117,10 +117,10 @@ class ConnectorSlack(Connector):
             message["text"] = await self.replace_usernames(
                 message["text"])
 
-            await self.opsdroid.parse(Message(user_info["name"],
+            await self.opsdroid.parse(Message(message["text"],
+                                              user_info["name"],
                                               message["channel"],
                                               self,
-                                              message["text"],
                                               raw_event=message))
 
     @register_event(Message)

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -241,12 +241,13 @@ class ConnectorTelegram(Connector):
         await self._closing.wait()
         message_getter.cancel()
 
-    async def respond(self, message, room=None):
+    @register_event(Message)
+    async def send_message(self, message, target):
         """Respond with a message.
 
         Args:
             message (object): An instance of Message.
-            room (string, optional): Name of the room to respond to.
+            target (string): Name of the room to respond to.
 
         """
         _LOGGER.debug("Responding with: %s", message.text)

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -242,12 +242,11 @@ class ConnectorTelegram(Connector):
         message_getter.cancel()
 
     @register_event(Message)
-    async def send_message(self, message, target):
+    async def send_message(self, message):
         """Respond with a message.
 
         Args:
             message (object): An instance of Message.
-            target (string): Name of the room to respond to.
 
         """
         _LOGGER.debug("Responding with: %s", message.text)

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -170,7 +170,7 @@ class ConnectorTelegram(Connector):
                 else:
                     message.text = "Sorry, you're not allowed " \
                                    "to speak with this bot."
-                    await self.respond(message)
+                    await self.send(message)
                 self.latest_update = result["update_id"] + 1
             else:
                 _LOGGER.error("Unable to parse the message.")

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -8,7 +8,7 @@ import aiohttp
 import aiohttp.web
 from aiohttp import WSCloseCode
 
-from opsdroid.connector import Connector
+from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
 
 
@@ -106,13 +106,15 @@ class ConnectorWebsocket(Connector):
 
         """
 
-    async def respond(self, message, room=None):
+    @register_event(Message)
+    async def send_message(self, message, target=None):
         """Respond with a message."""
+        target = target if target else message.target
         try:
-            if message.room is None:
-                message.room = next(iter(self.active_connections))
+            if target is None:
+                target = next(iter(self.active_connections))
             _LOGGER.debug("Responding with: '" + message.text +
-                          "' in room " + message.room)
-            await self.active_connections[message.room].send_str(message.text)
+                          "' in target " + target)
+            await self.active_connections[target].send_str(message.text)
         except KeyError:
-            _LOGGER.error("No active socket for room %s", message.room)
+            _LOGGER.error("No active socket for target %s", target)

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -105,13 +105,13 @@ class ConnectorWebsocket(Connector):
         """
 
     @register_event(Message)
-    async def send_message(self, message, target):
+    async def send_message(self, message):
         """Respond with a message."""
         try:
-            if target is None:
-                target = next(iter(self.active_connections))
+            if message.target is None:
+                message.target = next(iter(self.active_connections))
             _LOGGER.debug("Responding with: '" + message.text +
-                          "' in target " + target)
-            await self.active_connections[target].send_str(message.text)
+                          "' in target " + message.target)
+            await self.active_connections[message.target].send_str(message.text)
         except KeyError:
-            _LOGGER.error("No active socket for target %s", target)
+            _LOGGER.error("No active socket for target %s", message.target)

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -23,8 +23,6 @@ class ConnectorWebsocket(Connector):
         super().__init__(config, opsdroid=opsdroid)
         _LOGGER.debug("Starting Websocket connector")
         self.name = "websocket"
-        self.config = config
-        self.default_room = None
         self.max_connections = self.config.get("max-connections", 10)
         self.connection_timeout = self.config.get("connection-timeout", 60)
         self.accepting_connections = True
@@ -107,9 +105,8 @@ class ConnectorWebsocket(Connector):
         """
 
     @register_event(Message)
-    async def send_message(self, message, target=None):
+    async def send_message(self, message, target):
         """Respond with a message."""
-        target = target if target else message.target
         try:
             if target is None:
                 target = next(iter(self.active_connections))

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -112,6 +112,7 @@ class ConnectorWebsocket(Connector):
                 message.target = next(iter(self.active_connections))
             _LOGGER.debug("Responding with: '" + message.text +
                           "' in target " + message.target)
-            await self.active_connections[message.target].send_str(message.text)
+            await self.active_connections[message.target].send_str(
+                message.text)
         except KeyError:
             _LOGGER.error("No active socket for target %s", message.target)

--- a/opsdroid/constraints.py
+++ b/opsdroid/constraints.py
@@ -18,7 +18,7 @@ def constrain_rooms(rooms):
         """Add room constraint to skill."""
         def constraint_callback(message, rooms=rooms):
             """Check if the room is correct."""
-            return message.room in rooms
+            return message.target in rooms
         func = add_skill_attributes(func)
         func.constraints.append(constraint_callback)
         return func

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -291,8 +291,9 @@ class OpsDroid():
         else:
             self.critical("All connectors failed to load", 1)
 
+    # pylint: disable=W0640
     @property
-    def _connector_names(self):
+    def _connector_names(self):  # noqa: D401
         """Mapping of names to connector instances."""
         if not self.connectors:
             raise ValueError("No connectors have been started")

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -4,6 +4,7 @@ import asyncio
 from abc import ABC
 from random import randrange
 from datetime import datetime
+import warnings
 
 from opsdroid.helper import get_opsdroid
 
@@ -173,6 +174,13 @@ class Message(Event):
                 await self._typing_delay(response.text)
 
         await super().respond(response)
+
+    async def react(self, emoji):
+        warnings.warn(
+            "Message.react is deprecated. Use "
+            "Message.respond(events.Reaction(emoji)) instead.",
+            DeprecationWarning)
+        return await self.respond(Reaction(emoji))
 
 
 class Reaction(Event):

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -68,7 +68,6 @@ class Event(ABC):
         event.connector = event.connector or self.connector
         event.linked_event = event.linked_event or self
 
-        opsdroid = get_opsdroid()
         await opsdroid.send(event)
 
         if not self.responded_to:

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -84,8 +84,8 @@ class Message(Event):
 
     """
 
-    def __init__(self, user, target, connector,
-                 text, raw_event=None):  # noqa: D107
+    def __init__(self, user, target, connector, text,
+                 raw_event=None):  # noqa: D107
         """Create object with minimum properties."""
         super().__init__(user, target, connector)
         self.text = text
@@ -145,8 +145,9 @@ class Message(Event):
 
 class Reaction(Event):
     """Event class to support Unicode reaction to an event."""
-    def __init__(self, user, target, connector, raw_event=None):
+    def __init__(self, user, target, connector, emoji, raw_event=None):
         super().__init__(user, target, connector, raw_event)
+        self.emoji = emoji
 
 
 class File(Event):

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -4,7 +4,6 @@ import asyncio
 from abc import ABC
 from random import randrange
 from datetime import datetime
-import warnings
 
 from opsdroid.helper import get_opsdroid
 
@@ -174,13 +173,6 @@ class Message(Event):
                 await self._typing_delay(response.text)
 
         await super().respond(response)
-
-    async def react(self, emoji):
-        warnings.warn(
-            "Message.react is deprecated. Use "
-            "Message.respond(events.Reaction(emoji)) instead.",
-            DeprecationWarning)
-        return await self.respond(Reaction(emoji))
 
 
 class Reaction(Event):

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from opsdroid.helper import get_opsdroid
 
 
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods,keyword-arg-before-vararg
 class Event(ABC):
     """A generic event type.
 
@@ -83,7 +83,9 @@ class Typing(Event):
         timeout (float, optional): Timeout on typing event.
 
     """
+
     def __init__(self, trigger, timeout=None, *args, **kwargs):
+        """Create the object."""
         self.timeout = timeout
         self.trigger = trigger
         super().__init__(self, *args, **kwargs)
@@ -151,7 +153,7 @@ class Message(Event):
 
         await asyncio.sleep(char_count*seconds)
 
-    async def respond(self, response_event):
+    async def respond(self, event):
         """Respond to this message using the connector it was created by.
 
         Creates copy of this message with updated text as response.
@@ -159,10 +161,10 @@ class Message(Event):
         Updates responded_to attribute to True if False.
         Logs response and response time in OpsDroid object stats.
         """
-        if isinstance(response_event, str):
-            response = Message(response_event)
+        if isinstance(event, str):
+            response = Message(event)
         else:
-            response = response_event
+            response = event
 
         if 'thinking-delay' in self.connector.configuration or \
            'typing-delay' in self.connector.configuration:
@@ -185,7 +187,8 @@ class Reaction(Event):
         raw_event (dict, optional): Raw message as provided by chat service.
                                     None by default
     """
-    def __init__(self, emoji, *args, **kwargs):
+
+    def __init__(self, emoji, *args, **kwargs):  # noqa: D107
         super().__init__(*args, **kwargs)
         self.emoji = emoji
 
@@ -193,7 +196,8 @@ class Reaction(Event):
 class File(Event):
     """Event class to represent arbitrary files as bytes."""
 
-    def __init__(self, file_bytes=None, url=None, *args, **kwargs):  # noqa: D107
+    def __init__(self, file_bytes=None, url=None,
+                 *args, **kwargs):  # noqa: D107
         if not (file_bytes or url):
             raise ValueError("Either file_bytes or url must be specified")
 
@@ -206,5 +210,7 @@ class File(Event):
 class Image(File):
     """Event class specifically for image files."""
 
-    def __init__(self, image_bytes=None, image_url=None, *args, **kwargs):  # noqa: D107
-        super().__init__(file_bytes=image_bytes, url=image_url, *args, **kwargs)
+    def __init__(self, image_bytes=None, image_url=None,
+                 *args, **kwargs):  # noqa: D107
+        super().__init__(file_bytes=image_bytes, url=image_url,
+                         *args, **kwargs)

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -75,7 +75,7 @@ class Event(ABC):
             self.responded_to = True
 
 
-class Typing(Event):
+class Typing(Event):  # pragma: nocover
     """An event to set the user typing.
 
     Args:
@@ -198,7 +198,7 @@ class File(Event):
 
     def __init__(self, file_bytes=None, url=None,
                  *args, **kwargs):  # noqa: D107
-        if not (file_bytes or url):
+        if not (file_bytes or url) or (file_bytes and url):
             raise ValueError("Either file_bytes or url must be specified")
 
         super().__init__(*args, **kwargs)

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -62,8 +62,8 @@ class Event(ABC):
         event.connector = event.connector or self.connector
         event.linked_event = event.linked_event or self
 
-        # TODO: This needs to be opsdroid.send
-        await self.connector.send(event)
+        opsdroid = get_opsdroid()
+        await opsdroid.send(event)
 
         if not self.responded_to:
             now = datetime.now()

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -11,10 +11,46 @@ warn("opsdroid.message.Message is deprecated. "
 
 
 # pylint: disable=C0103
-def Message(text, user, room, connector, raw_event=None):
+def Message(text, user, room, connector, raw_message=None):
     """
     Stand-in function for the deprecated opsdroid.message.Message object.
 
     Returns a new opsdroid.events.Message object using the same arguments.
     """
-    return NewMessage(text, user, room, connector, raw_event=raw_event)
+    return NewMessage(text, user, room, connector, raw_event=raw_message)
+
+    @property
+    def room(self):
+        warn(
+            "Message.room is deprecated. Use "
+            "Message.target instead.",
+            DeprecationWarning)
+
+        return self.target
+
+    @room.setter
+    def room(self, value):
+        warn(
+            "Message.room is deprecated. Use "
+            "Message.target instead.",
+            DeprecationWarning)
+
+        self.target = value
+
+    @property
+    def raw_message(self):
+        warn(
+            "Message.raw_message is deprecated. Use "
+            "Message.raw_event instead.",
+            DeprecationWarning)
+
+        return self.raw_event
+
+    @raw_message.setter
+    def raw_message(self, value):
+        warn(
+            "Message.raw_message is deprecated. Use "
+            "Message.raw_event instead.",
+            DeprecationWarning)
+
+        self.raw_event = value

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -17,4 +17,4 @@ def Message(text, user, room, connector, raw_event=None):
 
     Returns a new opsdroid.events.Message object using the same arguments.
     """
-    return NewMessage(user, room, connector, text, raw_event)
+    return NewMessage(text, user, room, connector, raw_event=raw_event)

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -11,16 +11,21 @@ warn("opsdroid.message.Message is deprecated. "
 
 
 # pylint: disable=C0103
-def Message(text, user, room, connector, raw_message=None):
-    """
-    Stand-in function for the deprecated opsdroid.message.Message object.
+class Message(NewMessage):
+    """A message object.
 
-    Returns a new opsdroid.events.Message object using the same arguments.
+    Deprecated. Use ``opsdroid.events.Message`` instead.
     """
-    return NewMessage(text, user, room, connector, raw_event=raw_message)
+
+    def __init__(self, text, user, room, connector,
+                 raw_message=None):  # noqa: D401
+        """Deprecated opsdroid.message.Message object."""
+        super().__init__(text, user, room, connector,
+                         raw_event=raw_message)
 
     @property
-    def room(self):
+    def room(self):  # noqa: D401
+        """The room the message was sent into."""
         warn(
             "Message.room is deprecated. Use "
             "Message.target instead.",
@@ -38,7 +43,8 @@ def Message(text, user, room, connector, raw_message=None):
         self.target = value
 
     @property
-    def raw_message(self):
+    def raw_message(self):  # noqa: D401
+        """The raw contents of the message."""
         warn(
             "Message.raw_message is deprecated. Use "
             "Message.raw_event instead.",

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -1,13 +1,13 @@
 """Support for deprecated opsdroid.message.Message."""
 
-from warnings import warn
+import warnings
 
 from opsdroid.events import Message as NewMessage
 
 
-warn("opsdroid.message.Message is deprecated. "
-     "Please use opsdroid.events.Message instead.",
-     DeprecationWarning)
+warnings.warn("opsdroid.message.Message is deprecated. "
+              "Please use opsdroid.events.Message instead.",
+              DeprecationWarning)
 
 
 # pylint: disable=C0103
@@ -26,7 +26,7 @@ class Message(NewMessage):
     @property
     def room(self):  # noqa: D401
         """The room the message was sent into."""
-        warn(
+        warnings.warn(
             "Message.room is deprecated. Use "
             "Message.target instead.",
             DeprecationWarning)
@@ -35,7 +35,7 @@ class Message(NewMessage):
 
     @room.setter
     def room(self, value):
-        warn(
+        warnings.warn(
             "Message.room is deprecated. Use "
             "Message.target instead.",
             DeprecationWarning)
@@ -45,7 +45,7 @@ class Message(NewMessage):
     @property
     def raw_message(self):  # noqa: D401
         """The raw contents of the message."""
-        warn(
+        warnings.warn(
             "Message.raw_message is deprecated. Use "
             "Message.raw_event instead.",
             DeprecationWarning)
@@ -54,7 +54,7 @@ class Message(NewMessage):
 
     @raw_message.setter
     def raw_message(self, value):
-        warn(
+        warnings.warn(
             "Message.raw_message is deprecated. Use "
             "Message.raw_event instead.",
             DeprecationWarning)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -6,8 +6,8 @@ import asynctest.mock as amock
 
 from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
-from opsdroid.connector import Connector
-from opsdroid.events import Message, Typing, Reaction
+from opsdroid.connector import Connector, register_event
+from opsdroid.events import Message, Reaction
 from opsdroid.__main__ import configure_lang
 
 
@@ -50,6 +50,18 @@ class TestConnectorBaseClass(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.loop.run_until_complete(connector.send(Reaction("emoji")))
 
+    def test_incorrect_event(self):
+        class NotanEvent:
+            pass
+
+        class MyConnector(Connector):
+            @register_event(NotanEvent)
+            def send_my_event(self, event):
+                pass
+
+        with self.assertRaises(TypeError):
+            MyConnector()
+
 
 class TestConnectorAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid connector base class."""
@@ -60,3 +72,8 @@ class TestConnectorAsync(asynctest.TestCase):
         connector = Connector({}, opsdroid=OpsDroid())
         res = await connector.disconnect()
         assert res is None
+
+    async def test_send_incorrect_event(self):
+        connector = Connector({"name": "shell"})
+        with self.assertRaises(TypeError):
+            await connector.send(object())

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -7,6 +7,7 @@ import asynctest.mock as amock
 from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.connector import Connector
+from opsdroid.events import Message, Typing, Reaction
 from opsdroid.__main__ import configure_lang
 
 
@@ -20,7 +21,7 @@ class TestConnectorBaseClass(unittest.TestCase):
     def test_init(self):
         config = {"example_item": "test"}
         connector = Connector(config, opsdroid=OpsDroid())
-        self.assertEqual(None, connector.default_room)
+        self.assertEqual(None, connector.default_target)
         self.assertEqual("", connector.name)
         self.assertEqual("test", connector.config["example_item"])
 
@@ -41,20 +42,13 @@ class TestConnectorBaseClass(unittest.TestCase):
 
     def test_respond(self):
         connector = Connector({}, opsdroid=OpsDroid())
-        with self.assertRaises(NotImplementedError):
-            self.loop.run_until_complete(connector.respond({}))
+        with self.assertRaises(TypeError):
+            self.loop.run_until_complete(connector.send(Message("")))
 
-    def test_react(self):
+    def test_unsupported_event(self):
         connector = Connector({}, opsdroid=OpsDroid())
-        reacted = self.loop.run_until_complete(connector.react({}, 'emoji'))
-        self.assertFalse(reacted)
-
-    def test_user_typing(self):
-        opsdroid = 'opsdroid'
-        connector = Connector({}, opsdroid=OpsDroid())
-        user_typing = self.loop.run_until_complete(
-            connector.user_typing(trigger=True))
-        assert user_typing is None
+        with self.assertRaises(TypeError):
+            self.loop.run_until_complete(connector.send(Reaction("emoji")))
 
 
 class TestConnectorAsync(asynctest.TestCase):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -7,7 +7,7 @@ import asynctest.mock as amock
 from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.connector import Connector, register_event
-from opsdroid.events import Message, Reaction
+from opsdroid.events import Event, Message, Reaction
 from opsdroid.__main__ import configure_lang
 
 
@@ -77,3 +77,31 @@ class TestConnectorAsync(asynctest.TestCase):
         connector = Connector({"name": "shell"})
         with self.assertRaises(TypeError):
             await connector.send(object())
+
+    async def test_dep_respond(self):
+        connector = Connector({"name": "shell"})
+        with amock.patch("opsdroid.connector.Connector.send") as patched_send:
+            with self.assertWarns(DeprecationWarning):
+                await connector.respond("hello", room="bob")
+
+            patched_send.call_count == 1
+
+    async def test_dep_react(self):
+        connector = Connector({"name": "shell"})
+        with amock.patch("opsdroid.events.Message.respond") as patched_respond:
+            with self.assertWarns(DeprecationWarning):
+                await connector.react(Message("ori"), "hello")
+
+            patched_respond.call_count == 1
+
+    async def test_depreacted_properties(self):
+        connector = Connector({"name": "shell"})
+
+        connector.default_target = "spam"
+        with self.assertWarns(DeprecationWarning):
+            assert connector.default_room == "spam"
+
+        with self.assertWarns(DeprecationWarning):
+            connector.default_room = "eggs"
+
+        assert connector.default_target == "eggs"

--- a/tests/test_connector_facebook.py
+++ b/tests/test_connector_facebook.py
@@ -21,7 +21,7 @@ class TestConnectorFacebook(unittest.TestCase):
     def test_init(self):
         opsdroid = amock.CoroutineMock()
         connector = ConnectorFacebook({}, opsdroid=opsdroid)
-        self.assertEqual(None, connector.default_room)
+        self.assertEqual(None, connector.default_target)
         self.assertEqual("facebook", connector.name)
 
     def test_property(self):
@@ -148,7 +148,7 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
             connector = ConnectorFacebook({}, opsdroid=opsdroid)
             room = "a146f52c-548a-11e8-a7d1-28cfe949e12d"
             test_message = Message(user="Alice",
-                                   room=room,
+                                   target=room,
                                    connector=connector,
                                    text="Hello world")
             patched_request.return_value = asyncio.Future()
@@ -170,7 +170,7 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
             connector = ConnectorFacebook({}, opsdroid=opsdroid)
             room = "a146f52c-548a-11e8-a7d1-28cfe949e12d"
             test_message = Message(user="Alice",
-                                   room=room,
+                                   target=room,
                                    connector=connector,
                                    text="Hello world")
             patched_request.return_value = asyncio.Future()

--- a/tests/test_connector_facebook.py
+++ b/tests/test_connector_facebook.py
@@ -147,10 +147,10 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
             self.assertTrue(opsdroid.__class__.instances)
             connector = ConnectorFacebook({}, opsdroid=opsdroid)
             room = "a146f52c-548a-11e8-a7d1-28cfe949e12d"
-            test_message = Message(user="Alice",
+            test_message = Message(text="Hello world",
+                                   user="Alice",
                                    target=room,
-                                   connector=connector,
-                                   text="Hello world")
+                                   connector=connector)
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(post_response)
             await test_message.respond("Response")
@@ -169,10 +169,10 @@ class TestConnectorFacebookAsync(asynctest.TestCase):
             self.assertTrue(opsdroid.__class__.instances)
             connector = ConnectorFacebook({}, opsdroid=opsdroid)
             room = "a146f52c-548a-11e8-a7d1-28cfe949e12d"
-            test_message = Message(user="Alice",
+            test_message = Message(text="Hello world",
+                                   user="Alice",
                                    target=room,
-                                   connector=connector,
-                                   text="Hello world")
+                                   connector=connector)
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(post_response)
             await test_message.respond("Response")

--- a/tests/test_connector_github.py
+++ b/tests/test_connector_github.py
@@ -26,7 +26,7 @@ class TestConnectorGitHub(unittest.TestCase):
             'name': 'github',
             'token': 'test'
         })
-        self.assertEqual(None, connector.default_room)
+        self.assertEqual(None, connector.default_target)
         self.assertEqual("github", connector.name)
 
     def test_missing_token(self):
@@ -90,7 +90,7 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             message = self.connector.opsdroid.parse.call_args[0][0]
             self.assertEqual(message.connector.name, 'github')
             self.assertEqual(message.text, 'hello')
-            self.assertEqual(message.room, 'opsdroid/opsdroid#237')
+            self.assertEqual(message.target, 'opsdroid/opsdroid#237')
             self.assertTrue(self.connector.opsdroid.parse.called)
 
     async def test_get_pr(self):
@@ -108,7 +108,7 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             message = self.connector.opsdroid.parse.call_args[0][0]
             self.assertEqual(message.connector.name, 'github')
             self.assertEqual(message.text, 'hello world')
-            self.assertEqual(message.room, 'opsdroid/opsdroid-audio#175')
+            self.assertEqual(message.target, 'opsdroid/opsdroid-audio#175')
             self.assertTrue(self.connector.opsdroid.parse.called)
 
     async def test_get_issue(self):
@@ -126,7 +126,7 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             message = self.connector.opsdroid.parse.call_args[0][0]
             self.assertEqual(message.connector.name, 'github')
             self.assertEqual(message.text, 'test')
-            self.assertEqual(message.room, 'opsdroid/opsdroid#740')
+            self.assertEqual(message.target, 'opsdroid/opsdroid#740')
             self.assertTrue(self.connector.opsdroid.parse.called)
 
     async def test_get_label(self):
@@ -173,9 +173,9 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             mockresponse.status = 201
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(mockresponse)
-            resp = await self.connector.respond(
-                Message('jacobtomlinson', 'opsdroid/opsdroid#1',
-                        self.connector, 'test'))
+            resp = await self.connector.send(
+                Message("test", 'jacobtomlinson', 'opsdroid/opsdroid#1',
+                        self.connector))
             self.assertTrue(patched_request.called)
             self.assertTrue(resp)
 
@@ -186,9 +186,9 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(mockresponse)
             self.connector.github_username = 'opsdroid-bot'
-            resp = await self.connector.respond(
-                Message('opsdroid-bot', 'opsdroid/opsdroid#1',
-                        self.connector, 'test'))
+            resp = await self.connector.send(
+                Message('test', 'opsdroid-bot', 'opsdroid/opsdroid#1',
+                        self.connector))
             self.assertFalse(patched_request.called)
             self.assertTrue(resp)
 
@@ -201,8 +201,8 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             })
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(mockresponse)
-            resp = await self.connector.respond(
-                Message('opsdroid-bot', 'opsdroid/opsdroid#1',
-                        self.connector, 'test'))
+            resp = await self.connector.send(
+                Message('test', 'opsdroid-bot', 'opsdroid/opsdroid#1',
+                        self.connector))
             self.assertTrue(patched_request.called)
             self.assertFalse(resp)

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -265,7 +265,7 @@ class TestConnectorMatrixAsync(asynctest.TestCase):
             patched_room_id.return_value = asyncio.Future()
             patched_room_id.return_value.set_result(message.target)
 
-            message.room = "main"
+            message.target = "main"
             await self.connector.send(message)
 
             message_obj = self.connector._get_formatted_message_body(message.text)

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -182,7 +182,7 @@ class TestConnectorMatrixAsync(asynctest.TestCase):
 
             assert returned_message.text == 'LOUD NOISES'
             assert returned_message.user == 'SomeUsersName'
-            assert returned_message.room == '!aroomid:localhost'
+            assert returned_message.target == '!aroomid:localhost'
             assert returned_message.connector == self.connector
             raw_message = self.sync_return['rooms']['join']['!aroomid:localhost']['timeline']['events'][0]
             assert returned_message.raw_event == raw_message
@@ -237,20 +237,20 @@ class TestConnectorMatrixAsync(asynctest.TestCase):
         with amock.patch(api_string.format("send_message_event")) as patched_send:
             patched_send.return_value = asyncio.Future()
             patched_send.return_value.set_result(None)
-            await self.connector.respond(message)
+            await self.connector.send(message)
 
             message_obj = self.connector._get_formatted_message_body(message.text)
-            assert patched_send.called_once_with(message.room,
+            assert patched_send.called_once_with(message.target,
                                                  "m.room.message",
                                                  message_obj)
 
             patched_send.side_effect = [aiohttp.client_exceptions.ServerDisconnectedError(),
                                         patched_send.return_value]
 
-            await self.connector.respond(message)
+            await self.connector.send(message)
 
             message_obj = self.connector._get_formatted_message_body(message.text)
-            assert patched_send.called_once_with(message.room,
+            assert patched_send.called_once_with(message.target,
                                                  "m.room.message",
                                                  message_obj)
 
@@ -263,12 +263,13 @@ class TestConnectorMatrixAsync(asynctest.TestCase):
             patched_send.return_value.set_result(None)
 
             patched_room_id.return_value = asyncio.Future()
-            patched_room_id.return_value.set_result(message.room)
+            patched_room_id.return_value.set_result(message.target)
 
-            await self.connector.respond(message, room="main")
+            message.room = "main"
+            await self.connector.send(message)
 
             message_obj = self.connector._get_formatted_message_body(message.text)
-            assert patched_send.called_once_with(message.room,
+            assert patched_send.called_once_with(message.target,
                                                  "m.room.message",
                                                  message_obj)
 

--- a/tests/test_connector_rocketchat.py
+++ b/tests/test_connector_rocketchat.py
@@ -26,7 +26,7 @@ class TestRocketChat(unittest.TestCase):
             'access-token': 'test',
             'user-id': 'userID'
         }, opsdroid=OpsDroid())
-        self.assertEqual("general", connector.default_room)
+        self.assertEqual("general", connector.default_target)
         self.assertEqual("rocket.chat", connector.name)
 
     def test_missing_token(self):
@@ -45,7 +45,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
                 'name': 'rocket.chat',
                 'token': 'test',
                 'user-id': 'userID',
-                'default_room': "test"
+                'default_target': "test"
             }, opsdroid=OpsDroid())
 
         self.connector.latest_update = '2018-10-08T12:57:37.126Z'
@@ -210,7 +210,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             self.assertTrue(opsdroid.__class__.instances)
             test_message = Message(text="This is a test",
                                    user="opsdroid",
-                                   room="test",
+                                   target="test",
                                    connector=self.connector)
 
             patched_request.return_value = asyncio.Future()
@@ -229,7 +229,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             self.assertTrue(opsdroid.__class__.instances)
             test_message = Message(text="This is a test",
                                    user="opsdroid",
-                                   room="test",
+                                   target="test",
                                    connector=self.connector)
 
             patched_request.return_value = asyncio.Future()

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -368,7 +368,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             self.assertTrue(opsdroid.__class__.instances)
             test_message = Message(text="This is a test",
                                    user="opsdroid",
-                                   room={"id": 12404},
+                                   target={"id": 12404},
                                    connector=self.connector)
 
             patched_request.return_value = asyncio.Future()
@@ -388,7 +388,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             self.assertTrue(opsdroid.__class__.instances)
             test_message = Message(text="This is a test",
                                    user="opsdroid",
-                                   room={"id": 12404},
+                                   target={"id": 12404},
                                    connector=self.connector)
 
             patched_request.return_value = asyncio.Future()

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -24,7 +24,7 @@ class TestConnectorTelegram(unittest.TestCase):
             'name': 'telegram',
             'token': 'test',
         }, opsdroid=OpsDroid())
-        self.assertEqual(None, connector.default_room)
+        self.assertEqual(None, connector.default_target)
         self.assertEqual("telegram", connector.name)
 
     def test_missing_token(self):
@@ -249,7 +249,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
 
         message_text = "Sorry, you're not allowed to speak with this bot."
 
-        with amock.patch.object(self.connector, 'respond') \
+        with amock.patch.object(self.connector, 'send') \
                 as mocked_respond:
             await self.connector._parse_message(response)
             self.assertTrue(mocked_respond.called)

--- a/tests/test_connector_websocket.py
+++ b/tests/test_connector_websocket.py
@@ -20,7 +20,7 @@ class TestConnectorWebsocket(unittest.TestCase):
 
     def test_init(self):
         connector = ConnectorWebsocket({}, opsdroid=OpsDroid())
-        self.assertEqual(None, connector.default_room)
+        self.assertEqual(None, connector.default_target)
         self.assertEqual("websocket", connector.name)
 
     def test_property(self):
@@ -103,19 +103,19 @@ class TestConnectorWebsocketAsync(asynctest.TestCase):
             connector.active_connections[room].send_str = amock.CoroutineMock()
             test_message = Message(text="Hello world",
                                    user="Alice",
-                                   room=room,
+                                   target=room,
                                    connector=connector)
             await test_message.respond("Response")
             self.assertTrue(connector.active_connections[room].send_str.called)
 
             connector.active_connections[room].send_str.reset_mock()
-            test_message.room = None
+            test_message.target = None
             await test_message.respond("Response")
             self.assertTrue(
                 connector.active_connections[room].send_str.called)
 
             connector.active_connections[room].send_str.reset_mock()
-            test_message.room = "Invalid Room"
+            test_message.target = "Invalid Room"
             await test_message.respond("Response")
             self.assertFalse(
                 connector.active_connections[room].send_str.called)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -30,7 +30,7 @@ class TestConstraints(asynctest.TestCase):
             opsdroid.skills.append(skill)
 
             tasks = await opsdroid.parse(
-                Message('user', '#random', None, 'Hello')
+                Message('Hello', 'user', '#random', None)
             )
             self.assertEqual(len(tasks), 1) # Just match_always
 
@@ -43,7 +43,7 @@ class TestConstraints(asynctest.TestCase):
             opsdroid.skills.append(skill)
 
             tasks = await opsdroid.parse(
-                Message('user', '#general', None, 'Hello')
+                Message('Hello', 'user', '#general', None)
             )
             self.assertEqual(len(tasks), 2) # match_always and the skill
 
@@ -57,7 +57,7 @@ class TestConstraints(asynctest.TestCase):
             opsdroid.skills.append(skill)
 
             tasks = await opsdroid.parse(
-                Message('otheruser', '#general', None, 'Hello')
+                Message('Hello', 'otheruser', '#general', None)
             )
             self.assertEqual(len(tasks), 1) # Just match_always
 
@@ -70,7 +70,7 @@ class TestConstraints(asynctest.TestCase):
             opsdroid.skills.append(skill)
 
             tasks = await opsdroid.parse(
-                Message('user', '#general', None, 'Hello')
+                Message('Hello', 'user', '#general', None)
             )
             self.assertEqual(len(tasks), 2) # match_always and the skill
 
@@ -85,7 +85,7 @@ class TestConstraints(asynctest.TestCase):
             connector.configure_mock(name='twitter')
 
             tasks = await opsdroid.parse(
-                Message('user', '#random', connector, 'Hello')
+                Message('Hello', 'user', '#random', connector)
             )
             self.assertEqual(len(tasks), 1) # Just match_always
 
@@ -100,6 +100,6 @@ class TestConstraints(asynctest.TestCase):
             connector.configure_mock(name='slack')
 
             tasks = await opsdroid.parse(
-                Message('user', '#general', connector, 'Hello')
+                Message('Hello', 'user', '#general', connector)
             )
             self.assertEqual(len(tasks), 2) # match_always and the skill

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -198,10 +198,10 @@ class TestCore(unittest.TestCase):
             self.assertEqual(opsdroid.default_connector,
                              mock_default_connector)
 
-    def test_default_room(self):
+    def test_default_target(self):
         with OpsDroid() as opsdroid:
             mock_connector = Connector({}, opsdroid=opsdroid)
-            self.assertEqual(None, mock_connector.default_room)
+            self.assertEqual(None, mock_connector.default_target)
 
     def test_train_rasanlu(self):
         with OpsDroid() as opsdroid:
@@ -290,40 +290,40 @@ class TestCoreAsync(asynctest.TestCase):
         with OpsDroid() as opsdroid:
             regex = r"Hello .*"
             mock_connector = Connector({}, opsdroid=opsdroid)
-            mock_connector.respond = amock.CoroutineMock()
+            mock_connector.send = amock.CoroutineMock()
             skill = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex)(skill))
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello World", "user", "default", mock_connector)
             tasks = await opsdroid.parse(message)
             for task in tasks:
                 await task
-            self.assertTrue(mock_connector.respond.called)
+            self.assertTrue(mock_connector.send.called)
 
     async def test_parse_regex_method_skill(self):
         with OpsDroid() as opsdroid:
             regex = r"Hello .*"
             mock_connector = Connector({}, opsdroid=opsdroid)
-            mock_connector.respond = amock.CoroutineMock()
+            mock_connector.send = amock.CoroutineMock()
             skill = await self.getMockMethodSkill()
             opsdroid.skills.append(match_regex(regex)(skill))
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
             tasks = await opsdroid.parse(message)
             for task in tasks:
                 await task
-            self.assertTrue(mock_connector.respond.called)
+            self.assertTrue(mock_connector.send.called)
 
     async def test_parse_regex_insensitive(self):
         with OpsDroid() as opsdroid:
             regex = r"Hello .*"
             mock_connector = Connector({}, opsdroid=opsdroid)
-            mock_connector.respond = amock.CoroutineMock()
+            mock_connector.send = amock.CoroutineMock()
             skill = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex, case_sensitive=False)(skill))
-            message = Message("user", "default", mock_connector, "HELLO world")
+            message = Message("HELLO world", "user", "default", mock_connector)
             tasks = await opsdroid.parse(message)
             for task in tasks:
                 await task
-            self.assertTrue(mock_connector.respond.called)
+            self.assertTrue(mock_connector.send.called)
 
     async def test_parse_dialogflow(self):
         with OpsDroid() as opsdroid:
@@ -332,7 +332,7 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_dialogflow_action(dialogflow_action)(skill)
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.dialogflow.parse_dialogflow'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -353,7 +353,7 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_luisai_intent(luisai_intent)(skill)
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.luisai.parse_luisai'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -367,7 +367,7 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_rasanlu(rasanlu_intent)(skill)
-            message = Message("user", "default", mock_connector, "Hello")
+            message = Message("Hello", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.rasanlu.parse_rasanlu'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -381,7 +381,7 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_sapcai(sapcai_intent)(skill)
-            message = Message("user", "default", mock_connector, "Hello")
+            message = Message("Hello", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.sapcai.parse_sapcai'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -395,7 +395,7 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_witai(witai_intent)(skill)
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
             with amock.patch('opsdroid.parsers.witai.parse_witai'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -401,3 +401,56 @@ class TestCoreAsync(asynctest.TestCase):
                 self.assertEqual(len(tasks), 1)
                 for task in tasks:
                     await task
+
+    async def test_send_default_one(self):
+        with OpsDroid() as opsdroid, \
+             amock.patch("opsdroid.connector.Connector.send") as patched_send:
+            connector = Connector({"name": "shell"})
+            patched_send.return_value = asyncio.Future()
+            patched_send.return_value.set_result("")
+
+            opsdroid.connectors = [connector]
+
+            input_message = Message("Test")
+            await opsdroid.send(input_message)
+
+            patched_send.assert_called_once()
+            message = patched_send.call_args[0][0]
+
+            assert message is input_message
+
+    async def test_send_default_explicit(self):
+        with OpsDroid() as opsdroid, \
+             amock.patch("opsdroid.connector.Connector.send") as patched_send:
+            connector = Connector({"name": "shell", "default": True})
+            connector2 = Connector({"name": "matrix"})
+            patched_send.return_value = asyncio.Future()
+            patched_send.return_value.set_result("")
+
+            opsdroid.connectors = [connector, connector2]
+
+            input_message = Message("Test")
+            await opsdroid.send(input_message)
+
+            patched_send.assert_called_once()
+            message = patched_send.call_args[0][0]
+
+            assert message is input_message
+
+    async def test_send_name(self):
+        with OpsDroid() as opsdroid, \
+             amock.patch("opsdroid.connector.Connector.send") as patched_send:
+            connector = Connector({"name": "shell"})
+            connector2 = Connector({"name": "matrix"})
+            patched_send.return_value = asyncio.Future()
+            patched_send.return_value.set_result("")
+
+            opsdroid.connectors = [connector, connector2]
+
+            input_message = Message("Test", connector="shell")
+            await opsdroid.send(input_message)
+
+            patched_send.assert_called_once()
+            message = patched_send.call_args[0][0]
+
+            assert message is input_message

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -414,7 +414,6 @@ class TestCoreAsync(asynctest.TestCase):
             input_message = Message("Test")
             await opsdroid.send(input_message)
 
-            patched_send.assert_called_once()
             message = patched_send.call_args[0][0]
 
             assert message is input_message
@@ -432,7 +431,6 @@ class TestCoreAsync(asynctest.TestCase):
             input_message = Message("Test")
             await opsdroid.send(input_message)
 
-            patched_send.assert_called_once()
             message = patched_send.call_args[0][0]
 
             assert message is input_message
@@ -450,7 +448,6 @@ class TestCoreAsync(asynctest.TestCase):
             input_message = Message("Test", connector="shell")
             await opsdroid.send(input_message)
 
-            patched_send.assert_called_once()
             message = patched_send.call_args[0][0]
 
             assert message is input_message

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -211,6 +211,21 @@ class TestCore(unittest.TestCase):
                 opsdroid.train_parsers({})
                 opsdroid.eventloop.close()
 
+    def test_connector_names(self):
+        with OpsDroid() as opsdroid:
+            with self.assertRaises(ValueError):
+                opsdroid._connector_names
+
+            # Ensure names are always unique
+            c1 = Connector({"name": "spam"}, opsdroid=opsdroid)
+            c2 = Connector({"name": "spam"}, opsdroid=opsdroid)
+
+            opsdroid.connectors = [c1, c2]
+
+            names = opsdroid._connector_names
+            assert "spam" in names
+            assert "spam_1" in names
+
 
 class TestCoreAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid core class."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,7 @@ import asynctest
 import asynctest.mock as amock
 
 from opsdroid import events
+from opsdroid.core import OpsDroid
 from opsdroid.connector import Connector
 from opsdroid.__main__ import configure_lang
 
@@ -31,156 +32,156 @@ class TestMessage(asynctest.TestCase):
         configure_lang({})
 
     async def test_message(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({}, opsdroid=opsdroid)
-        raw_message = {
-            'text': 'Hello world',
-            'user': 'user',
-            'room': 'default',
-            'timestamp': '01/01/2000 19:23:00',
-            'messageId': '101'
-        }
-        message = events.Message(
-            "Hello world",
-            "user",
-            "default",
-            mock_connector,
-            raw_event=raw_message)
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({}, opsdroid=opsdroid)
+            raw_message = {
+                'text': 'Hello world',
+                'user': 'user',
+                'room': 'default',
+                'timestamp': '01/01/2000 19:23:00',
+                'messageId': '101'
+            }
+            message = events.Message(
+                "Hello world",
+                "user",
+                "default",
+                mock_connector,
+                raw_event=raw_message)
 
-        self.assertEqual(message.text, "Hello world")
-        self.assertEqual(message.user, "user")
-        self.assertEqual(message.target, "default")
-        self.assertEqual(
-            message.raw_event['timestamp'], '01/01/2000 19:23:00'
-            )
-        self.assertEqual(message.raw_event['messageId'], '101')
-        with self.assertRaises(TypeError):
-            await message.respond("Goodbye world")
-        # Also try responding with just some empty Event
-        with self.assertRaises(TypeError):
-            await message.respond(events.Event(
-                message.user, message.target, message.connector))
+            self.assertEqual(message.text, "Hello world")
+            self.assertEqual(message.user, "user")
+            self.assertEqual(message.target, "default")
+            self.assertEqual(
+                message.raw_event['timestamp'], '01/01/2000 19:23:00'
+                )
+            self.assertEqual(message.raw_event['messageId'], '101')
+            with self.assertRaises(TypeError):
+                await message.respond("Goodbye world")
+            # Also try responding with just some empty Event
+            with self.assertRaises(TypeError):
+                await message.respond(events.Event(
+                    message.user, message.target, message.connector))
 
     async def test_response_effects(self):
         """Responding to a message shouldn't change the message."""
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({}, opsdroid=opsdroid)
-        message_text = "Hello world"
-        message = events.Message(message_text, "user", "default", mock_connector)
-        with self.assertRaises(TypeError):
-            await message.respond("Goodbye world")
-        self.assertEqual(message_text, message.text)
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({}, opsdroid=opsdroid)
+            message_text = "Hello world"
+            message = events.Message(message_text, "user", "default", mock_connector)
+            with self.assertRaises(TypeError):
+                await message.respond("Goodbye world")
+            self.assertEqual(message_text, message.text)
 
     async def test_thinking_delay(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({
-            'name': 'shell',
-            'thinking-delay': 3,
-            'type': 'connector',
-            'module_path': 'opsdroid-modules.connector.shell'
-        }, opsdroid=opsdroid)
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({
+                'name': 'shell',
+                'thinking-delay': 3,
+                'type': 'connector',
+                'module_path': 'opsdroid-modules.connector.shell'
+            }, opsdroid=opsdroid)
 
-        with amock.patch(
-                'opsdroid.events.Message._thinking_delay') as logmock:
-            message = events.Message("hi", "user", "default", mock_connector)
-            with self.assertRaises(TypeError):
-                await message.respond("Hello there")
-
-            self.assertTrue(logmock.called)
-
-    async def test_thinking_sleep(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector_int = Connector({
-            'name': 'shell',
-            'thinking-delay': 3,
-            'type': 'connector',
-            'module_path': 'opsdroid-modules.connector.shell'
-        }, opsdroid=opsdroid)
-
-        with amock.patch('asyncio.sleep') as mocksleep_int:
-            message = events.Message("hi", "user", "default", mock_connector_int)
-            with self.assertRaises(TypeError):
-                await message.respond("Hello there")
-
-            self.assertTrue(mocksleep_int.called)
-
-        # Test thinking-delay with a list
-
-        mock_connector_list = Connector({
-            'name': 'shell',
-            'thinking-delay': [1, 4],
-            'type': 'connector',
-            'module_path': 'opsdroid-modules.connector.shell'
-        }, opsdroid=opsdroid)
-
-        with amock.patch('asyncio.sleep') as mocksleep_list:
-            message = events.Message("hi", "user", "default", mock_connector_list)
-            with self.assertRaises(TypeError):
-                await message.respond("Hello there")
-
-            self.assertTrue(mocksleep_list.called)
-
-    async def test_typing_delay(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({
-            'name': 'shell',
-            'typing-delay': 0.3,
-            'type': 'connector',
-            'module_path': 'opsdroid-modules.connector.shell'
-        }, opsdroid=opsdroid)
-        with amock.patch(
-                'opsdroid.events.Message._typing_delay') as logmock:
-            with amock.patch('asyncio.sleep') as mocksleep:
+            with amock.patch(
+                    'opsdroid.events.Message._thinking_delay') as logmock:
                 message = events.Message("hi", "user", "default", mock_connector)
                 with self.assertRaises(TypeError):
                     await message.respond("Hello there")
 
                 self.assertTrue(logmock.called)
-                self.assertTrue(mocksleep.called)
 
-        # Test thinking-delay with a list
+    async def test_thinking_sleep(self):
+        with OpsDroid() as opsdroid:
+            mock_connector_int = Connector({
+                'name': 'shell',
+                'thinking-delay': 3,
+                'type': 'connector',
+                'module_path': 'opsdroid-modules.connector.shell'
+            }, opsdroid=opsdroid)
 
-        mock_connector_list = Connector({
-            'name': 'shell',
-            'typing-delay': [1, 4],
-            'type': 'connector',
-            'module_path': 'opsdroid-modules.connector.shell'
-        }, opsdroid=opsdroid)
+            with amock.patch('asyncio.sleep') as mocksleep_int:
+                message = events.Message("hi", "user", "default", mock_connector_int)
+                with self.assertRaises(TypeError):
+                    await message.respond("Hello there")
 
-        with amock.patch('asyncio.sleep') as mocksleep_list:
-            message = events.Message("hi", "user", "default", mock_connector_list)
-            with self.assertRaises(TypeError):
-                await message.respond("Hello there")
+                self.assertTrue(mocksleep_int.called)
 
-            self.assertTrue(mocksleep_list.called)
+            # Test thinking-delay with a list
+
+            mock_connector_list = Connector({
+                'name': 'shell',
+                'thinking-delay': [1, 4],
+                'type': 'connector',
+                'module_path': 'opsdroid-modules.connector.shell'
+            }, opsdroid=opsdroid)
+
+            with amock.patch('asyncio.sleep') as mocksleep_list:
+                message = events.Message("hi", "user", "default", mock_connector_list)
+                with self.assertRaises(TypeError):
+                    await message.respond("Hello there")
+
+                self.assertTrue(mocksleep_list.called)
+
+    async def test_typing_delay(self):
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({
+                'name': 'shell',
+                'typing-delay': 0.3,
+                'type': 'connector',
+                'module_path': 'opsdroid-modules.connector.shell'
+            }, opsdroid=opsdroid)
+            with amock.patch(
+                    'opsdroid.events.Message._typing_delay') as logmock:
+                with amock.patch('asyncio.sleep') as mocksleep:
+                    message = events.Message("hi", "user", "default", mock_connector)
+                    with self.assertRaises(TypeError):
+                        await message.respond("Hello there")
+
+                    self.assertTrue(logmock.called)
+                    self.assertTrue(mocksleep.called)
+
+            # Test thinking-delay with a list
+
+            mock_connector_list = Connector({
+                'name': 'shell',
+                'typing-delay': [1, 4],
+                'type': 'connector',
+                'module_path': 'opsdroid-modules.connector.shell'
+            }, opsdroid=opsdroid)
+
+            with amock.patch('asyncio.sleep') as mocksleep_list:
+                message = events.Message("hi", "user", "default", mock_connector_list)
+                with self.assertRaises(TypeError):
+                    await message.respond("Hello there")
+
+                self.assertTrue(mocksleep_list.called)
 
     async def test_typing_sleep(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({
-            'name': 'shell',
-            'typing-delay': 6,
-            'type': 'connector',
-            'module_path': 'opsdroid-modules.connector.shell'
-        }, opsdroid=opsdroid)
-        with amock.patch('asyncio.sleep') as mocksleep:
-            message = events.Message("hi", "user", "default", mock_connector)
-            with self.assertRaises(TypeError):
-                await message.respond("Hello there")
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({
+                'name': 'shell',
+                'typing-delay': 6,
+                'type': 'connector',
+                'module_path': 'opsdroid-modules.connector.shell'
+            }, opsdroid=opsdroid)
+            with amock.patch('asyncio.sleep') as mocksleep:
+                message = events.Message("hi", "user", "default", mock_connector)
+                with self.assertRaises(TypeError):
+                    await message.respond("Hello there")
 
-            self.assertTrue(mocksleep.called)
+                self.assertTrue(mocksleep.called)
 
     async def test_react(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({
-            'name': 'shell',
-            'thinking-delay': 2,
-            'type': 'connector',
-        }, opsdroid=opsdroid)
-        with amock.patch('asyncio.sleep') as mocksleep:
-            message = events.Message("Hello world", "user", "default", mock_connector)
-            with self.assertRaises(TypeError):
-                await message.respond(events.Reaction("emoji"))
-            self.assertTrue(mocksleep.called)
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({
+                'name': 'shell',
+                'thinking-delay': 2,
+                'type': 'connector',
+            }, opsdroid=opsdroid)
+            with amock.patch('asyncio.sleep') as mocksleep:
+                message = events.Message("Hello world", "user", "default", mock_connector)
+                with self.assertRaises(TypeError):
+                    await message.respond(events.Reaction("emoji"))
+                self.assertTrue(mocksleep.called)
 
 
 class TestFile(asynctest.TestCase):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -202,6 +202,13 @@ class TestFile(asynctest.TestCase):
         self.assertEqual(event.target, "default")
         self.assertEqual(event.file_bytes.decode(), "some file contents")
 
+    def test_error_on_construct(self):
+        with self.assertRaises(ValueError):
+            events.File()
+
+        with self.assertRaises(ValueError):
+            events.File(b"a", "https://localhost")
+
 
 class TestImage(asynctest.TestCase):
     """Test the opsdroid image class"""

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -6,7 +6,7 @@ import unittest.mock as mock
 
 from opsdroid.helper import (
     del_rw, move_config_to_appdir, file_is_ipython_notebook,
-    convert_ipynb_to_script, extract_gist_id)
+    convert_ipynb_to_script, extract_gist_id, get_opsdroid)
 
 
 class TestHelper(unittest.TestCase):
@@ -57,3 +57,7 @@ class TestHelper(unittest.TestCase):
         self.assertEqual(
             extract_gist_id("c9852fa17d3463acc14dca1217d911f6"),
             "c9852fa17d3463acc14dca1217d911f6")
+
+    def test_opsdroid(self):
+        # Test that get_opsdroid returns None if no instances exist
+        assert get_opsdroid() is None

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -37,3 +37,24 @@ class TestMessage(asynctest.TestCase):
             self.assertEqual(message.raw_event['messageId'], '101')
             with self.assertRaises(TypeError):
                 await message.respond("Goodbye world")
+
+    def test_depreacted_properties(self):
+        message = Message("hello", "user", "", "")
+
+        message.target = "spam"
+        with self.assertWarns(DeprecationWarning):
+            assert message.room == "spam"
+
+        with self.assertWarns(DeprecationWarning):
+            message.room = "eggs"
+
+        assert message.room == "eggs"
+
+        message.raw_event = "spam"
+        with self.assertWarns(DeprecationWarning):
+            assert message.raw_message == "spam"
+
+        with self.assertWarns(DeprecationWarning):
+            message.raw_message = "eggs"
+
+        assert message.raw_event == "eggs"

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -26,14 +26,14 @@ class TestMessage(asynctest.TestCase):
             "user",
             "default",
             mock_connector,
-            raw_message)
+            raw_event=raw_message)
 
         self.assertEqual(message.text, "Hello world")
         self.assertEqual(message.user, "user")
-        self.assertEqual(message.room, "default")
+        self.assertEqual(message.target, "default")
         self.assertEqual(
             message.raw_event['timestamp'], '01/01/2000 19:23:00'
             )
         self.assertEqual(message.raw_event['messageId'], '101')
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             await message.respond("Goodbye world")

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,6 +1,6 @@
 import asynctest
-import asynctest.mock as amock
 
+from opsdroid.core import OpsDroid
 from opsdroid.message import Message
 from opsdroid.connector import Connector
 from opsdroid.__main__ import configure_lang
@@ -12,28 +12,28 @@ class TestMessage(asynctest.TestCase):
         configure_lang({})
 
     async def test_message(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({}, opsdroid=opsdroid)
-        raw_message = {
-            'text': 'Hello world',
-            'user': 'user',
-            'room': 'default',
-            'timestamp': '01/01/2000 19:23:00',
-            'messageId': '101'
-        }
-        message = Message(
-            "Hello world",
-            "user",
-            "default",
-            mock_connector,
-            raw_event=raw_message)
+        with OpsDroid() as opsdroid:
+            mock_connector = Connector({}, opsdroid=opsdroid)
+            raw_message = {
+                'text': 'Hello world',
+                'user': 'user',
+                'room': 'default',
+                'timestamp': '01/01/2000 19:23:00',
+                'messageId': '101'
+            }
+            message = Message(
+                "Hello world",
+                "user",
+                "default",
+                mock_connector,
+                raw_message=raw_message)
 
-        self.assertEqual(message.text, "Hello world")
-        self.assertEqual(message.user, "user")
-        self.assertEqual(message.target, "default")
-        self.assertEqual(
-            message.raw_event['timestamp'], '01/01/2000 19:23:00'
-            )
-        self.assertEqual(message.raw_event['messageId'], '101')
-        with self.assertRaises(TypeError):
-            await message.respond("Goodbye world")
+            self.assertEqual(message.text, "Hello world")
+            self.assertEqual(message.user, "user")
+            self.assertEqual(message.target, "default")
+            self.assertEqual(
+                message.raw_event['timestamp'], '01/01/2000 19:23:00'
+                )
+            self.assertEqual(message.raw_event['messageId'], '101')
+            with self.assertRaises(TypeError):
+                await message.respond("Goodbye world")

--- a/tests/test_parser_always.py
+++ b/tests/test_parser_always.py
@@ -63,9 +63,9 @@ class TestParserAlways(asynctest.TestCase):
             self.assertEqual(len(opsdroid.skills), 1)
 
             mock_connector = amock.MagicMock()
-            mock_connector.respond = amock.CoroutineMock()
-            message = Message("user", "default",
-                              mock_connector, "Hello world")
+            mock_connector.send = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default",
+                              mock_connector)
 
             await parse_always(opsdroid, message)
             self.assertLogs('_LOGGER', 'exception')

--- a/tests/test_parser_always.py
+++ b/tests/test_parser_always.py
@@ -34,7 +34,7 @@ class TestParserAlways(asynctest.TestCase):
             opsdroid.run_skill = amock.CoroutineMock()
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             await parse_always(opsdroid, message)
 
@@ -47,7 +47,7 @@ class TestParserAlways(asynctest.TestCase):
             opsdroid.run_skill = amock.CoroutineMock()
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             await parse_always(opsdroid, message)
 

--- a/tests/test_parser_dialogflow.py
+++ b/tests/test_parser_dialogflow.py
@@ -34,7 +34,7 @@ class TestParserDialogflow(asynctest.TestCase):
     async def test_call_dialogflow(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("user", "default", mock_connector, "Hello world")
+        message = Message("Hello world", "user", "default", mock_connector)
         config = {'name': 'dialogflow', 'access-token': 'test'}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
@@ -67,7 +67,7 @@ class TestParserDialogflow(asynctest.TestCase):
             opsdroid.skills.append(match_dialogflow_action('myaction')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             with amock.patch.object(dialogflow, 'call_dialogflow') as \
                     mocked_call_dialogflow:
@@ -97,8 +97,8 @@ class TestParserDialogflow(asynctest.TestCase):
             opsdroid.skills.append(match_dialogflow_action('myaction')(mock_skill))
 
             mock_connector = amock.MagicMock()
-            mock_connector.respond = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            mock_connector.send = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
 
             with amock.patch.object(dialogflow, 'call_dialogflow') as \
                     mocked_call_dialogflow:
@@ -130,7 +130,7 @@ class TestParserDialogflow(asynctest.TestCase):
             match_dialogflow_action('myaction')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             with amock.patch.object(dialogflow, 'call_dialogflow') as \
                     mocked_call_dialogflow:
@@ -161,7 +161,7 @@ class TestParserDialogflow(asynctest.TestCase):
             match_dialogflow_action('myaction')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             with amock.patch.object(dialogflow, 'call_dialogflow') as \
                     mocked_call_dialogflow:
@@ -192,7 +192,7 @@ class TestParserDialogflow(asynctest.TestCase):
             match_dialogflow_action('myaction')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             with amock.patch.object(dialogflow, 'call_dialogflow') \
                     as mocked_call:

--- a/tests/test_parser_luisai.py
+++ b/tests/test_parser_luisai.py
@@ -34,8 +34,8 @@ class TestParserLuisai(asynctest.TestCase):
     async def test_call_luisai(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("user", "default", mock_connector,
-                          "schedule meeting")
+        message = Message("schedule meeting", "user", "default",
+                          mock_connector)
         config = {'name': 'luisai',
                   'appid': 'test',
                   'appkey': 'test',
@@ -77,8 +77,7 @@ class TestParserLuisai(asynctest.TestCase):
             opsdroid.skills.append(match_luisai_intent('Calendar.Add')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "schedule meeting")
+            message = Message("schedule meeting", "user", "default", mock_connector)
 
             with amock.patch.object(luisai, 'call_luisai') as \
                     mocked_call_luisai:
@@ -115,8 +114,8 @@ class TestParserLuisai(asynctest.TestCase):
             opsdroid.skills.append(match_luisai_intent('Calendar.Add')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "schedule meeting")
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(luisai, 'call_luisai') as \
                     mocked_call_luisai:
@@ -147,9 +146,9 @@ class TestParserLuisai(asynctest.TestCase):
             opsdroid.skills.append(match_luisai_intent('Calendar.Add')(mock_skill))
 
             mock_connector = amock.MagicMock()
-            mock_connector.respond = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "schedule meeting")
+            mock_connector.send = amock.CoroutineMock()
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(luisai, 'call_luisai') as \
                     mocked_call_luisai:
@@ -188,8 +187,8 @@ class TestParserLuisai(asynctest.TestCase):
             match_luisai_intent('Calendar.Add')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "schedule meeting")
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(luisai, 'call_luisai') as \
                     mocked_call_luisai:
@@ -213,8 +212,8 @@ class TestParserLuisai(asynctest.TestCase):
             match_luisai_intent('Calendar.Add')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "schedule meeting")
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(luisai, 'call_luisai') as \
                     mocked_call_luisai:
@@ -250,8 +249,8 @@ class TestParserLuisai(asynctest.TestCase):
             match_luisai_intent('Calendar.Add')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "schedule meeting")
+            message = Message("schedule meeting", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(luisai, 'call_luisai') as \
                     mocked_call:

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -165,9 +165,9 @@ class TestParserRasaNLU(asynctest.TestCase):
             opsdroid.skills.append(match_rasanlu('get_weather')(mock_skill))
 
             mock_connector = amock.MagicMock()
-            mock_connector.respond = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            mock_connector.send = amock.CoroutineMock()
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(rasanlu, 'call_rasanlu') \
                     as mocked_call_rasanlu:
@@ -215,8 +215,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             match_rasanlu('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(rasanlu, 'call_rasanlu') \
                     as mocked_call_rasanlu:
@@ -234,8 +234,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             match_rasanlu('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(rasanlu, 'call_rasanlu') \
                     as mocked_call_rasanlu:
@@ -279,8 +279,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             match_rasanlu('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "hi")
+            message = Message("hi", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(rasanlu, 'call_rasanlu') \
                     as mocked_call_rasanlu:
@@ -304,8 +304,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             match_rasanlu('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(rasanlu, 'call_rasanlu') \
                     as mocked_call_rasanlu:
@@ -329,8 +329,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             match_rasanlu('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(rasanlu, 'call_rasanlu') as mocked_call:
                 mocked_call.side_effect = ClientOSError()

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -34,8 +34,8 @@ class TestParserRasaNLU(asynctest.TestCase):
     async def test_call_rasanlu(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("user", "default", mock_connector,
-                          "how's the weather outside")
+        message = Message("how's the weather outside", "user", "default",
+                          mock_connector)
         config = {'name': 'rasanlu',
                   'access-token': 'test',
                   'min-score': 0.3,
@@ -78,8 +78,8 @@ class TestParserRasaNLU(asynctest.TestCase):
     async def test_call_rasanlu_bad_response(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("user", "default", mock_connector,
-                          "how's the weather outside")
+        message = Message("how's the weather outside", "user", "default",
+                          mock_connector)
         config = {'name': 'rasanlu', 'access-token': 'test', 'min-score': 0.3}
         result = amock.Mock()
         result.status = 403
@@ -95,8 +95,8 @@ class TestParserRasaNLU(asynctest.TestCase):
     async def test_call_rasanlu_raises(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("user", "default", mock_connector,
-                          "how's the weather outside")
+        message = Message("how's the weather outside", "user", "default",
+                          mock_connector)
         config = {'name': 'rasanlu', 'access-token': 'test', 'min-score': 0.3}
         result = amock.Mock()
         result.status = 403
@@ -118,8 +118,8 @@ class TestParserRasaNLU(asynctest.TestCase):
             opsdroid.skills.append(match_rasanlu('get_weather')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(rasanlu, 'call_rasanlu') \
                     as mocked_call_rasanlu:

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -62,9 +62,9 @@ class TestParserRegex(asynctest.TestCase):
             self.assertEqual(len(opsdroid.skills), 1)
 
             mock_connector = amock.MagicMock()
-            mock_connector.respond = amock.CoroutineMock()
-            message = Message("user", "default",
-                              mock_connector, "Hello world")
+            mock_connector.send = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default",
+                              mock_connector)
 
             skills = await parse_regex(opsdroid, opsdroid.skills, message)
             self.assertEqual(mock_skill, skills[0]["skill"])

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -33,7 +33,7 @@ class TestParserRegex(asynctest.TestCase):
             opsdroid.skills.append(match_regex(r"(.*)")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             skills = await parse_regex(opsdroid, opsdroid.skills, message)
             self.assertEqual(mock_skill, skills[0]["skill"])
@@ -49,7 +49,7 @@ class TestParserRegex(asynctest.TestCase):
             opsdroid.skills.append(match_regex(regex, score_factor=1)(mock_skill_high))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello world")
+            message = Message("Hello world", "user", "default", mock_connector)
 
             skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
             self.assertEqual(mock_skill_high, skills[0]["skill"])

--- a/tests/test_parser_sapcai.py
+++ b/tests/test_parser_sapcai.py
@@ -33,8 +33,8 @@ class TestParserRecastAi(asynctest.TestCase):
     async def test_call_sapcai(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("user", "default", mock_connector, "Hello")
-        config = {'name': 'sapcai', 'access-token': 'test'}
+        message = Message("Hello" "user", "default", mock_connector)
+        config = {'name': 'recastai', 'access-token': 'test'}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
         result.json.return_value = {
@@ -78,7 +78,7 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello")
+            message = Message("Hello" "user", "default", mock_connector)
 
             with amock.patch.object(sapcai, 'call_sapcai') as \
                     mocked_call_sapcai:

--- a/tests/test_parser_sapcai.py
+++ b/tests/test_parser_sapcai.py
@@ -120,8 +120,8 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.MagicMock()
-            mock_connector.respond = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello")
+            mock_connector.send = amock.CoroutineMock()
+            message = Message("Hello", "user", "default", mock_connector)
 
             with amock.patch.object(sapcai, 'call_sapcai') as \
                     mocked_call_sapcai:
@@ -168,7 +168,7 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "")
+            message = Message("", "user", "default", mock_connector)
 
             with amock.patch.object(sapcai, 'call_sapcai') as \
                     mocked_call_sapcai:
@@ -193,10 +193,10 @@ class TestParserRecastAi(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
+                "kdjiruetosakdg",
                 "user",
                 "default",
-                mock_connector,
-                "kdjiruetosakdg")
+                mock_connector)
 
             with amock.patch.object(sapcai, 'call_sapcai') as \
                     mocked_call_sapcai:
@@ -237,7 +237,7 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai('intent')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello")
+            message = Message("Hello", "user", "default", mock_connector)
 
             with amock.patch.object(sapcai, 'call_sapcai') as \
                     mocked_call_sapcai:
@@ -281,7 +281,7 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "Hello")
+            message = Message("Hello", "user", "default", mock_connector)
 
             with amock.patch.object(sapcai, 'call_sapcai') \
                     as mocked_call:

--- a/tests/test_parser_witai.py
+++ b/tests/test_parser_witai.py
@@ -33,8 +33,8 @@ class TestParserWitai(asynctest.TestCase):
     async def test_call_witai(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("user", "default", mock_connector,
-                          "how's the weather outside")
+        message = Message("how's the weather outside","user", "default",
+                          mock_connector)
         config = {'name': 'witai', 'access-token': 'test', 'min-score': 0.3}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
@@ -64,8 +64,8 @@ class TestParserWitai(asynctest.TestCase):
             opsdroid.skills.append(match_witai('get_weather')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside","user", "default",
+                              mock_connector)
 
             with amock.patch.object(witai, 'call_witai') as mocked_call_witai:
                 mocked_call_witai.return_value = {

--- a/tests/test_parser_witai.py
+++ b/tests/test_parser_witai.py
@@ -95,9 +95,9 @@ class TestParserWitai(asynctest.TestCase):
             opsdroid.skills.append(match_witai('get_weather')(mock_skill))
 
             mock_connector = amock.MagicMock()
-            mock_connector.respond = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            mock_connector.send = amock.CoroutineMock()
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(witai, 'call_witai') as mocked_call_witai:
                 mocked_call_witai.return_value = {
@@ -128,8 +128,8 @@ class TestParserWitai(asynctest.TestCase):
             match_witai('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(witai, 'call_witai') as mocked_call_witai:
                 mocked_call_witai.return_value = {
@@ -149,8 +149,8 @@ class TestParserWitai(asynctest.TestCase):
             match_witai('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message,("user", "default", mock_connector,
-                               "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(witai, 'call_witai') as mocked_call_witai:
                 mocked_call_witai.return_value = {
@@ -178,7 +178,8 @@ class TestParserWitai(asynctest.TestCase):
             match_witai('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector, "hi")
+            message = Message("hi", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(witai, 'call_witai') as mocked_call_witai:
                 mocked_call_witai.return_value = {
@@ -199,8 +200,8 @@ class TestParserWitai(asynctest.TestCase):
             match_witai('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(witai, 'call_witai') as mocked_call_witai:
                 mocked_call_witai.return_value = {
@@ -227,8 +228,8 @@ class TestParserWitai(asynctest.TestCase):
             match_witai('get_weather')(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("user", "default", mock_connector,
-                              "how's the weather outside")
+            message = Message("how's the weather outside", "user", "default",
+                              mock_connector)
 
             with amock.patch.object(witai, 'call_witai') as mocked_call:
                 mocked_call.side_effect = ClientOSError()


### PR DESCRIPTION
# Description

This is a follow on for #721 which addresses the second stage of #719. This provides the foundation for connectors to be able to respond to different types of events, via a `send` method.

~*No allowances for backwards compatibility have been made yet.*~

## Status
**READY**


## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

