### PR TITLE
Update telegram connector to accept first_name and username

### DIFF
--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -30,11 +30,12 @@ connectors:
 ## Usage
 
 To talk with Opsdroid you will have to start a new private chat by searching for the name of your bot
-in the search bar.
+in the search bar. The telegram API doesn't include the name of a user when they send a message to a channel, 
+so the connector is unable to trigger any commands sent from a channel.
 
-For example, if you named your bot: `MyAwesome_Bot` you can just search for that name and wait for the 
-result to show up, then click on the name of your bot and a new chat window will start. You can now talk 
-with your bot and give him commands.
+For example, if you named your bot: `MyAwesome_Bot` you can just search for that name and wait for the result 
+to show up, then click on the name of your bot and a new chat window will start. You can now talk with your 
+bot and give him commands.
 
 _Note: To avoid unauthorized users to interact with your bot you should specify a list of whitelisted users
 in your `config.yaml`._
@@ -65,4 +66,4 @@ Bye FabioRosado
 ```
 
 To avoid this from happening, you should only contact the bot when opsdroid is running. The bot should reply immediately.
-If it doesn't, check that the bot is running before attempting to send another command - or try with a risk free one like `hello`.
+If it doesn't, check that the bot is running before attempting to send another command - or try with a risk-free one like `hello`.

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -33,12 +33,8 @@ To talk with Opsdroid you will have to start a new private chat by searching for
 in the search bar. The telegram API doesn't include the name of a user when they send a message to a channel, 
 so the connector is unable to trigger any commands sent from a channel.
 
-For example, if you named your bot: `MyAwesome_Bot` you can just search for that name and wait for the result 
-to show up, then click on the name of your bot and a new chat window will start. You can now talk with your 
-bot and give him commands.
+For example, if you named your bot: `MyAwesome_Bot` you can just search for that name and wait for the result to show up, then click on the name of your bot and a new chat window will start. You can now talk with your bot and give him commands.
 
-_Note: To avoid unauthorized users to interact with your bot you should specify a list of whitelisted users
-in your `config.yaml`._
 
 ```
 [6:13:11 PM] Fabio:
@@ -67,3 +63,37 @@ Bye FabioRosado
 
 To avoid this from happening, you should only contact the bot when opsdroid is running. The bot should reply immediately.
 If it doesn't, check that the bot is running before attempting to send another command - or try with a risk-free one like `hello`.
+
+## White listing users
+
+This is an optional config option that you can include on your `config.yaml` to prevent unauthorized users to interact with your bot.
+Currently, you can specify a user `nickname` or a `userID`. Using the `userID` method is preferable as it will increase the security 
+of the connector since users can't change this ID.
+
+Here is how you can whitelist a user:
+```yaml
+  - name: Telegram
+    token: <your bot token>
+    whitelisted-users:
+      - user1
+      - 124324234 # this is a userID
+```
+
+Finding your `userID` is not straight forward. This value is sent by Telegram when a user sends a private message to someone (the bot in this case) or when someone calls the `getUpdate` from the API.
+To find a `userID` by a private message, set the `logging` level to `debug` and start a new private message to the bot. You will see the API response on your console - it will look similar to this:
+
+```json
+{
+  'update_id': 539026743, 
+  'message': {
+    'message_id': 109, 
+    'from': {
+      'id': 4532189818, 
+      'is_bot': False, 
+      'first_name': 'user', 
+      'language_code': 'en'},
+    'chat': {}
+ }}
+```
+
+Use the `id` value from the `message["from"]` field and add it to your `whitelisted-users` config option.

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -93,8 +93,13 @@ class ConnectorTelegram(Connector):
         """
         for result in response["result"]:
             _LOGGER.debug(result)
-            if result["message"]["text"]:
+
+            try:
                 user = result["message"]["from"]["username"]
+            except KeyError:
+                user = result["message"]["from"]["first_name"]
+
+            if "message" in result and "text" in result["message"]:
 
                 message = Message(
                     user,
@@ -110,6 +115,8 @@ class ConnectorTelegram(Connector):
                                    "to speak with this bot."
                     await self.respond(message)
                 self.latest_update = result["update_id"] + 1
+            else:
+                _LOGGER.error("Unable to parse message.")
 
     async def _get_messages(self):
         """Connect to the Telegram API.

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -39,6 +39,28 @@ class ConnectorTelegram(Connector):
             _LOGGER.error("Unable to login: Access token is missing. "
                           "Telegram connector will be unavailable.")
 
+    @staticmethod
+    def get_user(response):
+        """Get user from response.
+
+        The API response is different depending on how
+        the bot is set up and where the message is coming
+        from. This method was created to keep if/else
+        statements to a minium on  _parse_message.
+
+        Args:
+            response (dict): Response returned by aiohttp.ClientSession.
+
+        """
+        user = None
+        if "username" in response["message"]["from"]:
+            user = response["message"]["from"]["username"]
+
+        elif "first_name" in response["message"]["from"]:
+            user = response["message"]["from"]["first_name"]
+
+        return user
+
     def build_url(self, method):
         """Build the url to connect to the API.
 
@@ -93,13 +115,9 @@ class ConnectorTelegram(Connector):
         """
         for result in response["result"]:
             _LOGGER.debug(result)
+            user = self.get_user(result)
 
-            try:
-                user = result["message"]["from"]["username"]
-            except KeyError:
-                user = result["message"]["from"]["first_name"]
-
-            if "message" in result and "text" in result["message"]:
+            if "message" in result and "text" in result["message"] and user:
 
                 message = Message(
                     user,

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -97,7 +97,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
                     "id": 649671308,
                     "first_name": "A",
                     "last_name": "User",
-                    "username": "a_user",
+                    "username": "user",
                     "type": "private"
                 },
                 "date": 1538756863,

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -1,11 +1,10 @@
 """Tests for the ConnectorTelegram class."""
 import asyncio
+import contextlib
 import unittest
-import unittest.mock as mock
 import asynctest
 import asynctest.mock as amock
 
-from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.connector.telegram import ConnectorTelegram
 from opsdroid.events import Message
@@ -44,6 +43,8 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
                 'token': 'bot:765test',
                 'whitelisted-users': ['user', 'test', 'AnUser']
             }, opsdroid=OpsDroid())
+        with amock.patch('aiohttp.ClientSession') as mocked_session:
+            self.connector.session = mocked_session
 
     async def test_connect(self):
         connect_response = amock.Mock()
@@ -59,7 +60,8 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             }
         }
 
-        with amock.patch('aiohttp.ClientSession.get') as patched_request:
+        with amock.patch('aiohttp.ClientSession.get')\
+                as patched_request:
 
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(connect_response)
@@ -72,7 +74,8 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
         result = amock.MagicMock()
         result.status = 401
 
-        with amock.patch('aiohttp.ClientSession.get') as patched_request:
+        with amock.patch('aiohttp.ClientSession.get')\
+                as patched_request:
 
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
@@ -108,6 +111,35 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
         with amock.patch('opsdroid.core.OpsDroid.parse') as mocked_parse:
             await self.connector._parse_message(response)
             self.assertTrue(mocked_parse.called)
+
+    async def test_parse_message_channel(self):
+        response = {'result': [{
+            "update_id": 427647860,
+            "message": {
+                "message_id": 12,
+                "from": {
+                    "id": 649671308,
+                    "is_bot": False,
+                    "first_name": "A",
+                    "last_name": "User",
+                    "username": "user",
+                    "language_code": "en-GB"
+                },
+                "chat": {
+                    "id": 649671308,
+                    "first_name": "A",
+                    "last_name": "User",
+                    "username": "user",
+                    "type": "channel"
+                },
+                "date": 1538756863,
+                "text": "Hello"
+            }
+        }]}
+
+        with amock.patch('opsdroid.core.OpsDroid.parse') as mocked_parse:
+            await self.connector._parse_message(response)
+            self.assertLogs('_LOGGER', 'debug')
 
     async def test_parse_message_first_name(self):
         response = { 'result': [{
@@ -189,8 +221,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
 
         message_text = "Sorry, you're not allowed to speak with this bot."
 
-        with OpsDroid() as opsdroid, \
-                amock.patch.object(self.connector, 'respond') \
+        with amock.patch.object(self.connector, 'respond') \
                 as mocked_respond:
             await self.connector._parse_message(response)
             self.assertTrue(mocked_respond.called)
@@ -226,9 +257,9 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             }
         ]}
 
-        with OpsDroid() as opsdroid, \
-            amock.patch('aiohttp.ClientSession.get') as patched_request,\
-            amock.patch.object(self.connector, '_parse_message') \
+        with amock.patch.object(self.connector.session, 'get') \
+                as patched_request,\
+                amock.patch.object(self.connector, '_parse_message') \
                 as mocked_parse_message:
 
             self.connector.latest_update = 54
@@ -244,25 +275,27 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
         listen_response = amock.Mock()
         listen_response.status = 401
 
-        with OpsDroid() as opsdroid, \
-            amock.patch('aiohttp.ClientSession.get') as patched_request:
+        with amock.patch.object(self.connector.session, 'get') \
+                as patched_request:
 
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(listen_response)
             await self.connector._get_messages()
             self.assertLogs('_LOGGER', 'error')
 
-    async def test_listen(self):
-        self.connector.listening = amock.CoroutineMock()
-        self.connector.listening.side_effect = Exception()
-        await self.connector.listen()
+    async def test_get_messages_loop(self):
+        self.connector._get_messages = amock.CoroutineMock()
+        self.connector._get_messages.side_effect = Exception()
+        with contextlib.suppress(Exception):
+            await self.connector.get_messages_loop()
 
     async def test_respond(self):
         post_response = amock.Mock()
         post_response.status = 200
 
         with OpsDroid() as opsdroid, \
-            amock.patch('aiohttp.ClientSession.post') as patched_request:
+                amock.patch.object(self.connector.session, 'post')\
+                as patched_request:
 
             self.assertTrue(opsdroid.__class__.instances)
             test_message = Message(text="This is a test",
@@ -281,7 +314,8 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
         post_response.status = 401
 
         with OpsDroid() as opsdroid, \
-            amock.patch('aiohttp.ClientSession.post') as patched_request:
+                amock.patch.object(self.connector.session, 'post')\
+                as patched_request:
 
             self.assertTrue(opsdroid.__class__.instances)
             test_message = Message(text="This is a test",
@@ -293,3 +327,26 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             patched_request.return_value.set_result(post_response)
             await test_message.respond("Response")
             self.assertLogs('_LOGGER', 'debug')
+
+    async def test_listen(self):
+        with amock.patch.object(self.connector.loop, 'create_task') \
+                as mocked_task, \
+                amock.patch.object(self.connector._closing, 'wait') as\
+                        mocked_event:
+            mocked_event.return_value = asyncio.Future()
+            mocked_event.return_value.set_result(True)
+            mocked_task.return_value = asyncio.Future()
+            await self.connector.listen()
+
+            self.assertTrue(mocked_event.called)
+            self.assertTrue(mocked_task.called)
+
+    async def test_disconnect(self):
+            with amock.patch.object(self.connector.session, 'close') as mocked_close:
+                mocked_close.return_value = asyncio.Future()
+                mocked_close.return_value.set_result(True)
+
+                await self.connector.disconnect()
+                self.assertFalse(self.connector.listening)
+                self.assertTrue(self.connector.session.closed())
+                self.assertEqual(self.connector._closing.set(), None)

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -271,6 +271,46 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             self.assertLogs('_LOGGER', 'debug')
             self.assertTrue(mocked_parse_message.called)
 
+    async def test_delete_webhook(self):
+        response = amock.Mock()
+        response.status = 200
+
+        with amock.patch.object(self.connector.session, 'get') \
+                as mock_request:
+            mock_request.return_value = asyncio.Future()
+            mock_request.return_value.set_result(response)
+
+            await self.connector.delete_webhook()
+            self.assertLogs('_LOGGER', 'debug')
+
+    async def test_get_message_webhook(self):
+        response = amock.Mock()
+        response.status = 409
+
+        with amock.patch.object(self.connector.session, 'get') \
+                as mock_request, \
+                amock.patch.object(self.connector, 'delete_webhook') \
+                as mock_method:
+            mock_request.return_value = asyncio.Future()
+            mock_request.return_value.set_result(response)
+
+            await self.connector._get_messages()
+            self.assertLogs('_LOGGER', 'info')
+            self.assertTrue(mock_method.called)
+
+
+    async def test_delete_webhook_failure(self):
+        response = amock.Mock()
+        response.status = 401
+
+        with amock.patch.object(self.connector.session, 'get') \
+                as mock_request:
+            mock_request.return_value = asyncio.Future()
+            mock_request.return_value.set_result(response)
+
+            await self.connector.delete_webhook()
+            self.assertLogs('_LOGGER', 'debug')
+
     async def test_get_messages_failure(self):
         listen_response = amock.Mock()
         listen_response.status = 401


### PR DESCRIPTION
# Description

This is a fix for the issue with Telegram, I've also added the suggestion by @iobreaker so this connector should now work with private messages, groups and chats. 

I have also decided to include a warning message when the result didn't contain `message` and `text` in its fields.

On the test side, I have removed the unused opsdroid mock.

--EDIT--
I decided to follow the Matrix connector logic by setting `self.session` to `aiohttp.ClientSession` on connect and use that same session when calling different api methods. I would like to know if this is a good way to do it instead of using `with` - this definitely kept the line numbers shorter

I have refactored the telegram methods, added changes suggested by @iobreaker. Changed the whitelist method to include userIDs to try and address the issue raised by Cadair about people bypassing this by changing their name.

I have also implemented a disconnect method - this was suggested by another contributor (I dont remember the name sorry) and was implemented to the shell connector. I have tested the disconnect method extensively without cancelling pending tasks and everything seems to be working okay.

In order to get this disconnect method I had to move the while loop to another method - this probably could be done in a different way.

Overall, I am happy with these changes and ready for the review 😄👍 


Fixes #839 and #840


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- Documentation fix
- Test fixed and added


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
-  Manually with telegram - all good
- Tested telegram with userID, username and none - all okay
- Tested disconnect with `tasks.cancel()` commented out in core - connector disconnected property without raising an exception



# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes