### PR TITLE
Update recastai

### DIFF
--- a/docs/matchers/sapcai.md
+++ b/docs/matchers/sapcai.md
@@ -1,8 +1,8 @@
-# Recast.AI Matcher
+# SAP Conversational AI Matcher (previously Recast.ai)
 
 ## Configuring opsdroid
 
-In order to enable Recast.AI skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file.
+In order to enable SAP Conversational AI skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file.
 You can find this `access-token` in the settings of your bot under the name: `'Request access token'`.
 
 You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
@@ -10,26 +10,26 @@ You can also set a `min-score` option to tell opsdroid to ignore any matches whi
 ```yaml
 
 parsers:
-  - name: recastai
+  - name: sapcai
     access-token: 85769fjoso084jd
     min-score: 0.8
 ```
 
 ##
 
-[Recast.AI](https://recast.ai/) is an NLP API for matching strings to [intents](https://recast.ai/docs/intent). Intents are created on the Recast.AI website.
+[SAP Conversational AI](https://cai.tools.sap/) is an NLP API for matching strings to [intents](https://cai.tools.sap/docs/concepts/intent). Intents are created on the SAP Conversational AI website.
 
 ## [Example 1](#example1)
 
 ```python
 from opsdroid.skill import Skill
-from opsdroid.matchers import match_recastai
+from opsdroid.matchers import match_sapcai
 
 class MySkill(Skill):
-    @match_recastai('greetings')
+    @match_sapcai('greetings')
     async def hello(self, message):
         """Replies to user when any 'greetings'
-        intent is returned by Recast.AI
+        intent is returned by SAP Conversational AI
         """
         await message.respond("Hello there!")
 ```
@@ -40,10 +40,10 @@ The above skill would be called on any intent which has a name of `'greetings'`.
 
 ```python
 from opsdroid.skill import Skill
-from opsdroid.matchers import match_recastai
+from opsdroid.matchers import match_sapcai
 
 class MySkill(Skill):
-    @match_recastai('ask-joke')
+    @match_sapcai('ask-joke')
     async def my_skill(self, message):
         """Returns a joke if asked by the user"""
         await message.respond('What do you call a bear with no teeth? -- A gummy bear!')
@@ -52,33 +52,33 @@ class MySkill(Skill):
 The above skill would be called on any intent which has a name of `'ask-joke'`.
 
 
-## Creating a Recast.AI bot
-You need to [register](https://recast.ai/signup) on Recast.AI and create a bot in order to use Recast.AI with opsdroid.
+## Creating a SAP Conversational AI bot
+You need to [register](https://cai.tools.sap/signup) on SAP Conversational AI and create a bot in order to use SAP Conversational AI with opsdroid.
 
-You can find a quick getting started with the Recast.AI guide [here](https://recast.ai/docs/create-your-bot).
+You can find a quick getting started with the SAP Conversational AI guide [here](https://cai.tools.sap/docs/concepts/create-builder-bot).
 
-If you want to use Recast.AI in a different language other than English, all you need to do is specify the `lang` parameter in opsdroid's configuration.
+If you want to use SAP Conversational AI in a different language other than English, all you need to do is specify the `lang` parameter in opsdroid's configuration.
 
-_Note: "If you do not have any expressions in this language, we will use your default bot language for processing." - [Recast.AI Language page](https://recast.ai/docs/language)_
+_Note: "If you do not have any expressions in this language, we will use your default bot language for processing." - [SAP Conversational AI Language page](https://cai.tools.sap/docs/concepts/language)_
 
 ## Message object additional parameters
 
 ### `message.recastai`
 
-An http response object which has been returned by the Recast.AI API. This allows you to access any information from the matched intent including other entities, intents, values, etc.
+An http response object which has been returned by the SAP Conversational AI API. This allows you to access any information from the matched intent including other entities, intents, values, etc.
 
 
 ## Example Skill
 
 ```python
 from opsdroid.skill import Skill
-from opsdroid.matchers import match_recastai
+from opsdroid.matchers import match_sapcai
 
 import json
 
 class MySkill(Skill):
-    @match_recastai('ask-feeling')
-    async def dumpResponse(self, message):
+    @match_sapcai('ask-feeling')
+    async def dump_response(self, message):
         print(json.dumps(message.recastai))
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ pages:
       - 'Rasa NLU (local)': 'matchers/rasanlu.md'
       - 'Dialogflow (Api.ai)': 'matchers/dialogflow.md'
       - 'LUIS.AI': 'matchers/luis.ai.md'
-      - 'Recast.AI': 'matchers/recast.ai.md'
+      - 'Recast.AI (SAPCAI)': 'matchers/sapcai.md'
       - 'wit.ai': 'matchers/wit.ai.md'
       - 'Crontab': 'matchers/crontab.md'
       - 'Webhook': 'matchers/webhook.md'

--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -35,4 +35,4 @@ DIALOGFLOW_API_VERSION = "20150910"
 WITAI_DEFAULT_VERSION = "20170307"
 WITAI_API_ENDPOINT = "https://api.wit.ai/message?"
 
-RECASTAI_API_ENDPOINT = "https://api.recast.ai/v2/request"
+SAPCAI_API_ENDPOINT = "https://api.cai.tools.sap/v2/request"

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -21,7 +21,7 @@ from opsdroid.parsers.always import parse_always
 from opsdroid.parsers.regex import parse_regex
 from opsdroid.parsers.dialogflow import parse_dialogflow
 from opsdroid.parsers.luisai import parse_luisai
-from opsdroid.parsers.recastai import parse_recastai
+from opsdroid.parsers.sapcai import parse_sapcai
 from opsdroid.parsers.witai import parse_witai
 from opsdroid.parsers.rasanlu import parse_rasanlu, train_rasanlu
 from opsdroid.parsers.crontab import parse_crontab
@@ -362,14 +362,14 @@ class OpsDroid():
                     await parse_luisai(self, skills,
                                        message, luisai[0])
 
-            recastai = [p for p in parsers if p["name"] == "recastai"]
-            if len(recastai) == 1 and \
-                    ("enabled" not in recastai[0] or
-                     recastai[0]["enabled"] is not False):
+            sapcai = [p for p in parsers if p["name"] == "sapcai"]
+            if len(sapcai) == 1 and \
+                    ("enabled" not in sapcai[0] or
+                     sapcai[0]["enabled"] is not False):
                 _LOGGER.debug(_("Checking Recast.AI..."))
                 ranked_skills += \
-                    await parse_recastai(self, skills,
-                                         message, recastai[0])
+                    await parse_sapcai(self, skills,
+                                       message, sapcai[0])
 
             witai = [p for p in parsers if p["name"] == "witai"]
             if len(witai) == 1 and \

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -109,7 +109,22 @@ def match_recastai(intent):
         """Add decorated function to skills list for recastai matching."""
         func = add_skill_attributes(func)
         func.matchers.append(
-            {"recastai_intent": intent}
+            {"sapcai_intent": intent}
+        )
+        return func
+    _LOGGER.warning(_("Recast.AI is now called SAP Conversational AI, "
+                      "this matcher  will stop working in the future. "
+                      "Use match_sapcai instead."))
+    return matcher
+
+
+def match_sapcai(intent):
+    """Return SAP Conversational AI intent match decorator."""
+    def matcher(func):
+        """Add decorated function to skills list for SAPCAI matching."""
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"sapcai_intent": intent}
         )
         return func
     return matcher

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,7 +13,7 @@ from opsdroid.connector import Connector
 from opsdroid.database import Database
 from opsdroid.web import Web
 from opsdroid.matchers import (match_regex, match_dialogflow_action,
-                               match_luisai_intent, match_recastai,
+                               match_luisai_intent, match_sapcai,
                                match_rasanlu, match_witai)
 
 
@@ -374,15 +374,15 @@ class TestCoreAsync(asynctest.TestCase):
                 for task in tasks:
                     await task
 
-    async def test_parse_recastai(self):
+    async def test_parse_sapcai(self):
         with OpsDroid() as opsdroid:
-            opsdroid.config["parsers"] = [{"name": "recastai"}]
-            recastai_intent = ""
+            opsdroid.config["parsers"] = [{"name": "sapcai"}]
+            sapcai_intent = ""
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
-            match_recastai(recastai_intent)(skill)
+            match_sapcai(sapcai_intent)(skill)
             message = Message("user", "default", mock_connector, "Hello")
-            with amock.patch('opsdroid.parsers.recastai.parse_recastai'):
+            with amock.patch('opsdroid.parsers.sapcai.parse_sapcai'):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
                 for task in tasks:

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -96,6 +96,16 @@ class TestMatchers(asynctest.TestCase):
             self.assertEqual(opsdroid.skills[0].matchers[0]["rasanlu_intent"], intent)
             self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
 
+    async def test_match_recastai(self):
+        with OpsDroid() as opsdroid:
+            intent = "myIntent"
+            decorator = matchers.match_recastai(intent)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
+            self.assertEqual(len(opsdroid.skills), 1)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["sapcai_intent"], intent)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
+            self.assertLogs("Warning", "_LOGGER")
+
     async def test_match_crontab(self):
         with OpsDroid() as opsdroid:
             crontab = "* * * * *"

--- a/tests/test_parser_sapcai.py
+++ b/tests/test_parser_sapcai.py
@@ -6,14 +6,14 @@ from aiohttp import ClientOSError
 
 from opsdroid.__main__ import configure_lang
 from opsdroid.core import OpsDroid
-from opsdroid.matchers import match_recastai
+from opsdroid.matchers import match_sapcai
 from opsdroid.events import Message
-from opsdroid.parsers import recastai
+from opsdroid.parsers import sapcai
 from opsdroid.connector import Connector
 
 
 class TestParserRecastAi(asynctest.TestCase):
-    """Test the opsdroid recastai parser."""
+    """Test the opsdroid sapcai parser."""
 
     async def setup(self):
         configure_lang({})
@@ -30,11 +30,11 @@ class TestParserRecastAi(asynctest.TestCase):
         mockedskill.config = {}
         return mockedskill
 
-    async def test_call_recastai(self):
+    async def test_call_sapcai(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message("user", "default", mock_connector, "Hello")
-        config = {'name': 'recastai', 'access-token': 'test'}
+        config = {'name': 'sapcai', 'access-token': 'test'}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
         result.json.return_value = {
@@ -63,26 +63,26 @@ class TestParserRecastAi(asynctest.TestCase):
         with amock.patch('aiohttp.ClientSession.post') as patched_request:
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
-            await recastai.call_recastai(message, config)
+            await sapcai.call_sapcai(message, config)
             self.assertTrue(patched_request.called)
 
-    async def test_parse_recastai(self):
+    async def test_parse_sapcai(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = [
-                {'name': 'recastai', 'access-token': "test"}
+                {'name': 'sapcai', 'access-token': "test"}
             ]
             mock_skill = await self.getMockSkill()
             mock_skill.config = {
                 "name": "greetings"
             }
-            opsdroid.skills.append(match_recastai('greetings')(mock_skill))
+            opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
             message = Message("user", "default", mock_connector, "Hello")
 
-            with amock.patch.object(recastai, 'call_recastai') as \
-                    mocked_call_recastai:
-                mocked_call_recastai.return_value = {
+            with amock.patch.object(sapcai, 'call_sapcai') as \
+                    mocked_call_sapcai:
+                mocked_call_sapcai.return_value = {
                     'results':
                         {
                             "uuid": "f482bddd-a9d7-41ae-aae3-6e64ad3f02dc",
@@ -104,28 +104,28 @@ class TestParserRecastAi(asynctest.TestCase):
                             "status": 200
                         }
                 }
-                skills = await recastai.parse_recastai(
+                skills = await sapcai.parse_sapcai(
                     opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
-    async def test_parse_recastai_raises(self):
+    async def test_parse_sapcai_raises(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = [
-                    {'name': 'recastai', 'access-token': "test"}
+                    {'name': 'sapcai', 'access-token': "test"}
                 ]
             mock_skill = await self.getRaisingMockSkill()
             mock_skill.config = {
                 "name": "mocked-skill"
             }
-            opsdroid.skills.append(match_recastai('greetings')(mock_skill))
+            opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.MagicMock()
             mock_connector.respond = amock.CoroutineMock()
             message = Message("user", "default", mock_connector, "Hello")
 
-            with amock.patch.object(recastai, 'call_recastai') as \
-                    mocked_call_recastai:
-                mocked_call_recastai.return_value = {
+            with amock.patch.object(sapcai, 'call_sapcai') as \
+                    mocked_call_sapcai:
+                mocked_call_sapcai.return_value = {
                     'results':
                         {
                             "uuid": "f482bddd-a9d7-41ae-aae3-6e64ad3f02dc",
@@ -148,7 +148,7 @@ class TestParserRecastAi(asynctest.TestCase):
                         }
                 }
 
-                skills = await recastai.parse_recastai(
+                skills = await sapcai.parse_sapcai(
                     opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertEqual(mock_skill, skills[0]["skill"])
 
@@ -156,40 +156,40 @@ class TestParserRecastAi(asynctest.TestCase):
                 skills[0]["skill"], skills[0]["config"], message)
             self.assertLogs('_LOGGER', 'exception')
 
-    async def test_parse_recastai_failure(self):
+    async def test_parse_sapcai_failure(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = [
-                    {'name': 'recastai', 'access-token': "test"}
+                    {'name': 'sapcai', 'access-token': "test"}
                 ]
             mock_skill = await self.getMockSkill()
             mock_skill.config = {
                 "name": "greetings"
             }
-            opsdroid.skills.append(match_recastai('greetings')(mock_skill))
+            opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
             message = Message("user", "default", mock_connector, "")
 
-            with amock.patch.object(recastai, 'call_recastai') as \
-                    mocked_call_recastai:
-                mocked_call_recastai.return_value = {
+            with amock.patch.object(sapcai, 'call_sapcai') as \
+                    mocked_call_sapcai:
+                mocked_call_sapcai.return_value = {
                     'results': None,
                     'message': 'Text is empty'
                 }
-                skills = await recastai.parse_recastai(
+                skills = await sapcai.parse_sapcai(
                     opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertFalse(skills)
 
-    async def test_parse_recastai_no_intent(self):
+    async def test_parse_sapcai_no_intent(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = [
-                    {'name': 'recastai', 'access-token': "test"}
+                    {'name': 'sapcai', 'access-token': "test"}
                 ]
             mock_skill = await self.getMockSkill()
             mock_skill.config = {
                 "name": "greetings"
             }
-            opsdroid.skills.append(match_recastai('greetings')(mock_skill))
+            opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
             message = Message(
@@ -198,9 +198,9 @@ class TestParserRecastAi(asynctest.TestCase):
                 mock_connector,
                 "kdjiruetosakdg")
 
-            with amock.patch.object(recastai, 'call_recastai') as \
-                    mocked_call_recastai:
-                mocked_call_recastai.return_value = {
+            with amock.patch.object(sapcai, 'call_sapcai') as \
+                    mocked_call_sapcai:
+                mocked_call_sapcai.return_value = {
                     'results':
                         {
                             'uuid': 'e4b365be-815b-4e40-99c3-7a25583b4892',
@@ -216,16 +216,16 @@ class TestParserRecastAi(asynctest.TestCase):
                             'timestamp': '2017-11-15T07:32:42.641604+00:00',
                             'status': 200}}
 
-                skills = await recastai.parse_recastai(
+                skills = await sapcai.parse_sapcai(
                     opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
                 self.assertLogs('_LOGGER', 'error')
                 self.assertFalse(skills)
 
-    async def test_parse_recastai_low_score(self):
+    async def test_parse_sapcai_low_score(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = [
                     {
-                        'name': 'recastai',
+                        'name': 'sapcai',
                         'access-token': "test",
                         "min-score": 1.0
                     }
@@ -234,14 +234,14 @@ class TestParserRecastAi(asynctest.TestCase):
             mock_skill.config = {
                 "name": "greetings"
             }
-            opsdroid.skills.append(match_recastai('intent')(mock_skill))
+            opsdroid.skills.append(match_sapcai('intent')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
             message = Message("user", "default", mock_connector, "Hello")
 
-            with amock.patch.object(recastai, 'call_recastai') as \
-                    mocked_call_recastai:
-                mocked_call_recastai.return_value = {
+            with amock.patch.object(sapcai, 'call_sapcai') as \
+                    mocked_call_sapcai:
+                mocked_call_sapcai.return_value = {
                     'results':
                         {
                             "uuid": "f482bddd-a9d7-41ae-aae3-6e64ad3f02dc",
@@ -263,14 +263,14 @@ class TestParserRecastAi(asynctest.TestCase):
                             "status": 200
                         }
                 }
-                await recastai.parse_recastai(
+                await sapcai.parse_sapcai(
                     opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
 
-    async def test_parse_recastai_raise_ClientOSError(self):
+    async def test_parse_sapcai_raise_ClientOSError(self):
         with OpsDroid() as opsdroid:
             opsdroid.config['parsers'] = [
                     {
-                        'name': 'recastai',
+                        'name': 'sapcai',
                         'access-token': "test",
                     }
                 ]
@@ -278,15 +278,15 @@ class TestParserRecastAi(asynctest.TestCase):
             mock_skill.config = {
                 "name": "greetings"
             }
-            opsdroid.skills.append(match_recastai('greetings')(mock_skill))
+            opsdroid.skills.append(match_sapcai('greetings')(mock_skill))
 
             mock_connector = amock.CoroutineMock()
             message = Message("user", "default", mock_connector, "Hello")
 
-            with amock.patch.object(recastai, 'call_recastai') \
+            with amock.patch.object(sapcai, 'call_sapcai') \
                     as mocked_call:
                 mocked_call.side_effect = ClientOSError()
-                await recastai.parse_recastai(
+                await sapcai.parse_sapcai(
                     opsdroid, opsdroid.skills, message, opsdroid.config['parsers'][0])
 
             self.assertTrue(mocked_call.called)


### PR DESCRIPTION
# Description

I decided to take a stab at recast.ai renaming issue. The API didn't really change so it was a matter of changing the references to recast.ai and adding a message saying that the old matcher `match_recastai` will stop working in the future. 

Tox was complaining that this function didn't have any tests, so these were included.

I was a bit unsure if I should just use SAP Conversational AI, SAPCAI or CAI so I used the two first ones around the code - mostly because the full name is extremely long.


Fixes #833


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran bot - responded as expected


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes