### PR TITLE
Now ignoring pipenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ var/
 .installed.cfg
 *.egg
 .pytest_cache
+pipfile
+pipfile.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
# Description

I updated the `.gitignore` file to be able to ignore the files created by pipenv.

Fixes #843


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- I cloned my fork, created a virtualenv, then installed pipenv `pip install pipenv`, then initialized it `pipenv install`. After that the file was created and if I type `git status` I get:
    
        On branch master
        Your branch is up to date with 'origin/master'.

        nothing to commit, working tree clean


# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

