### PR TITLE
Telegram Connector: Parse edited messages as if new message

### DIFF
--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -152,6 +152,8 @@ class ConnectorTelegram(Connector):
         """
         for result in response["result"]:
             _LOGGER.debug(result)
+            if result.get('edited_message', None):
+                result['message'] = result.pop('edited_message')
             if "channel" in result["message"]["chat"]["type"]:
                 _LOGGER.debug("Channel message parsing not supported "
                               "- Ignoring message")


### PR DESCRIPTION
# Description

I have decided to just implement @iobreaker easiest solution to the edited_message issue. I have tested the connector with an edited message and as reported everything worked fine 👍 

The test added was meant to keep coverage to 100% when I ran the test to see if `opsdroid.parse` was called it would always return False - maybe I have to call parse twice but I'm not entirely sure 🤔 

Fixes #862


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran opsdroid with the fix, edited message, opsdroid parsed newly edited message.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes