### PR TITLE
Fixing websocket Message parsing error #867

### DIFF
--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -82,10 +82,9 @@ class ConnectorWebsocket(Connector):
         await websocket.prepare(request)
 
         self.active_connections[socket] = websocket
-
         async for msg in websocket:
             if msg.type == aiohttp.WSMsgType.TEXT:
-                message = Message(None, socket, self, msg.data)
+                message = Message(msg.data, None, None, self)
                 await self.opsdroid.parse(message)
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 _LOGGER.error('Websocket connection closed with exception %s',

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -436,19 +436,19 @@ class OpsDroid():
             if str(message.text).strip():
                 _LOGGER.debug(_("Parsing input: %s"), message.text)
 
-            tasks.append(
-                self.eventloop.create_task(parse_always(self, message)))
-
-            unconstrained_skills = await self._constrain_skills(
-                self.skills, message)
-            ranked_skills = await self.get_ranked_skills(
-                unconstrained_skills, message)
-            if ranked_skills:
                 tasks.append(
-                    self.eventloop.create_task(
-                        self.run_skill(ranked_skills[0]["skill"],
-                                       ranked_skills[0]["config"],
-                                       message)))
+                    self.eventloop.create_task(parse_always(self, message)))
+
+                unconstrained_skills = await self._constrain_skills(
+                    self.skills, message)
+                ranked_skills = await self.get_ranked_skills(
+                    unconstrained_skills, message)
+                if ranked_skills:
+                    tasks.append(
+                        self.eventloop.create_task(
+                            self.run_skill(ranked_skills[0]["skill"],
+                                           ranked_skills[0]["config"],
+                                           message)))
 
         return tasks
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -432,8 +432,9 @@ class OpsDroid():
         """Parse a string against all skills."""
         self.stats["messages_parsed"] = self.stats["messages_parsed"] + 1
         tasks = []
-        if message is not None and message.text.strip() != "":
-            _LOGGER.debug(_("Parsing input: %s"), message.text)
+        if message is not None:
+            if str(message.text).strip():
+                _LOGGER.debug(_("Parsing input: %s"), message.text)
 
             tasks.append(
                 self.eventloop.create_task(parse_always(self, message)))


### PR DESCRIPTION
# Description

This fix is for issue #867 with Message Parameters order in websocket connector and for the exception raised when testing if message.text is not empty when message object is None in core.py

Fixes #867


## Status
**READY** | **~~UNDER DEVELOPMENT~~** | **~~ON HOLD~~**


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Test fixed and added


# How Has This Been Tested?

- Manually with opsdroid-desktop (all good)

# Testing Logs

```
INFO opsdroid.web: Started web server on http://127.0.0.1:8080
INFO aiohttp.access: 127.0.0.1 [07/Mar/2019:21:23:40 +0000] "POST /connector/websocket HTTP/1.1" 200 220 "-" "-"
DEBUG opsdroid.connector.websocket: User connected to 474c9c84-411f-11e9-a552-b8e85642f7e8
<opsdroid.connector.websocket.ConnectorWebsocket object at 0x10311b940>
DEBUG opsdroid.core: Parsing input: hi
DEBUG opsdroid.core: Processing parsers...
DEBUG opsdroid.connector.websocket: Responding with: 'Hi None' in target 474c9c84-411f-11e9-a552-b8e85642f7e8
```


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

