### PR TITLE
Pin python version to 3.6 due to bug in mkdocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+# .readthedocs.yml
+
+version: 2
+
+python:
+  version: 3.6


### PR DESCRIPTION
Looks like docs builds are failing again. Seem to be related to [this bug](https://github.com/mkdocs/mkdocs/issues/1531) in mkdocs.

I'm guessing readthedocs have bumped their python version to 3.7 but this has caused problems with mkdocs. I've pinned the readthedocs python version back to 3.6 to fix for now.