### PR TITLE
Adding fullmatch and match capabilities to regex parser #875

### DIFF
--- a/docs/matchers/regex.md
+++ b/docs/matchers/regex.md
@@ -16,77 +16,100 @@ parsers:
 
 This is the simplest matcher available in opsdroid. It matches the message from the user against a regular expression. If the regex matches then the function is called.
 
-_note: The use of position anchors(`^` or `$`) are encouraged when using regex to match a function. This should prevent opsdroid to be triggered with every use of the matched regular expression_
+You can specify to the regex matcher which kind of matching you want to apply through the `matching_condition` kwarg (*match* matching is the default). This kwarg should give you more control on how to use the regex matcher.
 
-## Example 1
+Matching conditions:
 
-```python
-from opsdroid.skill import Skill
-from opsdroid.matchers import match_regex
+- **search** - Scans through the string looking for the first location where the regular expression pattern produces a match.
+- **match** - Scans through the string looking at the beginning of the string to match the regular expression pattern.
+- **fullmatch** - Scans and checks if the whole string matches the regular expression pattern.
 
-class MySkill(Skill):
-    @match_regex('hi', case_sensitive=False)
-    async def hello(self, message):
-        await message.respond('Hey')
-```
+### Example 1 - Search condition
 
-The above skill would be called on any message which matches the regex `'hi'`, `'Hi'`, `'hI'` or `'HI'`. The `case_sensitive` kwarg is optional and defaults to `True`.
-
-## Example 2
+Let's use the following hello skill with the kwarg `matching_condition="search"`.
 
 ```python
-from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
+import random
 
-class MySkill(Skill):
-@match_regex('cold')
-async def is_cold(self, message):
-    await message.respond('it is')
+@match_regex(r'hi|hello|hey|hallo', case_sensitive=False, matching_condition="search")
+async def hello(opsdroid, config, message):
+    text = random.choice(["Hi {}", "Hello {}", "Hey {}"]).format(message.user)
+    await message.respond(text)
 ```
 
-The above skill would be called on any message that matches the regex `'cold'` .
+When we run opsdroid and send the message *"Hi opsdroid"* opsdroid will match the hello to the skill and reply immediately.
 
-> user: is it cold?
->
-> opsdroid: it is
+```
+[6:13:11 PM] HichamTerkiba:
+Hi opsdroid
 
-Undesired effect:
+[6:13:12 PM] opsdroid:
+Hi HichamTerkiba
+```
 
-> user:  Wow, yesterday was so cold at practice!
->
-> opsdroid: it is.
+### Example 2 - match condition
 
-Since this matcher searches a message for the regular expression used on a skill, opsdroid will trigger any mention of the `'cold'`. To prevent this position anchors should be used.
-
-#### Fixed example
+Let's use the following hello skill with the kwarg `matching_condition="match"`.
 
 ```python
-from opsdroid.skill import Skill
 from opsdroid.matchers import match_regex
+import random
 
-class MySkill(Skill):
-    @match_regex('cold$')
-    async def is_cold(self, message):
-        await message.respond('it is')
+@match_regex(r'hi|hello|hey|hallo', case_sensitive=False, matching_condition="match")
+async def hello(opsdroid, config, message):
+    text = random.choice(["Hi {}", "Hello {}", "Hey {}"]).format(message.user)
+    await message.respond(text)
 ```
 
-Now this skill will only be triggered if `'cold'` is located at the end of the message.
+With the matching condition kwarg set to match, opsdroid will only trigger the skill if *Hi** is present at the beginning of the message.
 
-> user: is it cold
->
-> opsdroid: it is
->
-> user: Wow it was so cold outside yesterday!
->
-> opsdroid:
+```
+[6:13:11 PM] HichamTerkiba:
+Hi opsdroid
 
-Since `'cold'` wasn't located at the end of the message, opsdroid didn't react to the second message posted by the user.
+[6:13:12 PM] opsdroid:
+Hi HichamTerkiba
+
+[6:13:11 PM] HichamTerkiba:
+I said Hi opsdroid
+
+<No reply from opsdroid>
+```
+
+### Example 3 - fullmatch condition
+
+Let's use the following hello skill with the kwarg `matching_condition="fullmatch"`.
+
+```python
+from opsdroid.matchers import match_regex
+import random
+
+@match_regex(r'hi|hello|hey|hallo', case_sensitive=False, matching_condition="fullmatch")
+async def hello(opsdroid, config, message):
+    text = random.choice(["Hi {}", "Hello {}", "Hey {}"]).format(message.user)
+    await message.respond(text)
+```
+With the matching condition to fullmatch, opsdroid will only trigger the skill if the whole message matches the pattern.
+
+```
+[6:13:11 PM] HichamTerkiba:
+Hi
+
+[6:13:12 PM] opsdroid:
+Hi HichamTerkiba
+
+[6:13:11 PM] HichamTerkiba:
+Hi!
+
+<No reply from opsdroid>
+```
 
 ## Message object additional parameters
 
 ### `message.regex`
 
-A _[re match object](https://docs.python.org/3/library/re.html#re.MatchObject)_ for the regular expression the message was matched against. This allows you to access any wildcard matches in the regex from within your skill.
+You can access any group or wildcard matches in the regex from within your skill.
 
 ```python
 from opsdroid.skill import Skill
@@ -140,7 +163,7 @@ The above example gives each group a name and retrieves each group by using thei
 
 In order to make NLU skills execute over regex skills, opsdroid always applies a default factor of `0.6` to every regex evaluated score.
 
-If a developer want to have a regex skill executed over a NLU one then the keyword argument `score_factor` can be used to achieve this.
+If a developer wants to have a regex skill executed over an NLU one then the keyword argument `score_factor` can be used to achieve this.
 
 
 ### Example

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -9,8 +9,8 @@ from opsdroid.helper import add_skill_attributes
 _LOGGER = logging.getLogger(__name__)
 
 
-def match_regex(regex, case_sensitive=True, 
-    matching_condition="search", score_factor=None):
+def match_regex(regex, case_sensitive=True, matching_condition="search",
+                score_factor=None):
     """Return regex match decorator."""
     def matcher(func):
         """Add decorated function to skills list for regex matching."""

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -9,7 +9,7 @@ from opsdroid.helper import add_skill_attributes
 _LOGGER = logging.getLogger(__name__)
 
 
-def match_regex(regex, case_sensitive=True, matching_condition="search",
+def match_regex(regex, case_sensitive=True, matching_condition="match",
                 score_factor=None):
     """Return regex match decorator."""
     def matcher(func):

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -9,7 +9,8 @@ from opsdroid.helper import add_skill_attributes
 _LOGGER = logging.getLogger(__name__)
 
 
-def match_regex(regex, case_sensitive=True, matching_condition="search", score_factor=None):
+def match_regex(regex, case_sensitive=True, 
+    matching_condition="search", score_factor=None):
     """Return regex match decorator."""
     def matcher(func):
         """Add decorated function to skills list for regex matching."""

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -9,7 +9,7 @@ from opsdroid.helper import add_skill_attributes
 _LOGGER = logging.getLogger(__name__)
 
 
-def match_regex(regex, case_sensitive=True, score_factor=None):
+def match_regex(regex, case_sensitive=True, matching_condition="search", score_factor=None):
     """Return regex match decorator."""
     def matcher(func):
         """Add decorated function to skills list for regex matching."""
@@ -18,6 +18,7 @@ def match_regex(regex, case_sensitive=True, score_factor=None):
             {"regex": {
                 "expression": regex,
                 "case_sensitive": case_sensitive,
+                "matching_condition": matching_condition,
                 "score_factor": score_factor or REGEX_SCORE_FACTOR,
             }}
         )

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -21,12 +21,12 @@ async def match_regex(text, opts):
             return False
         return re.IGNORECASE
 
-    if opts["matching_condition"].lower() == "match":
-        regex = re.match(opts["expression"], text, is_case_sensitive())
+    if opts["matching_condition"].lower() == "search":
+        regex = re.search(opts["expression"], text, is_case_sensitive())
     elif opts["matching_condition"].lower() == "fullmatch":
         regex = re.fullmatch(opts["expression"], text, is_case_sensitive())
     else:
-        regex = re.search(opts["expression"], text, is_case_sensitive())
+        regex = re.match(opts["expression"], text, is_case_sensitive())
     return regex
 
 

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -15,25 +15,20 @@ async def calculate_score(regex, score_factor):
 
 
 async def match_regex(text, opts):
-
+    """Return False if matching does not 
+    need to be case sensitive"""
     def is_case_sensitive():
         if opts["case_sensitive"] == True:
             return False
         else:    
             return re.IGNORECASE
 
-    params = {"matching_condition": opts["matching_condition"].lower(), "case_sensitive": is_case_sensitive(),
-        "score_factor": opts["score_factor"], "expression": opts["expression"]}
-    
-    _LOGGER.debug("matching parameters : {}".format(params))
     if opts["matching_condition"].lower() == "match":
         return re.match(opts["expression"], text, is_case_sensitive())
     elif opts["matching_condition"].lower() == "fullmatch":
         return re.fullmatch(opts["expression"], text, is_case_sensitive())
     else:
         return re.search(opts["expression"], text, is_case_sensitive())
-
-
 
 async def parse_regex(opsdroid, skills, message):
     """Parse a message against all regex skills."""
@@ -42,7 +37,6 @@ async def parse_regex(opsdroid, skills, message):
         for matcher in skill.matchers:
             if "regex" in matcher:
                 opts = matcher["regex"]
-                _LOGGER.debug("matching against {} skill ".format( str(skill.config["name"])))
                 regex = await match_regex(message.text, opts)
                 if regex:
                     new_message = copy.copy(message)

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -15,20 +15,19 @@ async def calculate_score(regex, score_factor):
 
 
 async def match_regex(text, opts):
-    """Return False if matching does not
-    need to be case sensitive
-    """
+    """Return False if matching does not need to be case sensitive."""
     def is_case_sensitive():
         if opts["case_sensitive"]:
-            return False  
+            return False
         return re.IGNORECASE
 
     if opts["matching_condition"].lower() == "match":
-        return re.match(opts["expression"], text, is_case_sensitive())
+        regex = re.match(opts["expression"], text, is_case_sensitive())
     elif opts["matching_condition"].lower() == "fullmatch":
-        return re.fullmatch(opts["expression"], text, is_case_sensitive())
+        regex = re.fullmatch(opts["expression"], text, is_case_sensitive())
     else:
-        return re.search(opts["expression"], text, is_case_sensitive())
+        regex = re.search(opts["expression"], text, is_case_sensitive())
+    return regex
 
 
 async def parse_regex(opsdroid, skills, message):

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -15,13 +15,13 @@ async def calculate_score(regex, score_factor):
 
 
 async def match_regex(text, opts):
-    """Return False if matching does not 
-    need to be case sensitive"""
+    """Return False if matching does not
+    need to be case sensitive
+    """
     def is_case_sensitive():
-        if opts["case_sensitive"] == True:
-            return False
-        else:    
-            return re.IGNORECASE
+        if opts["case_sensitive"]:
+            return False  
+        return re.IGNORECASE
 
     if opts["matching_condition"].lower() == "match":
         return re.match(opts["expression"], text, is_case_sensitive())
@@ -29,6 +29,7 @@ async def match_regex(text, opts):
         return re.fullmatch(opts["expression"], text, is_case_sensitive())
     else:
         return re.search(opts["expression"], text, is_case_sensitive())
+
 
 async def parse_regex(opsdroid, skills, message):
     """Parse a message against all regex skills."""

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -38,12 +38,22 @@ class TestParserRegex(asynctest.TestCase):
             skills = await parse_regex(opsdroid, opsdroid.skills, message)
             self.assertEqual(mock_skill, skills[0]["skill"])
 
-    async def test_parse_regex_priority(self):
+    async def test_parse_regex_priority_low(self):
         with OpsDroid() as opsdroid:
             regex = r"(.*)"
 
             mock_skill_low = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex, score_factor=0.6)(mock_skill_low))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
+            self.assertEqual(mock_skill_low, skills[0]["skill"])
+
+    async def test_parse_regex_priority_high(self):
+        with OpsDroid() as opsdroid:
+            regex = r"(.*)"
 
             mock_skill_high = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex, score_factor=1)(mock_skill_high))
@@ -68,3 +78,42 @@ class TestParserRegex(asynctest.TestCase):
 
             skills = await parse_regex(opsdroid, opsdroid.skills, message)
             self.assertEqual(mock_skill, skills[0]["skill"])
+
+    async def test_parse_regex_matching_condition_search(self):
+        with OpsDroid() as opsdroid:
+            regex = r"(.*)"
+
+            mock_skill_matching_search = await self.getMockSkill()
+            opsdroid.skills.append(match_regex(regex, matching_condition="search")(mock_skill_matching_search))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
+            self.assertEqual(mock_skill_matching_search, skills[0]["skill"])
+
+    async def test_parse_regex_matching_condition_match(self):
+        with OpsDroid() as opsdroid:
+            regex = r"(.*)"
+
+            mock_skill_matching_match = await self.getMockSkill()
+            opsdroid.skills.append(match_regex(regex, matching_condition="match")(mock_skill_matching_match))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
+            self.assertEqual(mock_skill_matching_match, skills[0]["skill"])
+
+    async def test_parse_regex_matching_condition_fullmatch(self):
+        with OpsDroid() as opsdroid:
+            regex = r"(.*)"
+
+            mock_skill_matching_fullmatch = await self.getMockSkill()
+            opsdroid.skills.append(match_regex(regex, matching_condition="fullmatch")(mock_skill_matching_fullmatch))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("Hello world", "user", "default", mock_connector)
+
+            skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
+            self.assertEqual(mock_skill_matching_fullmatch, skills[0]["skill"])


### PR DESCRIPTION
This have been suggested as an enhancement in #872 .
The goal here is to allow users to choose what kind of regex matching they want to play against received message. for the moment the regex only allow search method.

This will add an other layer of security and give the user the ability to execute a skill only if the message match exactly the patten.

@jacobtomlinson proposed to use the existing kwarg to pass this new parameter.


Enhancement #872


## Status
**READY** | **~~UNDER DEVELOPMENT~~** | **~~ON HOLD~~**


## Type of change

- Adding param matching_condition to regex matcher
- Adapting regex parser to manage matching conditions
- Adding Debug logs
- This change requires a documentation update -> **Need to be done on [opsdroid documentation](https://opsdroid.readthedocs.io/en/stable/matchers/regex/)**

# How Has This Been Tested?

I implemented the changes and tested against an updated hello skills

```python
from opsdroid.matchers import match_regex
import logging
import random


@match_regex(r'hi|hello|hey|hallo', case_sensitive=False, matching_condition="fullmatch")
async def hello(opsdroid, config, message):
    text = random.choice(["Hi {}", "Hello {}", "Hey {}"]).format(message.user)
    await message.respond(text)

@match_regex(r'bye( bye)?|see y(a|ou)|au revoir|gtg|I(\')?m off', score_factor=0.8, matching_condition="match")
async def goodbye(opsdroid, config, message):
    text = random.choice(["Bye {}", "See you {}", "Au revoir {}"]).format(message.user)
    await message.respond(text)
```

# Documentation update proposition

Example 3:

You can specify to the regex matcher wich kind of matching you want to apply, this can be done through  **matching_condition** kwarg. 

**matching_condition** is optional and defaults to search.

You can set  **matching_condition** to :
 
- **search** :  Scan through string looking for the first location where the regular expression pattern produces a match.
- **match** : Scan through string If zero or more characters at the beginning of string match the regular expression pattern
- **fullmatch** : Scan and check If the whole string matches the regular expression pattern


let's take this skill and play different matching conditions against it 

```python
from opsdroid.matchers import match_regex
import logging
import random

@match_regex(r'hi|hello|hey|hallo', case_sensitive=False, matching_condition="fullmatch")
async def hello(opsdroid, config, message):
    text = random.choice(["Hi {}", "Hello {}", "Hey {}"]).format(message.user)
    await message.respond(text)
```

- hello skill with matching_condition='search'

```
[6:13:11 PM] HichamTerkiba:
Hi opsdroid

[6:13:12 PM] opsdroid:
Hi HichamTerkiba
```

- hello skill with matching_condition='match'

```
[6:13:11 PM] HichamTerkiba:
Hi opsdroid

[6:13:12 PM] opsdroid:
Hi HichamTerkiba

[6:13:11 PM] HichamTerkiba:
i said Hi opsdroid

[6:13:12 PM] opsdroid:
-No answer from opsroid-
```

- hello skill with matching_condition='fullmatch'

```
[6:13:11 PM] HichamTerkiba:
Hi

[6:13:12 PM] opsdroid:
Hi HichamTerkiba

[6:13:11 PM] HichamTerkiba:
Hi!

[6:13:12 PM] opsdroid:
-No answer from opsroid-
```

> Please feel free to modify/add/update the doc part if neded


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Need to be Done)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

