### PR TITLE
Fix configuration in basic skill tutorial

### DIFF
--- a/docs/tutorials/basic-skill.md
+++ b/docs/tutorials/basic-skill.md
@@ -94,8 +94,8 @@ Open your `configuration.yaml` file and under the skills add the name and path o
 
 ```yaml
 skills:
-  name: how-are-you
-  path: /Users/username/documents/skill-howareyou
+  - name: how-are-you
+    path: /Users/username/documents/skill-howareyou
 ```
 
 As mentioned in the [introduction](introduction.md/), the indentation and the use of spaces instead of tabs is very important. If you have any issues when running opsdroid check both of this things, it might be a problem with a space.


### PR DESCRIPTION
# Description
According to the configuration reference the skills value should be a list.

ref: https://opsdroid.readthedocs.io/en/stable/configuration-reference/#skills

## Status
**READY**

## Type of change
- Documentation (fix or adds documentation)

# How Has This Been Tested?
Simple change to documentation, so no testing performed.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

