### PR TITLE
Fixing rasanlu parser : dict object has no attribute matchers issue #860

### DIFF
--- a/docs/matchers/rasanlu.md
+++ b/docs/matchers/rasanlu.md
@@ -44,17 +44,20 @@ class MySkill(Skill):
         await message.respond("Hello there!")
 ```
 
-Intents file (`intents.md`).
-```markdown
-## intent:greetings
-- Hey
-- Hello
-- Hi
-- Hiya
-- hey
-- whats up
-- wazzup
-- heya
+Intents file (`intents.yml`).
+```yaml
+language: "en"
+pipeline: "spacy_sklearn"
+data: |
+  ## intent:greetings
+  - Hey
+  - Hello
+  - Hi
+  - Hiya
+  - hey
+  - whats up
+  - wazzup
+  - heya
 ```
 
 > **Note** - Rasa NLU requires an intent to have at least three training examples in the list. There must also be a minimum of two intents in your file for Rasa to train.
@@ -75,15 +78,18 @@ class MySkill(Skill):
         await message.respond('What do you call a bear with no teeth? -- A gummy bear!')
 ```
 
-Intents file (`intents.md`).
-```markdown
-## intent:ask-joke
-- Tell me a joke
-- Say something funny
-- Do you know any jokes?
-- Tell me something funny
-- Can you tell jokes?
-- Do you know jokes?
+Intents file (`intents.yml`).
+```yaml
+language: "en"
+pipeline: "spacy_sklearn"
+data: |
+  ## intent:ask-joke
+  - Tell me a joke
+  - Say something funny
+  - Do you know any jokes?
+  - Tell me something funny
+  - Can you tell jokes?
+  - Do you know jokes?
 ```
 
 The above skill would be called on any intent which has a name of `'ask-joke'`.

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -188,7 +188,7 @@ class Loader:
 
     @staticmethod
     def _load_intents(config):
-        intent_file = os.path.join(config["install_path"], "intents.md")
+        intent_file = os.path.join(config["install_path"], "intents.yml")
         if os.path.isfile(intent_file):
             with open(intent_file, 'r') as intent_file_handle:
                 intents = intent_file_handle.read()

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 async def _get_all_intents(skills):
     """Get all skill intents and concatenate into a single markdown string."""
     intents = [skill["intents"] for skill in skills
-                if skill["intents"] is not None]
+               if skill["intents"] is not None]
     if not intents:
         return None
     intents = "\n\n".join(intents)

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -16,9 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def _get_all_intents(skills):
     """Get all skill intents and concatenate into a single markdown string."""
-    matchers = [matcher for skill in skills for matcher in skill.matchers]
-    intents = [matcher["intents"] for matcher in matchers
-               if matcher["intents"] is not None]
+    intents = [skill["intents"] for skill in skills
+                if skill["intents"] is not None]
     if not intents:
         return None
     intents = "\n\n".join(intents)
@@ -100,9 +99,16 @@ async def train_rasanlu(config, skills):
 
         url = await _build_training_url(config)
 
+        # https://github.com/RasaHQ/rasa_nlu/blob/master/docs/http.rst#post-train
+        # Note : The request should always be sent as
+        # application/x-yml regardless of wether you use
+        # json or md for the data format. Do not send json as
+        # application/json for example.+
+        headers = {'content-type': 'application/x-yml'}
+
         try:
             training_start = arrow.now()
-            resp = await session.post(url, data=intents)
+            resp = await session.post(url, data=intents, headers=headers)
         except aiohttp.client_exceptions.ClientConnectorError:
             _LOGGER.error(_("Unable to connect to Rasa NLU, training failed."))
             return False

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -217,7 +217,7 @@ class TestLoader(unittest.TestCase):
             self._tmp_dir, os.path.normpath("test/module/test"))
         os.makedirs(config['install_path'], mode=0o777)
         intent_contents = "Hello world"
-        intents_file = os.path.join(config['install_path'], "intents.md")
+        intents_file = os.path.join(config['install_path'], "intents.yml")
         with open(intents_file, 'w') as intents:
             intents.write(intent_contents)
         loaded_intents = ld.Loader._load_intents(config)

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -346,9 +346,9 @@ class TestParserRasaNLU(asynctest.TestCase):
             await self.getMockSkill(),
             await self.getMockSkill()
         ]
-        skills[0].matchers = [{"intents": "Hello"}]
-        skills[1].matchers = [{"intents": None}]
-        skills[2].matchers = [{"intents": "World"}]
+        skills[0] = {"intents": "Hello"}
+        skills[1] = {"intents": None}
+        skills[2] = {"intents": "World"}
         intents = await rasanlu._get_all_intents(skills)
         self.assertEqual(type(intents), type(b""))
         self.assertEqual(intents, b"Hello\n\nWorld")


### PR DESCRIPTION
# Description

When using rasanlu parser with no intents file (no need to train the module, already done) an attribute issue error happened in function _get_all_intents(skills)

...
    matchers = [matcher for skill in skills for matcher in skill.matchers]
  File "/Users/IOBreaker/Developments/Bots/opsdroid/opsdroid/parsers/rasanlu.py", line 19, in <listcomp>
    matchers = [matcher for skill in skills for matcher in skill.matchers]
AttributeError: 'dict' object has no attribute 'matchers'

Fixes #860

After discussion with @jacobtomlinson the decision  was to go using intents provided directly by the skill dict.

Beside, an other correction was added to this fixes according to [rasa_nlu](https://github.com/RasaHQ/rasa_nlu/blob/master/docs/http.rst#post-train) documentation

```
The request should always be sent as application/x-yml regardless of wether you use json or md for the data format. Do not send json as application/json for example.
```

## Status
**READY** | **~UNDER DEVELOPMENT~** | **~ON HOLD~**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the fix on my environment, no issue detected

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (test file modification)
- [x] New and existing unit tests pass locally with my changes
- [x] Tox ok
