### PR TITLE
Include missing `await` statements in weather example

### DIFF
--- a/docs/tutorials/create-weather-skill.md
+++ b/docs/tutorials/create-weather-skill.md
@@ -99,7 +99,7 @@ async def get_weather(config):
 
     async with aiohttp.ClientSession() as session:
         response = await session.get(api_url + parameters)
-    return response.json()
+    return await response.json()
 ```
 Now when we call our `get_weather` function, aiohttp will get all the data from the OpenWeatherMap API and return it to us in a json format.
 
@@ -180,7 +180,7 @@ async def get_weather(config):
 
     async with aiohttp.ClientSession() as session:
         response = await session.get(api_url + parameters)
-    return response.json()
+    return await response.json()
 
 
 class WeatherSkill(Skill):
@@ -252,7 +252,7 @@ class WeatherSkill(Skill):
 
         async with aiohttp.ClientSession() as session:
             response = await session.get(api_url + parameters)
-        return response.json()
+        return await response.json()
 
     @match_regex("How's the weather?")
     async def tell_weather(self, message):


### PR DESCRIPTION
# Description
The weather skill example is missing some `await` statements when returning the `response.json()`. Without the `await` statement a coroutine object is return instead of a dict.

## Status
**READY**


## Type of change
- Documentation (fix or adds documentation)


# How Has This Been Tested?
Tested by running the example locally with the Matrix connector

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes