### PR TITLE
Clean exit for Matrix connector

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -2,6 +2,7 @@
 
 import re
 import logging
+from concurrent.futures import CancelledError
 
 import aiohttp
 
@@ -141,6 +142,8 @@ class ConnectorMatrix(Connector):
                 message = await self._parse_sync_response(response)
                 await self.opsdroid.parse(message)
 
+            except CancelledError:
+                raise
             except Exception:  # pylint: disable=W0703
                 _LOGGER.exception('Matrix Sync Error')
 


### PR DESCRIPTION
# Description
When a user was pressing ctrl+c the Matrix connector was catching the `CancelledError` as part of the catchall `except` and just logging it to the console. The next (and subsequent) loops through would raise a `RuntimeError('Session is closed')` resulting in an infinite loop logging the same error to the console over and over.

By correctly catching the `CancelledError` we can ensure that the Matrix connector exits cleanly.

## Status
**READY** ?? not sure if this is being handled at the correct abstraction level or not. Also not sure how to change the test suite to test for this.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested manually by connecting to a Matrix homeserver then issuing a ctrl+c
Python 3.7.2

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

