### PR TITLE
add slack connect-timeout option

### DIFF
--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -18,6 +18,7 @@ connectors:
     bot-name: "mybot" # default "opsdroid"
     default-room: "#random" # default "#general"
     icon-emoji: ":smile:" # default ":robot_face:"
+    connect-timeout: 10 # default 10 seconds
 ```
 
 ## Usage

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -137,6 +137,7 @@ connectors:
 #    bot-name: "mybot" # default "opsdroid"
 #    default-room: "#random" # default "#general"
 #    icon-emoji: ":smile:" # default ":robot_face:"
+#    connect-timeout: 10 # default 10 seconds
 #
 #  ## Telegram (https://github.com/opsdroid/connector-telegram)
 #  - name: telegram

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -28,7 +28,8 @@ class ConnectorSlack(Connector):
         self.default_target = config.get("default-room", "#general")
         self.icon_emoji = config.get("icon-emoji", ':robot_face:')
         self.token = config["api-token"]
-        self.slacker = Slacker(self.token)
+        self.timeout = config.get("connect-timeout", 10)
+        self.slacker = Slacker(token=self.token, timeout=self.timeout)
         self.websocket = None
         self.bot_name = config.get("bot-name", 'opsdroid')
         self.known_users = {}

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -25,6 +25,7 @@ class TestConnectorSlack(unittest.TestCase):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
         self.assertEqual("#general", connector.default_target)
         self.assertEqual("slack", connector.name)
+        self.assertEqual(10, connector.timeout)
 
     def test_missing_api_key(self):
         """Test that creating without an API key raises an error."""


### PR DESCRIPTION
# Description

The Slack connector fails with a `concurrent.futures._base.TimeoutError` when using a large workspace as the connect() call can take some time to return. This PR adds a configuration for connect-timeout to the slack connector and sets the default to the current 10 seconds.

## Status
**READY**

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation (fix or adds documentation)

# How Has This Been Tested?

tested locally both with and without `connect-timeout` set in configuration.yml

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [?] New and existing unit tests pass locally with my changes (I'm not sure how to run the unit tests

