### PR TITLE
Suppress Matrix timeout errors in console (fixes #835)

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -142,6 +142,14 @@ class ConnectorMatrix(Connector):
                 message = await self._parse_sync_response(response)
                 await self.opsdroid.parse(message)
 
+            except MatrixRequestError as mre:
+                # We can safely ignore timeout errors. The non-standard error
+                # codes are returned by Cloudflare.
+                if mre.code in [504, 522, 524]:
+                    _LOGGER.info('Matrix Sync Timeout (code: %d)', mre.code)
+                    continue
+
+                _LOGGER.exception('Matrix Sync Error')
             except CancelledError:
                 raise
             except Exception:  # pylint: disable=W0703


### PR DESCRIPTION
# Description
The Matrix connector will often receive a timeout error when doing a sync request. The catch-all except would just dump the entire HTML of the timeout response to the console. This output can be quite voluminous and not that useful. By checking for know timeout error codes we can suppress the useless HTML output and just log the occurrence at the info level for those that are interested to know when timeouts occur.

In addition to the standard `504 Gateway Timeout` error we also check for `522 Connection timed out` and `524 A Timeout Error` which are timeout errors specific to Cloudflare. See:

  https://support.cloudflare.com/hc/en-us/articles/115003011431/

We check for these Cloudflare errors because the largest Matrix host (matrix.org) is fronted by Cloudflare.

Fixes #835 

## Status
**READY**


## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
As far as I can tell there are no existing tests covering this part of the codebase, but the changes have been tested against the matrix.org homeserver using Python 3.7.2+ (Debian testing).

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes