### PR TITLE
Import built in module if module is typed with Capital letter

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -105,7 +105,7 @@ class Loader:
             return importlib.util.find_spec(
                 'opsdroid.{module_type}.{module_name}'.format(
                     module_type=config["type"],
-                    module_name=config["name"]
+                    module_name=config["name"].lower()
                 )
             )
         except ImportError:
@@ -116,7 +116,7 @@ class Loader:
         """Generate the module import path from name and type."""
         if config["is_builtin"]:
             return "opsdroid" + "." + config["type"] + \
-                "." + config["name"]
+                "." + config["name"].lower()
         return MODULES_DIRECTORY + "." + config["type"] + \
             "." + config["name"]
 


### PR DESCRIPTION
# Description

If a module is typed with a capital letter, opsdroid would always import it from github. So if you try to import "Telegram" it will always import from the Repo, this is because the `is_builtin` will return false since the name is lowercase, but the config name starts with a capital letter.

This quick PR fixes this issue. I am turning `config['name']` to lowercase and then again when opsdroid tries to import it from the built-in folder.

Fixes #888


## Status
**READY** |~~ **UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran Telegram connector with config `-name: Telegram` and tried to interact with opsdroid. Returned the expected reply.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
