### PR TITLE
Fix _constrain_skills method #901

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -422,11 +422,12 @@ class OpsDroid():
             list: A list of the skills which were not constrained.
 
         """
-        for skill in skills:
-            for constraint in skill.constraints:
-                if not constraint(message):
-                    skills.remove(skill)
-        return skills
+        return [
+            skill for skill in skills if all(
+                constraint(message)
+                for constraint in skill.constraints
+            )
+        ]
 
     async def parse(self, message):
         """Parse a string against all skills."""

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -103,3 +103,26 @@ class TestConstraints(asynctest.TestCase):
                 Message('Hello', 'user', '#general', connector)
             )
             self.assertEqual(len(tasks), 2) # match_always and the skill
+
+    async def test_constraint_can_be_called_after_skip(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.eventloop = mock.CoroutineMock()
+            skill = await self.getMockSkill()
+            skill = match_regex(r'.*')(skill)
+            skill = constraints.constrain_users(['user'])(skill)
+            opsdroid.skills.append(skill)
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'user', '#general', None)
+            )
+            self.assertEqual(len(tasks), 2) # match_always and the skill
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'otheruser', '#general', None)
+            )
+            self.assertEqual(len(tasks), 1) # Just match_always
+
+            tasks = await opsdroid.parse(
+                Message('Hello', 'user', '#general', None)
+            )
+            self.assertEqual(len(tasks), 2)  # match_always and the skill


### PR DESCRIPTION
# Description

Changes _constraint_skills to create a new skill list avoiding the mutation of the original list.

Fixes #901


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- tests/test_constraints.py -> test_constraint_can_be_called_after_skip


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

