### PR TITLE
First attempt at token auth for matrix connector

### DIFF
--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -16,6 +16,7 @@ connectors:
     # Required
     mxid: "@username:matrix.org"
     password: "mypassword"
+    token: "user-access-token" #If token is desired, remove password else password will be used.
     # Name of a single room to connect to
     room: "#matrix:matrix.org"
     # Alternatively, a dictionary of multiple rooms

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -16,7 +16,7 @@ connectors:
     # Required
     mxid: "@username:matrix.org"
     password: "mypassword"
-    token: "user-access-token" #If token is desired, remove password else password will be used.
+    token: "user-access-token"
     # Name of a single room to connect to
     room: "#matrix:matrix.org"
     # Alternatively, a dictionary of multiple rooms

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -43,7 +43,6 @@ class ConnectorMatrix(Connector):
         self.token = config.get("token", None)
         self.password = config.get("password", None)
 
-
     @property
     def filter_json(self):
         """Define JSON filter to apply to incoming events."""

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -97,7 +97,6 @@ class ConnectorMatrix(Connector):
             login_response = await mapi.login(
                 "m.login.password", user=self.mxid, password=self.password)
             mapi.token = login_response['access_token']
-        
         mapi.sync_token = None
 
         for roomname, room in self.rooms.items():

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@ flake8==3.7.5
 pylint==2.2.2
 coveralls==1.6.0
 astroid==2.1.0
-pytest==4.2.1
+pytest==4.3.0
 pytest-cov==2.6.1
 pytest-timeout==1.3.3
 pydocstyle==3.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-flake8==3.7.5
+flake8==3.7.6
 pylint==2.2.2
 coveralls==1.6.0
 astroid==2.1.0


### PR DESCRIPTION
# Description

This will allow the user to define an authentication token in the config for the matrix connector instead of the username and password. This should simplify some situations where the matrix homeserver considers each login as a new device and provide users with a method of revoking authentication to a user without changing their credentials.

Fixes n/a


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update



# How Has This Been Tested?

- Removed password from config file and tested login with token for two separate users. (need to run actual tests)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

