### PR TITLE
Add CORS headers to websocket connector

### DIFF
--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -13,6 +13,9 @@ from opsdroid.events import Message
 
 
 _LOGGER = logging.getLogger(__name__)
+HEADERS = {
+    "Access-Control-Allow-Origin": "*"
+}
 
 
 class ConnectorWebsocket(Connector):
@@ -58,9 +61,13 @@ class ConnectorWebsocket(Connector):
             socket = {"id": str(uuid.uuid1()), "date": datetime.now()}
             self.available_connections.append(socket)
             return aiohttp.web.Response(
-                text=json.dumps({"socket": socket["id"]}), status=200)
+                text=json.dumps({"socket": socket["id"]}),
+                headers=HEADERS,
+                status=200)
         return aiohttp.web.Response(
-            text=json.dumps("No connections available"), status=429)
+            text=json.dumps("No connections available"),
+            headers=HEADERS,
+            status=429)
 
     async def websocket_handler(self, request):
         """Handle for aiohttp handling websocket connections."""
@@ -69,12 +76,16 @@ class ConnectorWebsocket(Connector):
                      if item["id"] == socket]
         if len(available) != 1:
             return aiohttp.web.Response(
-                text=json.dumps("Please request a socket first"), status=400)
+                text=json.dumps("Please request a socket first"),
+                headers=HEADERS,
+                status=400)
         if (datetime.now() - available[0]["date"]).total_seconds() \
                 > self.connection_timeout:
             self.available_connections.remove(available[0])
             return aiohttp.web.Response(
-                text=json.dumps("Socket request timed out"), status=408)
+                text=json.dumps("Socket request timed out"),
+                headers=HEADERS,
+                status=408)
         self.available_connections.remove(available[0])
         _LOGGER.debug("User connected to %s", socket)
 


### PR DESCRIPTION
# Description

When trying to write a browser based websocket client it isn't possible to communicate the an opsdroid instance at a different domain due to CORS limitations. This PR adds headers to allow cross-domain requests by default.

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I am working on opsdroid-web and have tested it manually.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

