### PR TITLE
Check Messages before Parsing

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -140,7 +140,8 @@ class ConnectorMatrix(Connector):
                     filter=self.filter_id)
                 _LOGGER.debug("matrix sync request returned")
                 message = await self._parse_sync_response(response)
-                await self.opsdroid.parse(message)
+                if message:
+                    await self.opsdroid.parse(message)
 
             except MatrixRequestError as mre:
                 # We can safely ignore timeout errors. The non-standard error
@@ -201,7 +202,7 @@ class ConnectorMatrix(Connector):
             "msgtype": msgtype,
             "format": "org.matrix.custom.html",
             "formatted_body": clean_html
-            }
+        }
 
     @register_event(Message)
     async def send_message(self, message):


### PR DESCRIPTION
# Description

The matrix connector attempts to parse empty messages. This issue is solved by checking the message has a value before calling the parsing function.

Fixes #905


## Status
**READY**


## Type of change


- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

- Tox tests pass locally

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

