### PR TITLE
Add parse_format matcher

### DIFF
--- a/docs/matchers/parse_format.md
+++ b/docs/matchers/parse_format.md
@@ -1,0 +1,163 @@
+# Parse Format Matcher
+
+## Configuring opsdroid
+
+As in [regex matcher](/matchers/regex.md), in order to enable parse format skills, you must set the `enabled` parameter to true in the parsers section of the opsdroid configuration file.
+
+```yaml
+parsers:
+  - name: parse_format
+    enabled: true
+```
+
+## About Parse Format Matcher
+
+This is the simplest matcher available in opsdroid. It matches the message from the user against a string with python [format syntax](https://docs.python.org/3/library/string.html#format-string-syntax). If the string matches then the function is called.
+
+The third party library [parse](https://github.com/r1chardj0n3s/parse) is used to parse the strings.
+
+You can specify which kind of matching you want to apply through the `matching_condition` kwarg (*match* matching is the default). Be careful, the matching condition names are the same than in regex but there are some differences between them.
+
+Matching conditions:
+
+- **match** - Scans through the string looking at the beginning of the string to match the pattern, **but the end must match too**. So if you have `hi` it will match `hi`, but no `say hi` or `hi!`.
+- **search** - Scans through the string looking for the first location where the pattern produces a match, and ignores what is before or after the match. So if you have `hi` it will match `hi`, `say hi` or `hi!`.
+
+
+### (Very) Basic example
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_parse
+import random
+
+class MySkill(Skill):
+    @match_parse('hi')
+    async def hello(self, message):
+        text = random.choice(['Hi {}', 'Hello {}', 'Hey {}']).format(message.user)
+        await message.respond(text)
+```
+
+When we run opsdroid and send the message *"hi"* opsdroid will match the hello to the skill and reply immediately. Opsdroid will only trigger the skill if *hi* is the only word in the message.
+
+```
+[6:13:11 PM] HichamTerkiba:
+hi
+
+[6:13:12 PM] opsdroid:
+Hi HichamTerkiba
+
+[6:13:16 PM] HichamTerkiba:
+I said hi
+
+<No reply from opsdroid>
+```
+
+### Example 2 - match condition
+
+Let's use the following hello skill with the kwarg `matching_condition='search'`.
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_parse
+import random
+
+class MySkill(Skill):
+    @match_parse('hi', case_sensitive=False, matching_condition='search')
+    async def hello(self, message):
+        text = random.choice(['Hi {}', 'Hello {}', 'Hey {}']).format(message.user)
+        await message.respond(text)
+```
+
+With the matching condition kwarg set to search and case sensitive set to `False`, opsdroid will be more flexible.
+
+```
+[6:13:11 PM] HichamTerkiba:
+Hi opsdroid!
+
+[6:13:12 PM] opsdroid:
+Hi HichamTerkiba
+
+[6:13:16 PM] HichamTerkiba:
+I said Hi opsdroid
+
+[6:13:17 PM] opsdroid:
+Hi HichamTerkiba
+```
+
+
+## Message object additional parameters
+
+### `message.parse_result`
+
+You can access any match result from within your skill.
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_parse
+
+class MySkill(Skill):
+    @match_parse('remember {}')
+    async def remember(self, message):
+        remember = message.parse_result[0]
+        await self.opsdroid.memory.put("remember", remember)
+        await message.respond("OK I'll remember that")
+```
+
+### Named Fields
+
+Instead of using empty brackets and then access by the position you can assign them a name and access by name.
+
+#### Example 1
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_parse
+
+class MySkill(Skill):
+    @match_parse('my name is {} and my wife is called {} and my son is called {}')
+    async def my_name_is(self, message):
+        name = message.parse_result[0]
+        wife = message.parse_result[1]
+        son = message.parse_result[2]
+```
+
+The above example does not use names and requires knowing the exact order of each of the fields in order to request them by their index.
+
+#### Fixed Example
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_parse
+
+class MySkill(Skill):
+    @match_parse('my name is {name} and my wife is called {wife} and my son is called {son}')
+    async def my_name_is(self, message):
+        name = message.parse_result['name']
+        wife = message.parse_result['wife']
+        son = message.parse_result['son']
+```
+
+The above example gives each field a name and retrieves each field by using their respective names. This is the recommended approach since it will simplify entity retrieval.
+
+
+### Field spec
+
+By default parse format captures anything, but format specification can be used to write complex format strings.
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_parse
+
+class MySkill(Skill):
+    @match_parse('say {text} {num:d} times')
+    async def say_n_times(self, message):
+        for _ in range(message.parse_result['num']):
+            await message.respond(message.parse_result['text'])
+```
+
+Read [parse format specification](https://github.com/r1chardj0n3s/parse#format-specification) to see all the possibilities.
+
+## Score factor
+
+As in [regex matcher](/matchers/regex.md), you can use the keyword argument `score_factor` in parse format skills to modify the score calculation.

--- a/docs/matchers/regex.md
+++ b/docs/matchers/regex.md
@@ -14,7 +14,7 @@ parsers:
 
 ## About Regular Expression Matcher
 
-This is the simplest matcher available in opsdroid. It matches the message from the user against a regular expression. If the regex matches then the function is called.
+This is [almost](/matchers/parse_format.md) the simplest matcher available in opsdroid. It matches the message from the user against a regular expression. If the regex matches then the function is called.
 
 You can specify to the regex matcher which kind of matching you want to apply through the `matching_condition` kwarg (*match* matching is the default). This kwarg should give you more control on how to use the regex matcher.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ pages:
       - 'Redis': 'databases/redis.md'
   - 'Matchers':
       - 'Regular Expressions': 'matchers/regex.md'
+      - 'Parse Format': 'matchers/parse_format.md'
       - 'Rasa NLU (local)': 'matchers/rasanlu.md'
       - 'Dialogflow (Api.ai)': 'matchers/dialogflow.md'
       - 'LUIS.AI': 'matchers/luis.ai.md'

--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -21,7 +21,7 @@ DEFAULT_LANGUAGE = 'en'
 LOCALE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'locale')
 EXAMPLE_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                    "configuration/example_configuration.yaml")
-REGEX_SCORE_FACTOR = 0.6
+REGEX_PARSE_SCORE_FACTOR = 0.6
 
 RASANLU_DEFAULT_URL = "http://localhost:5000"
 RASANLU_DEFAULT_PROJECT = "opsdroid"

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -19,6 +19,7 @@ from opsdroid.loader import Loader
 from opsdroid.web import Web
 from opsdroid.parsers.always import parse_always
 from opsdroid.parsers.regex import parse_regex
+from opsdroid.parsers.parseformat import parse_format
 from opsdroid.parsers.dialogflow import parse_dialogflow
 from opsdroid.parsers.luisai import parse_luisai
 from opsdroid.parsers.sapcai import parse_sapcai
@@ -347,6 +348,7 @@ class OpsDroid():
         """Take a message and return a ranked list of matching skills."""
         ranked_skills = []
         ranked_skills += await parse_regex(self, skills, message)
+        ranked_skills += await parse_format(self, skills, message)
 
         if "parsers" in self.config:
             _LOGGER.debug(_("Processing parsers..."))

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -2,9 +2,8 @@
 
 import logging
 
-from opsdroid.const import REGEX_SCORE_FACTOR
+from opsdroid.const import REGEX_PARSE_SCORE_FACTOR
 from opsdroid.helper import add_skill_attributes
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,7 +19,25 @@ def match_regex(regex, case_sensitive=True, matching_condition="match",
                 "expression": regex,
                 "case_sensitive": case_sensitive,
                 "matching_condition": matching_condition,
-                "score_factor": score_factor or REGEX_SCORE_FACTOR,
+                "score_factor": score_factor or REGEX_PARSE_SCORE_FACTOR,
+            }}
+        )
+        return func
+    return matcher
+
+
+def match_parse(format_str, case_sensitive=True, matching_condition="match",
+                score_factor=None):
+    """Return parse match decorator."""
+    def matcher(func):
+        """Add decorated function to skills list for parse matching."""
+        func = add_skill_attributes(func)
+        func.matchers.append(
+            {"parse_format": {
+                "expression": format_str,
+                "case_sensitive": case_sensitive,
+                "matching_condition": matching_condition,
+                "score_factor": score_factor or REGEX_PARSE_SCORE_FACTOR,
             }}
         )
         return func

--- a/opsdroid/parsers/parseformat.py
+++ b/opsdroid/parsers/parseformat.py
@@ -1,0 +1,43 @@
+"""A helper function for parsing and executing parse_format skills."""
+
+import logging
+import copy
+
+from parse import parse, search
+
+from opsdroid.parsers.regex import calculate_score
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def match_format(text, opts):
+    """Match a message considering the options."""
+    case_sensitive = opts["case_sensitive"]
+
+    match_fn = parse
+    if opts["matching_condition"].lower() == "search":
+        match_fn = search
+
+    return match_fn(opts["expression"], text, case_sensitive=case_sensitive)
+
+
+async def parse_format(opsdroid, skills, message):
+    """Parse a message against all parse_format skills."""
+    matched_skills = []
+    for skill in skills:
+        for matcher in skill.matchers:
+            if "parse_format" in matcher:
+                opts = matcher["parse_format"]
+                result = await match_format(message.text, opts)
+                if result:
+                    new_message = copy.copy(message)
+                    new_message.parse_result = result
+                    matched_skills.append({
+                        "score": await calculate_score(
+                            opts["expression"], opts["score_factor"]),
+                        "skill": skill,
+                        "config": skill.config,
+                        "message": new_message
+                    })
+    return matched_skills

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ motor==2.0.0
 multidict==4.5.2
 nbconvert==5.5.0
 nbformat==4.4.0
+parse==1.12.0
 pycron==1.0.0
 pyyaml==4.2b1
 setuptools==41.0.1

--- a/tests/test_parser_format.py
+++ b/tests/test_parser_format.py
@@ -1,0 +1,72 @@
+import asynctest
+import asynctest.mock as amock
+
+from opsdroid.__main__ import configure_lang
+from opsdroid.core import OpsDroid
+from opsdroid.matchers import match_parse
+from opsdroid.events import Message
+from opsdroid.parsers.parseformat import parse_format
+
+
+class TestParserParseFormat(asynctest.TestCase):
+    """Test the opsdroid parse_format parser."""
+
+    async def setup(self):
+        configure_lang({})
+
+    async def getMockSkill(self):
+        async def mockedskill(opsdroid, config, message):
+            pass
+        mockedskill.config = {}
+        return mockedskill
+
+    async def test_parse_format_match_condition(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(
+                match_parse("Hello")(mock_skill))
+
+            mock_connector = amock.CoroutineMock()
+
+            message = Message("Hello world", "user", "default", mock_connector)
+            skills = await parse_format(opsdroid, opsdroid.skills, message)
+            self.assertEqual(len(skills), 0)
+
+            message = Message("Hello", "user", "default", mock_connector)
+            skills = await parse_format(opsdroid, opsdroid.skills, message)
+            self.assertEqual(mock_skill, skills[0]["skill"])
+
+    async def test_parse_format_search_condition(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(
+                match_parse("Hello", matching_condition="search")(mock_skill))
+
+            mock_connector = amock.CoroutineMock()
+
+            message = Message("Hello", "user", "default", mock_connector)
+            skills = await parse_format(opsdroid, opsdroid.skills, message)
+            self.assertEqual(mock_skill, skills[0]["skill"])
+
+            message = Message("Hello world", "user", "default", mock_connector)
+            skills = await parse_format(opsdroid, opsdroid.skills, message)
+            self.assertEqual(mock_skill, skills[0]["skill"])
+
+    async def test_parse_format_parameters(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(
+                match_parse("say {text} {num:d} times", case_sensitive=False)
+                (mock_skill)
+            )
+
+            mock_connector = amock.CoroutineMock()
+            message = Message(
+                "Say hello 42 times", "user", "default", mock_connector)
+
+            skills = await parse_format(opsdroid, opsdroid.skills, message)
+            self.assertEqual(mock_skill, skills[0]["skill"])
+
+            parse_result = skills[0]["message"].parse_result
+            self.assertEqual(parse_result['text'], 'hello')
+            self.assertEqual(parse_result['num'], 42)


### PR DESCRIPTION
# Description

Add a new simple parser based on https://github.com/r1chardj0n3s/parse .

It is like the regex parser but simpler, useful for newcomers that don't need all the possibilities (and complexity) of the regular expressions.

Look the new doc page or the tests to see some examples of use :blush: 

## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

- A new test class in `tests/test_parser_format.py`

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
