### PR TITLE
Fix bug in  rocketchat - opsdroid wouldn't reply

### DIFF
--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -96,10 +96,10 @@ class RocketChat(Connector):
         """
         if response['messages']:
             message = Message(
+                response['messages'][0]['msg'],
                 response['messages'][0]['u']['username'],
                 response['messages'][0]['rid'],
-                self,
-                response['messages'][0]['msg'])
+                self)
             _LOGGER.debug("Received message from Rocket.Chat %s",
                           response['messages'][0]['msg'])
 


### PR DESCRIPTION
# Description

While working on implementing the Image event I have noticed that opsdroid wasn't replying to a command. This PR fixes this bug and also updates the documentation in regards to images. Which sadly doesn't seem to be able to be implemented with the current API.


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Sent message to rocket.chat - opsdroid replied successfully 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
