### PR TITLE
Attempt at fixing appveyor fails on 3.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
       TOXENV: "py37"
 
 install:
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip"
   - "%PYTHON%\\python.exe -m pip install tox"
 
 build: off


### PR DESCRIPTION
I have no idea if this will even work or affect something, but since pip is really outdated on python 3.5 I wonder if this could help fix the issue 🤔 
