### PR TITLE
Upgrade setuptools before install on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
       TOXENV: "py37"
 
 install:
+  - "%PYTHON%\\python.exe -m pip install --upgrade setuptools"
   - "%PYTHON%\\python.exe -m pip install tox"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,12 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       TOXENV: "py37"
 
+matrix:
+  allow_failures:
+    - TOXENV: py35
+
 install:
-  - "%PYTHON%\\python.exe -m pip install --upgrade setuptools"
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip setuptools"
   - "%PYTHON%\\python.exe -m pip install tox"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
 
 matrix:
   allow_failures:
-    - TOXENV: py35
+    - TOXENV: "py35"
 
 install:
   - "%PYTHON%\\python.exe -m pip install --upgrade pip setuptools"


### PR DESCRIPTION
# Description

Appveyor seems to be failing when running pip install. Looks like a setuptools issue. Upgrading to see if that helps.

