### PR TITLE
Make web server open by default

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -282,11 +282,11 @@ lang: <ISO 639-1 code -  example: 'en'>
 
 Configure the REST API in opsdroid.
 
-By default, opsdroid will start a web server accessible only to localhost on port `8080` (or `8443` if SSL details are provided). For more information see the [REST API docs](rest-api).
+By default, opsdroid will start a web server on port `8080` (or `8443` if SSL details are provided). For more information see the [REST API docs](rest-api).
 
 ```yaml
 web:
-  host: '127.0.0.1'  # set to '0.0.0.0' to allow all traffic
+  host: '0.0.0.0'
   port: 8080
   ssl:
     cert: /path/to/cert.pem

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,6 +1,6 @@
 # REST API
 
-There is a RESTful API for opsdroid which by default is only accessible to `localhost` on port `8080`. See the [configuration reference](configuration-reference#web) for config options.
+There is a RESTful API for opsdroid accessible on port `8080`. See the [configuration reference](configuration-reference#web) for config options.
 
 ## Methods
 

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -64,7 +64,7 @@ class Web:
         try:
             host = self.config["host"]
         except KeyError:
-            host = '127.0.0.1'
+            host = '0.0.0.0'
         return host
 
     @property

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -38,11 +38,11 @@ class TestWeb(asynctest.TestCase):
         with OpsDroid() as opsdroid:
             opsdroid.config["web"] = {}
             app = web.Web(opsdroid)
-            self.assertEqual(app.get_host, "127.0.0.1")
-
-            opsdroid.config["web"] = {"host": "0.0.0.0"}
-            app = web.Web(opsdroid)
             self.assertEqual(app.get_host, "0.0.0.0")
+
+            opsdroid.config["web"] = {"host": "127.0.0.1"}
+            app = web.Web(opsdroid)
+            self.assertEqual(app.get_host, "127.0.0.1")
 
     async def test_web_get_ssl(self):
         """Check the host getter."""


### PR DESCRIPTION
# Description

Change default web server host to `0.0.0.0` to allow all traffic.

Fixes #942


## Status
**READY** 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

