### PR TITLE
Add long description content type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     author_email='jacob@tom.linson.uk',
     description='An open source ChatOps bot framework.',
     long_description=README,
+    long_description_content_type='text/markdown',
     packages=PACKAGES,
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
# Description

I'm not 100% sure, but this could fix #944 . See https://pypi.org/help/#description-content-type :
> PyPI will reject uploads if the description fails to render.

Fixes #944


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

