### PR TITLE
Add opsdroid version to log messages

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -78,7 +78,7 @@ def configure_logging(config):
         file_handler.setFormatter(formatter)
         rootlogger.addHandler(file_handler)
     _LOGGER.info("="*40)
-    _LOGGER.info(_("Started application"))
+    _LOGGER.info(_("Started opsdroid %s"), __version__)
 
 
 def get_logging_level(logging_level):

--- a/opsdroid/locale/es/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/es/LC_MESSAGES/opsdroid.po
@@ -19,7 +19,7 @@ msgstr ""
 "Generated-By: Babel 2.5.3\n"
 
 #: opsdroid/__main__.py:71
-msgid "Started application"
+msgid "Started opsdroid %s"
 msgstr "Aplicación lanzada"
 
 #: opsdroid/__main__.py:99

--- a/opsdroid/locale/es/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/es/LC_MESSAGES/opsdroid.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: opsdroid/__main__.py:71
 msgid "Started opsdroid %s"
-msgstr "Aplicación lanzada"
+msgstr "Opsdroid %s lanzada"
 
 #: opsdroid/__main__.py:99
 msgid "Whoops! opsdroid requires python 3.5 or above."

--- a/opsdroid/locale/no/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/no/LC_MESSAGES/opsdroid.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 
 #: opsdroid/__main__.py:71
-msgid "Started application"
+msgid "Started opsdroid %s"
 msgstr "Applikasjon startet"
 
 #: opsdroid/__main__.py:99

--- a/opsdroid/locale/no/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/no/LC_MESSAGES/opsdroid.po
@@ -21,7 +21,7 @@ msgstr ""
 
 #: opsdroid/__main__.py:71
 msgid "Started opsdroid %s"
-msgstr "Applikasjon startet"
+msgstr "Opsdroid %s startet"
 
 #: opsdroid/__main__.py:99
 msgid "Whoops! opsdroid requires python 3.5 or above."

--- a/opsdroid/locale/pt/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/pt/LC_MESSAGES/opsdroid.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: opsdroid/__main__.py:71
 msgid "Started opsdroid %s"
-msgstr "A aplicacão iniciou"
+msgstr "Opsdroid %s iniciou"
 
 #: opsdroid/__main__.py:99
 msgid "Whoops! opsdroid requires python 3.5 or above."

--- a/opsdroid/locale/pt/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/pt/LC_MESSAGES/opsdroid.po
@@ -19,7 +19,7 @@ msgstr ""
 "Generated-By: Babel 2.5.3\n"
 
 #: opsdroid/__main__.py:71
-msgid "Started application"
+msgid "Started opsdroid %s"
 msgstr "A aplicacão iniciou"
 
 #: opsdroid/__main__.py:99

--- a/opsdroid/locale/pt_BR/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/pt_BR/LC_MESSAGES/opsdroid.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 
 #: opsdroid/__main__.py:81
-msgid "Started application"
+msgid "Started opsdroid %s"
 msgstr "A aplicacão iniciou"
 
 #: opsdroid/__main__.py:103

--- a/opsdroid/locale/ru/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/ru/LC_MESSAGES/opsdroid.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: opsdroid/__main__.py:81
 msgid "Started opsdroid %s"
-msgstr "Приложение создано"
+msgstr "Opsdroid %s создано"
 
 #: opsdroid/__main__.py:103
 msgid "Whoops! opsdroid requires python 3.5 or above."

--- a/opsdroid/locale/ru/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/ru/LC_MESSAGES/opsdroid.po
@@ -18,7 +18,7 @@ msgstr ""
 "Generated-By: Babel 2.6.0\n"
 
 #: opsdroid/__main__.py:81
-msgid "Started application"
+msgid "Started opsdroid %s"
 msgstr "Приложение создано"
 
 #: opsdroid/__main__.py:103


### PR DESCRIPTION
Instead of stating `Started application` in the logs I've added the opsdroid version. This is useful for troubleshooting logs.

```
INFO opsdroid: ========================================
INFO opsdroid: Started opsdroid v0.15.4+2.g4e60f86
INFO opsdroid: ========================================
```