### PR TITLE
Remove Python 3.5 support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,4 +3,4 @@
 version: 2
 
 python:
-  version: 3.6
+  version: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
-sudo: false
+sudo: true
+dist: xenial
 matrix:
   fast_finish: true
   include:
-    - python: "3.5"
-      env: TOXENV=docker
-    - python: "3.5"
-      env: TOXENV=docs
-    - python: "3.5"
-      env: TOXENV=lint
-    - python: "3.5"
-      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
-      dist: xenial
-      sudo: true
+    - python: "3.7"
+      env: TOXENV=docker
+    - python: "3.7"
+      env: TOXENV=docs
+    - python: "3.7"
+      env: TOXENV=lint
 cache:
   directories:
     - $HOME/.cache/pip
@@ -33,7 +30,7 @@ deploy:
   on:
     tags: true
     repo: opsdroid/opsdroid
-    condition: "$TOXENV = py35"
+    condition: "$TOXENV = py37"
 notifications:
   webhooks:
     urls:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 LABEL maintainer="Jacob Tomlinson <jacob@tom.linson.uk>"
 
 RUN mkdir -p /usr/src/app

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,10 @@ environment:
 
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
-
-    - PYTHON: "C:\\Python35-x64"
-      TOXENV: "py35"
     - PYTHON: "C:\\Python36-x64"
       TOXENV: "py36"
     - PYTHON: "C:\\Python37-x64"
       TOXENV: "py37"
-
-matrix:
-  allow_failures:
-    - TOXENV: "py35"
 
 install:
   - "%PYTHON%\\python.exe -m pip install --upgrade pip setuptools"

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -115,8 +115,8 @@ def get_logging_level(logging_level):
 
 def check_dependencies():
     """Check for system dependencies required by opsdroid."""
-    if sys.version_info.major < 3 or sys.version_info.minor < 5:
-        logging.critical(_("Whoops! opsdroid requires python 3.5 or above."))
+    if sys.version_info.major < 3 or sys.version_info.minor < 6:
+        logging.critical(_("Whoops! opsdroid requires python 3.6 or above."))
         sys.exit(1)
 
 

--- a/opsdroid/locale/es/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/es/LC_MESSAGES/opsdroid.po
@@ -23,8 +23,8 @@ msgid "Started opsdroid %s"
 msgstr "Opsdroid %s lanzada"
 
 #: opsdroid/__main__.py:99
-msgid "Whoops! opsdroid requires python 3.5 or above."
-msgstr "Ups! opsdroid requiere python 3.5 o superior"
+msgid "Whoops! opsdroid requires python 3.6 or above."
+msgstr "Ups! opsdroid requiere python 3.6 o superior"
 
 #: opsdroid/__main__.py:108
 msgid "You can customise your opsdroid by modifying your configuration.yaml"

--- a/opsdroid/locale/no/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/no/LC_MESSAGES/opsdroid.po
@@ -24,8 +24,8 @@ msgid "Started opsdroid %s"
 msgstr "Opsdroid %s startet"
 
 #: opsdroid/__main__.py:99
-msgid "Whoops! opsdroid requires python 3.5 or above."
-msgstr "Oops! opsdroid trenger python 3.5 eller nyere."
+msgid "Whoops! opsdroid requires python 3.6 or above."
+msgstr "Oops! opsdroid trenger python 3.6 eller nyere."
 
 #: opsdroid/__main__.py:108
 msgid "You can customise your opsdroid by modifying your configuration.yaml"

--- a/opsdroid/locale/pt/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/pt/LC_MESSAGES/opsdroid.po
@@ -23,8 +23,8 @@ msgid "Started opsdroid %s"
 msgstr "Opsdroid %s iniciou"
 
 #: opsdroid/__main__.py:99
-msgid "Whoops! opsdroid requires python 3.5 or above."
-msgstr "Whoops! opsdroid precisa que a tua versão de python seja 3.5 ou superior."
+msgid "Whoops! opsdroid requires python 3.6 or above."
+msgstr "Whoops! opsdroid precisa que a tua versão de python seja 3.6 ou superior."
 
 #: opsdroid/__main__.py:108
 msgid "You can customise your opsdroid by modifying your configuration.yaml"

--- a/opsdroid/locale/pt_BR/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/pt_BR/LC_MESSAGES/opsdroid.po
@@ -24,8 +24,8 @@ msgid "Started opsdroid %s"
 msgstr "A aplicacão iniciou"
 
 #: opsdroid/__main__.py:103
-msgid "Whoops! opsdroid requires python 3.5 or above."
-msgstr "Whoops! opsdroid precisa que a tua versão de python seja 3.5 ou superior."
+msgid "Whoops! opsdroid requires python 3.6 or above."
+msgstr "Whoops! opsdroid precisa que a tua versão de python seja 3.6 ou superior."
 
 #: opsdroid/__main__.py:148
 msgid "You can customise your opsdroid by modifying your configuration.yaml"

--- a/opsdroid/locale/ru/LC_MESSAGES/opsdroid.po
+++ b/opsdroid/locale/ru/LC_MESSAGES/opsdroid.po
@@ -22,8 +22,8 @@ msgid "Started opsdroid %s"
 msgstr "Opsdroid %s создано"
 
 #: opsdroid/__main__.py:103
-msgid "Whoops! opsdroid requires python 3.5 or above."
-msgstr "Упс! Для работы opsdroid требуется версия python 3.5 или выше"
+msgid "Whoops! opsdroid requires python 3.6 or above."
+msgstr "Упс! Для работы opsdroid требуется версия python 3.6 или выше"
 
 #: opsdroid/__main__.py:148
 msgid "You can customise your opsdroid by modifying your configuration.yaml"

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Communications :: Chat',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -157,6 +157,22 @@ class TestMain(unittest.TestCase):
         with mock.patch.object(sys, 'version_info') as version_info:
             version_info.major = 3
             version_info.minor = 5
+            with self.assertRaises(SystemExit):
+                opsdroid.check_dependencies()
+
+    def test_check_version_36(self):
+        with mock.patch.object(sys, 'version_info') as version_info:
+            version_info.major = 3
+            version_info.minor = 6
+            try:
+                opsdroid.check_dependencies()
+            except SystemExit:
+                self.fail("check_dependencies() exited unexpectedly!")
+
+    def test_check_version_37(self):
+        with mock.patch.object(sys, 'version_info') as version_info:
+            version_info.major = 3
+            version_info.minor = 7
             try:
                 opsdroid.check_dependencies()
             except SystemExit:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, lint, docker
+envlist = py36, py37, lint, docker
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
# Description
Remove Python 3.5 support.

Going forwards we will only be supporting the latest two releases of Python, with the latest release being the default for things like docker.

- Update tox to not run `py35`
- Update CI to not run `py35`
- Update CI to use `py37` as base for lint, docker, docs and deployment
- Update `setup.py` to not include 3.5
- Update `__main__.py` and tests to check for 3.6+
- Update `Dockerfile` to use 3.7 as base image

Fixes #953


## Status.
**READY**



