### PR TITLE
Fix readthedocs (again)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,3 +4,11 @@ version: 2
 
 python:
   version: 3.7
+
+mkdocs:
+  configuration: mkdocs.yml
+
+formats: all
+
+install:
+  - requirements: requirements_readthedocs.txt


### PR DESCRIPTION
# Description
Builds for readthedocs seem to be failing again. This time we are getting

```
Problem in your project's configuration. Invalid "sphinx.builder": .readthedocs.yml: Your project is configured as "Mkdocs (Markdown)" in your admin dashboard, but there is no "mkdocs" key specified.
```

This PR attempts to add the missing `mkdocs` key along with some others from the rtd documentation that seem sensible.