### PR TITLE
Downgrade rtd to py36

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 version: 2
 
 python:
-  version: 3.7
+  version: 3.6
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
# Description

Third times the charm! There seems to be a bug and rtd must be at py36.