### PR TITLE
Add Slack rich layouts support

### DIFF
--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -40,3 +40,55 @@ hi
 opsdroid APP [7:06 PM]
 Hi fabiorosado
 ```
+
+## Rich layouts and blocks
+
+Slack has support for [rich layouts](https://api.slack.com/messaging/composing/layouts) using a concept they call [blocks](https://api.slack.com/reference/messaging/blocks). Blocks are JSON objects which describe a rich element, and a list of them can be passed instead of a message to produce rich content.
+
+To do this you need to respond with an `opsdroid.connector.slack.events.Blocks` event which is constructed with a list of blocks.
+
+### Example
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
+from opsdroid.connector.slack.events import Blocks
+
+
+class BlocksSkill(Skill):
+
+    @match_regex(r"who are you\?")
+    async def who_are_you(self, event):
+        await event.respond(Blocks([
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Hey! I'm opsdroid.\nI'm a natural language event driven automation bot framework.\n*What a mouthful!*"
+                    },
+                    "accessory": {
+                        "type": "image",
+                        "image_url": "https://raw.githubusercontent.com/opsdroid/style-guidelines/master/logos/logo-light.png",
+                        "alt_text": "opsdroid logo"
+                    }
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Visit website",
+                                "emoji": True
+                            },
+                            "url": "https://opsdroid.dev"
+                        }
+                    ]
+                }
+            ]
+        ))
+
+```
+
+![](https://user-images.githubusercontent.com/1610850/58658951-ac523300-8319-11e9-8c2a-011469a436d0.png)

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -12,6 +12,7 @@ from emoji import demojize
 
 from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message, Reaction
+from opsdroid.connector.slack.events import Blocks
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -139,6 +140,20 @@ class ConnectorSlack(Connector):
             as_user=False,
             username=self.bot_name,
             icon_emoji=self.icon_emoji,
+        )
+
+    @register_event(Blocks)
+    async def send_blocks(self, blocks):
+        """Respond with structured blocks."""
+        _LOGGER.debug("Responding with interactive blocks in room  %s", blocks.target)
+        await self.slacker.chat.post(
+            "chat.postMessage",
+            data={
+                "channel": blocks.target,
+                "username": self.bot_name,
+                "blocks": blocks.blocks,
+                "icon_emoji": self.icon_emoji,
+            },
         )
 
     @register_event(Reaction)

--- a/opsdroid/connector/slack/events.py
+++ b/opsdroid/connector/slack/events.py
@@ -1,0 +1,44 @@
+"""Classes to describe different kinds of Slack specific event."""
+
+import json
+
+from opsdroid.events import Message
+
+
+class Blocks(Message):
+    """A blocks object.
+
+    Slack uses blocks to add advenced interactivity and formatting to messages.
+    https://api.slack.com/messaging/interactivity
+    Blocks are provided in JSON format to Slack which renders them.
+
+    Args:
+        blocks (string or dict): String or dict of json for blocks
+        room (string, optional): String name of the room or chat channel in
+                                 which message was sent
+        connector (Connector, optional): Connector object used to interact with
+                                         given chat service
+        raw_event (dict, optional): Raw message as provided by chat service.
+                                    None by default
+
+    Attributes:
+        created: Local date and time that message object was created
+        user: String name of user sending message
+        room: String name of the room or chat channel in which message was sent
+        connector: Connector object used to interact with given chat service
+        blocks: Blocks JSON as string
+        raw_event: Raw message provided by chat service
+        raw_match: A match object for a search against which the message was
+            matched. E.g. a regular expression or natural language intent
+        responded_to: Boolean initialized as False. True if event has been
+            responded to
+
+    """
+
+    def __init__(self, blocks, *args, **kwargs):
+        """Create object with minimum properties."""
+        super().__init__("", *args, **kwargs)
+
+        self.blocks = blocks
+        if isinstance(self.blocks, list):
+            self.blocks = json.dumps(self.blocks)

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -9,6 +9,7 @@ import slacker
 
 from opsdroid.core import OpsDroid
 from opsdroid.connector.slack import ConnectorSlack
+from opsdroid.connector.slack.events import Blocks
 from opsdroid.events import Message, Reaction
 from opsdroid.__main__ import configure_lang
 
@@ -231,6 +232,19 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         connector.slacker.chat.post_message = amock.CoroutineMock()
         await connector.send(Message("test", "user", "room", connector))
         self.assertTrue(connector.slacker.chat.post_message.called)
+
+    async def test_send_blocks(self):
+        connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
+        connector.slacker.chat.post = amock.CoroutineMock()
+        await connector.send(
+            Blocks(
+                [{"type": "section", "text": {"type": "mrkdwn", "text": "*Test*"}}],
+                "user",
+                "room",
+                connector,
+            )
+        )
+        self.assertTrue(connector.slacker.chat.post.called)
 
     async def test_react(self):
         connector = ConnectorSlack({"api-token": "abc123"})


### PR DESCRIPTION
# Description

Slack has support for [rich layouts](https://api.slack.com/messaging/composing/layouts) using a concept they call [blocks](https://api.slack.com/reference/messaging/blocks). Blocks are JSON objects which describe a rich element, and a list of them can be passed instead of a message body to produce rich content.

This PR adds support for sending blocks to slack with the new `opsdroid.connector.slack.events.Blocks` event.

```python
from opsdroid.skill import Skill
from opsdroid.matchers import match_regex
from opsdroid.connector.slack.events import Blocks


class BlocksSkill(Skill):

    @match_regex(r"who are you\?")
    async def who_are_you(self, event):
        await event.respond(Blocks([
                {
                    "type": "section",
                    "text": {
                        "type": "mrkdwn",
                        "text": "Hey! I'm opsdroid.\nI'm a natural language event driven automation bot framework.\n*What a mouthful!*"
                    },
                    "accessory": {
                        "type": "image",
                        "image_url": "https://raw.githubusercontent.com/opsdroid/style-guidelines/master/logos/logo-light.png",
                        "alt_text": "opsdroid logo"
                    }
                },
                {
                    "type": "actions",
                    "elements": [
                        {
                            "type": "button",
                            "text": {
                                "type": "plain_text",
                                "text": "Visit website",
                                "emoji": True
                            },
                            "url": "https://opsdroid.dev"
                        }
                    ]
                }
            ]
        ))

```

<img width="684" alt="image" src="https://user-images.githubusercontent.com/1610850/58658951-ac523300-8319-11e9-8c2a-011469a436d0.png">


Fixes #878


## Type of change
- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- Tested locally with my Slack account


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

