### PR TITLE
Reduce matrix the sync timeout to one minute

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -120,7 +120,7 @@ class ConnectorMatrix(Connector):
             try:
                 response = await self.connection.sync(
                     self.connection.sync_token,
-                    timeout_ms=int(5 * 60 * 1e3),  # 5m in ms
+                    timeout_ms=int(60 * 1e3),  # 1m in ms
                     filter=self.filter_id,
                 )
                 _LOGGER.debug("matrix sync request returned")


### PR DESCRIPTION
Apparently Riot uses 30s and matrix.org's load balancer times out after 90s, so 60s seems like a sensible default.

