### PR TITLE
Specify SSH key for private git repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 repos:
--   repo: https://github.com/ambv/black
+  - repo: https://github.com/ambv/black
     rev: stable
     hooks:
-    - id: black
-      language_version: python3.6
+      - id: black
+        language_version: python3.6
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY requirements.txt requirements.txt
 COPY README.md README.md
 COPY MANIFEST.in MANIFEST.in
 
-RUN apk update && apk add git
+RUN apk update && apk add --no-cache git openssh-client
 RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir --no-use-pep517 .
 RUN apk del gcc musl-dev

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -178,7 +178,6 @@ def main():
     welcome_message(config)
 
     with OpsDroid(config=config) as opsdroid:
-        opsdroid.load()
         opsdroid.run()
 
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -135,6 +135,7 @@ class OpsDroid:
 
     def run(self):
         """Start the event loop."""
+        self.sync_load()
         _LOGGER.info(_("Opsdroid is now running, press ctrl+c to exit."))
         if not self.is_running():
             self._running = True
@@ -151,7 +152,11 @@ class OpsDroid:
         else:
             _LOGGER.error(_("Oops! Opsdroid is already running."))
 
-    def load(self):
+    def sync_load(self):
+        """Run the load modules method synchronously."""
+        self.eventloop.run_until_complete(self.load())
+
+    async def load(self):
         """Load modules."""
         self.modules = self.loader.load_modules_from_config(self.config)
         _LOGGER.debug(_("Loaded %i skills"), len(self.modules["skills"]))
@@ -161,7 +166,7 @@ class OpsDroid:
         self.train_parsers(self.modules["skills"])
         if self.modules["databases"] is not None:
             self.start_databases(self.modules["databases"])
-        self.start_connectors(self.modules["connectors"])
+        await self.start_connectors(self.modules["connectors"])
         self.cron_task = self.eventloop.create_task(parse_crontab(self))
         self.eventloop.create_task(self.web_server.start())
 
@@ -288,7 +293,7 @@ class OpsDroid:
                 asyncio.gather(*tasks, loop=self.eventloop)
             )
 
-    def start_connectors(self, connectors):
+    async def start_connectors(self, connectors):
         """Start the connectors."""
         for connector_module in connectors:
             for _, cls in connector_module["module"].__dict__.items():
@@ -302,10 +307,7 @@ class OpsDroid:
 
         if connectors:
             for connector in self.connectors:
-                if self.eventloop.is_running():
-                    self.eventloop.create_task(connector.connect())
-                else:
-                    self.eventloop.run_until_complete(connector.connect())
+                await connector.connect()
             for connector in self.connectors:
                 task = self.eventloop.create_task(connector.listen())
                 self.connector_tasks.append(task)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.6.0
+aiohttp==3.6.1
 aioredis==1.2.0
 aioslacker==0.0.11
 aiosqlite==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ pyyaml==5.1.2
 setuptools==41.2.0
 websockets==8.0.2
 yamale==2.0.1
-webexteamssdk==1.1.1
+webexteamssdk==1.2

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -511,7 +511,29 @@ class TestLoader(unittest.TestCase):
         ) as mockclone:
             loader._install_module(config)
             mockclone.assert_called_with(
-                config["repo"], config["install_path"], config["branch"]
+                config["repo"], config["install_path"], config["branch"], None
+            )
+
+    def test_install_specific_remote_module_ssl(self):
+        opsdroid, loader = self.setup()
+        config = {
+            "name": "testmodule",
+            "install_path": os.path.join(self._tmp_dir, "test_specific_remote_module"),
+            "repo": "https://github.com/rmccue/test-repository.git",
+            "branch": "master",
+            "key_path": os.path.join(
+                self._tmp_dir, os.path.normpath("install/from/here.key")
+            ),
+        }
+        with mock.patch("opsdroid.loader._LOGGER.debug"), mock.patch.object(
+            loader, "git_clone"
+        ) as mockclone:
+            loader._install_module(config)
+            mockclone.assert_called_with(
+                config["repo"],
+                config["install_path"],
+                config["branch"],
+                config["key_path"],
             )
 
     def test_install_specific_local_git_module(self):
@@ -600,6 +622,7 @@ class TestLoader(unittest.TestCase):
                     + ".git",
                     config["install_path"],
                     config["branch"],
+                    None,
                 )
         shutil.rmtree(config["install_path"], onerror=del_rw)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import shutil
 import subprocess
@@ -65,7 +64,7 @@ class TestLoader(unittest.TestCase):
     def test_load_config_broken_without_connectors(self):
         opsdroid, loader = self.setup()
         with self.assertRaises(SystemExit) as cm:
-            config = loader.load_config_file(
+            _ = loader.load_config_file(
                 [os.path.abspath("tests/configs/broken_without_connectors.yaml")]
             )
         self.assertEqual(cm.exception.code, 1)
@@ -81,7 +80,7 @@ class TestLoader(unittest.TestCase):
         opsdroid, loader = self.setup()
 
         with self.assertRaises(SystemExit) as cm:
-            config = loader.load_config_file(
+            _ = loader.load_config_file(
                 [os.path.abspath("tests/configs/full_broken.yaml")]
             )
         self.assertEqual(cm.exception.code, 1)
@@ -105,7 +104,7 @@ class TestLoader(unittest.TestCase):
         """
         opsdroid, loader = self.setup()
         with self.assertRaises(SystemExit):
-            config = loader.load_config_file(
+            _ = loader.load_config_file(
                 [os.path.abspath("tests/configs/include_exploit.yaml")]
             )
             self.assertLogs("_LOGGER", "critical")
@@ -182,12 +181,16 @@ class TestLoader(unittest.TestCase):
     def test_git_clone(self):
         with mock.patch.object(subprocess, "Popen") as mock_subproc_popen:
             opsdroid, loader = self.setup()
+            myrsa = "/path/to/my/id_rsa"
             loader.git_clone(
                 "https://github.com/rmccue/test-repository.git",
                 os.path.join(self._tmp_dir, "/test"),
                 "master",
+                myrsa,
             )
             self.assertTrue(mock_subproc_popen.called)
+            _, mock_subproc_popen_kwargs = mock_subproc_popen.call_args
+            assert myrsa in mock_subproc_popen_kwargs["env"]["GIT_SSH_COMMAND"]
 
     def test_git_pull(self):
         with mock.patch.object(subprocess, "Popen") as mock_subproc_popen:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,8 +151,6 @@ class TestMain(unittest.TestCase):
         ) as mock_cl, mock.patch.object(
             opsdroid, "welcome_message"
         ) as mock_wm, mock.patch.object(
-            OpsDroid, "load"
-        ) as mock_load, mock.patch.object(
             web, "Web"
         ), mock.patch.object(
             OpsDroid, "run"
@@ -162,5 +160,4 @@ class TestMain(unittest.TestCase):
             self.assertTrue(mock_cd.called)
             self.assertTrue(mock_cl.called)
             self.assertTrue(mock_wm.called)
-            self.assertTrue(mock_load.called)
             self.assertTrue(mock_loop.called)


### PR DESCRIPTION
# Description

Added ability to specify a ssh key to be used to clone private git repos.  This also required installing openssh-client in the docker container.  i dont expect this to merge, just some guidance on how to get it to a better state would be great.

Fixes #980


## Status
**UNDER DEVELOPMENT**


## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Create new docker image
2. Put a ssh key in the docker container, I did this under opsdroid/configuration/my-key and copied the SRC dir into the container at runtime.
3. Load a skill, from a private repo, using the 'key_path' option, with the full path to the ssh key
4. Run container

Example

```
docker build -t opsdroid/opsdroid:feature-980 .
docker run --rm -ti -v $(pwd):/usr/src/app opsdroid/opsdroid:feature-980
```
configuration.yaml
```
logging:
  level: debug
  path: opsdroid.log
  console: true

welcome-message: false

connectors:
 - name: slack
   api-token: "keyhere"

skills:
  - name: delete
    repo: git@github.private.com:somewhere/skill-delete.git
    no-cache: true
    key_path: /usr/src/app/opsdroid/configuration/github-key
```

Logs would indicate
```
DEBUG opsdroid.loader: Loading skill modules...
DEBUG opsdroid.loader: 'no-cache' set, removing /root/.local/share/opsdroid/opsdroid-modules/skill/delete
DEBUG opsdroid.loader: Installing delete...
INFO opsdroid.loader: Cloning delete from remote repository
DEBUG opsdroid.loader: b"Cloning into '/root/.local/share/opsdroid/opsdroid-modules/skill/delete'..."
DEBUG opsdroid.loader: b"Warning: Permanently added 'github.private.com,10.10.109.208' (ECDSA) to the list of known hosts."
DEBUG opsdroid.loader: Installed delete to /root/.local/share/opsdroid/opsdroid-modules/skill/delete
DEBUG opsdroid.loader: Couldn't find the file requirements.txt, skipping.
DEBUG opsdroid.loader: Loaded skill: opsdroid-modules.skill.delete
```


# Checklist:

- [X ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

I have no idea how to write a test for this, but any direction provided im sure I could follow.  Also, I only can test against github. which doesnt appear to support that 'ssh://' setup, so I had to add a flag to look for 'git@'.  I also had to move where I checked for the key_path, since in my original idea as discussed on #980 actually caused an error where it was attempting to load key_path before it was defined when using non private repos.