### PR TITLE
Update pyyaml envvar/include code to work with latest version

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -17,6 +17,8 @@ from collections.abc import Mapping
 from pkg_resources import iter_entry_points
 import yaml
 
+from yaml.constructor import SafeConstructor, FullConstructor
+
 from opsdroid.helper import (
     move_config_to_appdir,
     file_is_ipython_notebook,
@@ -329,7 +331,7 @@ class Loader:
             config_path = cls.create_default_config(DEFAULT_CONFIG_PATH)
 
         env_var_pattern = re.compile(r"^\$([A-Z_]*)$")
-        yaml.add_implicit_resolver("!envvar", env_var_pattern)
+        yaml.SafeLoader.add_implicit_resolver("!envvar", env_var_pattern, first="$")
 
         def envvar_constructor(loader, node):
             """Yaml parser for env vars."""
@@ -345,13 +347,13 @@ class Loader:
             with open(included_yaml, "r") as included:
                 return yaml.safe_load(included)
 
-        yaml.add_constructor("!envvar", envvar_constructor)
-        yaml.add_constructor("!include", include_constructor)
+        yaml.SafeLoader.add_constructor("!envvar", envvar_constructor)
+        yaml.SafeLoader.add_constructor("!include", include_constructor)
 
         try:
             with open(config_path, "r") as stream:
                 _LOGGER.info(_("Loaded config from %s."), config_path)
-                return yaml.load(stream, Loader=yaml.SafeLoader)
+                return yaml.safe_load(stream)
         except yaml.YAMLError as error:
             _LOGGER.critical(error)
             sys.exit(1)

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -17,8 +17,6 @@ from collections.abc import Mapping
 from pkg_resources import iter_entry_points
 import yaml
 
-from yaml.constructor import SafeConstructor, FullConstructor
-
 from opsdroid.helper import (
     move_config_to_appdir,
     file_is_ipython_notebook,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ opsdroid-get-image-size==0.2.2
 parse==1.12.0
 puremagic==1.5
 pycron==1.0.0
-pyyaml==4.2b1
+pyyaml==5.1.1
 setuptools==41.0.1
 websockets==7.0


### PR DESCRIPTION
# Description

I've updated pyyaml code to work with the latest stable version of pyyaml 5.1.1. 
The envvar and include constructors were broken after this last version was released. I had to dig into pyyaml source to try and make things work but I'm happy to say that both envvar and include code is working as before!

Tox is showing that code unrelated to these changes is not being covered, I'm going to raise the PR and see if this is the case, if so I will create a quick test to cover that line (it's a logging that is logged when config_path doesn't exist.)


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Run opsdroid with envvar configured - worked as expected
- Run opsdroid with `!include` - worked as expected


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

