### PR TITLE
Fixing rasanlu parser does not manage the new returned response after training request 

### DIFF
--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -126,11 +126,10 @@ async def train_rasanlu(config, skills):
                     _LOGGER.debug(result)
             if resp.content_type == "application/zip" and resp.content_disposition.type == "attachment":
                 time_taken = (arrow.now() - training_start).total_seconds()
-                _LOGGER.info(_("Rasa NLU training completed in %s seconds."),
-                            int(time_taken))
+                _LOGGER.info(_("Rasa NLU training completed in %s seconds."), int(time_taken))
                 await _init_model(config)
-                
-                 # As inditated in the issue #886, returned zip file is ignored, this can be changed
+
+                # As inditated in the issue #886, returned zip file is ignored, this can be changed
                 # This can be changed in future release if needed
                 # Saving model.zip file example :
                 # try:

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -124,7 +124,7 @@ async def train_rasanlu(config, skills):
                     await _init_model(config)
                     return True
 
-                    _LOGGER.debug(result)
+                _LOGGER.debug(result)
             if (
                 resp.content_type == "application/zip"
                 and resp.content_disposition.type == "attachment"

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -118,28 +118,35 @@ async def train_rasanlu(config, skills):
                 result = await resp.json()
                 if "info" in result and "new model trained" in result["info"]:
                     time_taken = (arrow.now() - training_start).total_seconds()
-                    _LOGGER.info(_("Rasa NLU training completed in %s seconds."),
-                                 int(time_taken))
+                    _LOGGER.info(
+                        _("Rasa NLU training completed in %s seconds."), int(time_taken)
+                    )
                     await _init_model(config)
                     return True
 
                     _LOGGER.debug(result)
-            if resp.content_type == "application/zip" and resp.content_disposition.type == "attachment":
+            if (
+                resp.content_type == "application/zip"
+                and resp.content_disposition.type == "attachment"
+            ):
                 time_taken = (arrow.now() - training_start).total_seconds()
-                _LOGGER.info(_("Rasa NLU training completed in %s seconds."), int(time_taken))
+                _LOGGER.info(
+                    _("Rasa NLU training completed in %s seconds."), int(time_taken)
+                )
                 await _init_model(config)
-
-                # As inditated in the issue #886, returned zip file is ignored, this can be changed
-                # This can be changed in future release if needed
-                # Saving model.zip file example :
-                # try:
-                #     output_file = open("/target/directory/model.zip","wb")
-                #     data = await resp.read()
-                #     output_file.write(data)
-                #     output_file.close()
-                #     _LOGGER.debug("Rasa taining model file saved to /target/directory/model.zip")
-                # except:
-                #     _LOGGER.error("Cannot save rasa taining model file to /target/directory/model.zip")
+                """
+                As inditated in the issue #886, returned zip file is ignored, this can be changed
+                This can be changed in future release if needed
+                Saving model.zip file example :
+                try:
+                    output_file = open("/target/directory/model.zip","wb")
+                    data = await resp.read()
+                    output_file.write(data)
+                    output_file.close()
+                    _LOGGER.debug("Rasa taining model file saved to /target/directory/model.zip")
+                except:
+                    _LOGGER.error("Cannot save rasa taining model file to /target/directory/model.zip")
+                """
                 return True
 
         _LOGGER.error(_("Bad Rasa NLU response - %s"), await resp.text())

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -462,12 +462,38 @@ class TestParserRasaNLU(asynctest.TestCase):
             patched_request.return_value.set_result(result)
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), False)
 
-            result.status = 200
-            patched_request.return_value = asyncio.Future()
-            patched_request.return_value.set_result(result)
-            self.assertEqual(await rasanlu.train_rasanlu({}, {}), True)
-
             result.json.return_value = {"info": "error"}
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), False)
+
+
+            result = amock.Mock()
+            result.status = 200
+            result.text = amock.CoroutineMock()
+            result.json = amock.CoroutineMock()
+            mock_gai.return_value = "Hello World"
+            mock_gem.return_value = ["abc123"]
+            mock_gif.return_value = "abc123"
+
+            result.json.return_value = {"info": "new model trained: abc123"}
+            result.content_type == "application/json"
+            patched_request.return_value = asyncio.Future()
+            patched_request.return_value.set_result(result)
+            self.assertEqual(await rasanlu.train_rasanlu({}, {}), True)
+
+            result = amock.Mock()
+            result.status = 200
+            result.text = amock.CoroutineMock()
+            result.json = amock.CoroutineMock()
+            mock_gai.return_value = "Hello World"
+            mock_gem.return_value = ["abc123"]
+            mock_gif.return_value = "abc123"
+            
+            result.content_type == "application/zip"
+            result.content_disposition == "attachment"
+            result.json.return_value = {'Content-Type': 'application/zip', 'Content-Disposition': 'attachment'}
+            patched_request.return_value = asyncio.Future()
+            patched_request.return_value.set_result(result)
+            self.assertEqual(await rasanlu.train_rasanlu({}, {}), True)
+

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -419,7 +419,7 @@ class TestParserRasaNLU(asynctest.TestCase):
             models = await rasanlu._get_existing_models({})
             self.assertEqual(models, [])
 
-    async def test_train_rasanlu(self):
+    async def test_train_rasanlu_fails(self):
         result = amock.Mock()
         result.status = 404
         result.text = amock.CoroutineMock()
@@ -464,37 +464,53 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             result.json.return_value = {"info": "error"}
             patched_request.return_value = asyncio.Future()
+            patched_request.side_effect = None
             patched_request.return_value.set_result(result)
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), False)
 
-            result = amock.Mock()
-            result.status = 200
-            result.text = amock.CoroutineMock()
-            result.json = amock.CoroutineMock()
-            mock_gai.return_value = "Hello World"
-            mock_gem.return_value = ["abc123"]
-            mock_gif.return_value = "abc123"
+    async def test_train_rasanlu_succeeded(self):
+        result = amock.Mock()
+        result.text = amock.CoroutineMock()
+        result.json = amock.CoroutineMock()
+        result.status = 200
+        result.json.return_value = {"info": "new model trained: abc1234"}
 
-            result.json.return_value = {"info": "new model trained: abc123"}
-            result.content_type == "application/json"
+        with amock.patch(
+            "aiohttp.ClientSession.post"
+        ) as patched_request, amock.patch.object(
+            rasanlu, "_get_all_intents"
+        ) as mock_gai, amock.patch.object(
+            rasanlu, "_init_model"
+        ) as mock_im, amock.patch.object(
+            rasanlu, "_build_training_url"
+        ) as mock_btu, amock.patch.object(
+            rasanlu, "_get_existing_models"
+        ) as mock_gem, amock.patch.object(
+            rasanlu, "_get_intents_fingerprint"
+        ) as mock_gif:
+
+            mock_gem.return_value = ["abc123"]
+            mock_btu.return_value = "http://example.com"
+            mock_gai.return_value = "Hello World"
+            mock_gif.return_value = "abc1234"
+            result.content_type = "application/json"
+
+            patched_request.side_effect = None
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), True)
 
-            result = amock.Mock()
-            result.status = 200
-            result.text = amock.CoroutineMock()
-            result.json = amock.CoroutineMock()
-            mock_gai.return_value = "Hello World"
-            mock_gem.return_value = ["abc123"]
-            mock_gif.return_value = "abc123"
+            result.json.return_value = {}
+            patched_request.side_effect = None
+            patched_request.return_value = asyncio.Future()
+            patched_request.return_value.set_result(result)
+            self.assertEqual(await rasanlu.train_rasanlu({}, {}), False)
 
-            result.content_type == "application/zip"
-            result.content_disposition == "attachment"
-            result.json.return_value = {
-                "Content-Type": "application/zip",
-                "Content-Disposition": "attachment",
-            }
+            result.content_type = "application/zip"
+            result.content_disposition.type = "attachment"
+            result.json.return_value = {"info": "new model trained: abc1234"}
+
+            patched_request.side_effect = None
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), True)

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -488,11 +488,13 @@ class TestParserRasaNLU(asynctest.TestCase):
             mock_gai.return_value = "Hello World"
             mock_gem.return_value = ["abc123"]
             mock_gif.return_value = "abc123"
-            
+
             result.content_type == "application/zip"
             result.content_disposition == "attachment"
-            result.json.return_value = {'Content-Type': 'application/zip', 'Content-Disposition': 'attachment'}
+            result.json.return_value = {
+                "Content-Type": "application/zip",
+                "Content-Disposition": "attachment",
+            }
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), True)
-

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -467,7 +467,6 @@ class TestParserRasaNLU(asynctest.TestCase):
             patched_request.return_value.set_result(result)
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), False)
 
-
             result = amock.Mock()
             result.status = 200
             result.text = amock.CoroutineMock()


### PR DESCRIPTION
# Description

This issue was initially detected by @jhofeditz when testing the fix #881.
The new rasanlu trainer instead of returning a json response after a model training, it return a zip file with all files generated by the trainer.

Fixes #886 

Check if rasanlu response is **application/json** or **application/zip**, if it's a zip file and if the **content_disposition** indicate a file attachment.

After a discussion with @jacobtomlinson (see issue history) we decided to ignore the returned zip file for the moment. if needed the code can be updated to handle it differently (saving the file in a directory for example)



## Status
**READY** | **~~UNDER DEVELOPMENT~~** | **~~ON HOLD~~**


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested the fix on my environment, no issue detected

- **Test  : Using Docker opsdroid version**  

```

opsdroid ❯ python -m opsdroid
INFO opsdroid.logging: ========================================
INFO opsdroid.logging: Started opsdroid v0.15.4+24.g7ec3d7e.dirty
DEBUG asyncio: Using selector: KqueueSelector
DEBUG opsdroid.loader: Loaded loader
DEBUG opsdroid.loader: Loading modules from config...
WARNING opsdroid.loader: No databases in configuration.This will cause skills which store things in memory to lose data when opsdroid is restarted.
DEBUG opsdroid.loader: Loading skill modules...
DEBUG opsdroid.loader: 'no-cache' set, removing /Users/hicham/Library/Application Support/opsdroid/opsdroid-modules/skill/social
DEBUG opsdroid.loader: Installing social...
DEBUG opsdroid.loader: Installed social to /Users/hicham/Library/Application Support/opsdroid/opsdroid-modules/skill/social
DEBUG opsdroid.loader: Couldn't find the file requirements.txt, skipping.
DEBUG opsdroid.loader: Loaded skill: opsdroid-modules.skill.social
DEBUG opsdroid.loader: Loading connector modules...
DEBUG opsdroid.loader: Loaded connector: opsdroid.connector.websocket
DEBUG opsdroid.loader: Loaded connector: opsdroid.connector.telegram
DEBUG opsdroid.core: Loaded 1 skills
INFO opsdroid.parsers.rasanlu: Starting Rasa NLU training.
INFO opsdroid.parsers.rasanlu: Now training the model. This may take a while...
INFO opsdroid.parsers.rasanlu: Rasa NLU training completed in 15 seconds.
INFO opsdroid.parsers.rasanlu: Initialising Rasa NLU model.
DEBUG opsdroid.parsers.rasanlu: Rasa NLU response - {"intent": {"name": null, "confidence": 0.0}, "entities": [], "text": "", "project": "ibot", "model": "model_20190609-114156"}
INFO opsdroid.parsers.rasanlu: Initialisation complete in 14 seconds.
DEBUG opsdroid.parsers.rasanlu: =========> returned model file saved to : /Users/hicham/Desktop/model.zip
DEBUG opsdroid.connector.websocket: Starting Websocket connector
DEBUG opsdroid.connector.telegram: Loaded telegram connector
DEBUG opsdroid.connector.telegram: Connecting to telegram
DEBUG opsdroid.connector.telegram: {'ok': True, 'result': {'id': 731324986, 'is_bot': True, 'first_name': 'ChamixLocalBot', 'username': 'ChamixLocalBot'}}
DEBUG opsdroid.connector.telegram: Connected to telegram as ChamixLocalBot
INFO opsdroid.core: Opsdroid is now running, press ctrl+c to exit.
INFO opsdroid.web: Started web server on http://0.0.0.0:8080
```

No more crash

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

