### PR TITLE
Fix slack reactions

### DIFF
--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -165,7 +165,7 @@ class ConnectorSlack(Connector):
             await self.slacker.reactions.post(
                 "reactions.add",
                 data={
-                    "name": emoji,
+                    "name": emoji.replace(":", ""),
                     "channel": reaction.target,
                     "timestamp": reaction.linked_event.raw_event["ts"],
                 },

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -159,13 +159,13 @@ class ConnectorSlack(Connector):
     @register_event(Reaction)
     async def send_reaction(self, reaction):
         """React to a message."""
-        emoji = demojize(reaction.emoji)
+        emoji = demojize(reaction.emoji).replace(":", "")
         _LOGGER.debug("Reacting with: %s", emoji)
         try:
             await self.slacker.reactions.post(
                 "reactions.add",
                 data={
-                    "name": emoji.replace(":", ""),
+                    "name": emoji,
                     "channel": reaction.target,
                     "timestamp": reaction.linked_event.raw_event["ts"],
                 },

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -255,7 +255,7 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         self.assertTrue(connector.slacker.reactions.post)
         self.assertEqual(
             connector.slacker.reactions.post.call_args[1]["data"]["name"],
-            ":grinning_face:",
+            "grinning_face",
         )
 
     async def test_react_invalid_name(self):


### PR DESCRIPTION
The Slack API must take emojis without the surrounding `:` colons.