### PR TITLE
Fixing telegram connector does not handle emoji message #1010

### DIFF
--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -173,6 +173,13 @@ class ConnectorTelegram(Connector):
                     )
                     await self.send(message)
                 self.latest_update = result["update_id"] + 1
+            elif (
+                "message" in result
+                and "sticker" in result["message"]
+                and "emoji" in result["message"]["sticker"]
+            ):
+                self.latest_update = result["update_id"] + 1
+                _LOGGER.debug("Emoji message parsing not supported " "- Ignoring message")
             else:
                 _LOGGER.error("Unable to parse the message.")
 

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -179,7 +179,9 @@ class ConnectorTelegram(Connector):
                 and "emoji" in result["message"]["sticker"]
             ):
                 self.latest_update = result["update_id"] + 1
-                _LOGGER.debug("Emoji message parsing not supported " "- Ignoring message")
+                _LOGGER.debug(
+                    "Emoji message parsing not supported " "- Ignoring message"
+                )
             else:
                 _LOGGER.error("Unable to parse the message.")
 

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -286,6 +286,52 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             self.assertTrue(mocked_respond.called)
             self.assertTrue(mocked_respond.called_with(message_text))
 
+    async def test_parse_message_emoji(self):
+        response = {
+            "result": [
+                {
+                    "update_id": 427647860,
+                    "message": {
+                        "message_id": 12,
+                        "from": {
+                            "id": 649671308,
+                            "is_bot": False,
+                            "first_name": "A",
+                            "last_name": "User",
+                            "username": "user",
+                            "language_code": "en-GB",
+                        },
+                        "chat": {
+                            "id": 649671308,
+                            "first_name": "A",
+                            "last_name": "User",
+                            "username": "user",
+                            "type": "private",
+                        },
+                        "date": 1538756863,
+                        "sticker": {
+                            "width": 512,
+                            "height": 512,
+                            "emoji": "😔",
+                            "set_name": "YourALF",
+                            "thumb": {
+                                "file_id": "AAQCABODB_MOAARYC8yRaPPoIIZBAAIC",
+                                "file_size": 8582,
+                                "width": 128,
+                                "height": 128,
+                            },
+                            "file_id": "CAADAgAD3QMAAsSraAu37DAtdiNpAgI",
+                            "file_size": 64720,
+                        },
+                    },
+                }
+            ]
+        }
+
+        with amock.patch("opsdroid.core.OpsDroid.parse"):
+            await self.connector._parse_message(response)
+            self.assertLogs("_LOGGER", "debug")
+
     async def test_get_messages(self):
         listen_response = amock.Mock()
         listen_response.status = 200


### PR DESCRIPTION
# Description

When opsdroid receive an emoji message from telegram " it does not succeed to parse the incoming message and enter a loop process indicating **ERROR opsdroid.connector.telegram: Unable to parse the message**


Fixes #1010 


## Status
**READY** | **~~UNDER DEVELOPMENT~~** | **~~ON HOLD~~**


## Type of change


- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the fix using telgram and opsdroid in debug mode 

```
DEBUG opsdroid.connector.telegram: {'update_id': 993865162, 'message': {'message_id': 709, 'from': {'id': 452282388, 'is_bot': False, 'first_name': 'Chami', 'language_code': 'en'}, 'chat': {'id': 452282388, 'first_name': 'Chami', 'type': 'private'}, 'date': 1563036852, 'sticker': {'width': 512, 'height': 512, 'emoji': '💗', 'set_name': 'Aphrodite', 'thumb': {'file_id': 'AAQCABOcUUsNAARX0dKosC6YOO_QAAIC', 'file_size': 7022, 'width': 128, 'height': 128}, 'file_id': 'CAADAgAD4wMAAkb7rATRPciInbDccwI', 'file_size': 48874}}}
DEBUG opsdroid.connector.telegram: Emoji message parsing not supported - Ignoring message
```

Now a debug log is displayed and no error loop are present

Tox : All OK

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

