### PR TITLE
Events IIa - Core additions

### DIFF
--- a/docs/extending/events.md
+++ b/docs/extending/events.md
@@ -34,6 +34,11 @@ The base `Event` class has the following attributes and methods:
 #### Methods
 * `respond(event)`: A method which takes another `Event` object responds using any attributes of the event which are not overridden in the response `event`. i.e. if the `target` attribute on the `event` argument is `None` then the `target` of the event being responded to will be used.
 
+### OpsdroidStarted
+
+The `OpsdroidStarted` event is triggered once Opsdroid's loader has completed.
+Skills can respond to this in order to perform startup actions which require connectors, databases, etc. to be available first.
+
 ### `Message`
 
 The `Message` object is the most common event type, it represents textual events, and has the following attributes in addition to the base `Event` attributes.

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -20,6 +20,8 @@ def register_event(event_type, include_subclasses=False):
 
     Args:
         event_type (Event): The event class this method can handle.
+        include_subclasses (bool): Allow the function to trigger on subclasses of the registered
+            event. Defaults to False.
 
     """
 

--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 __all__ = ["Connector", "register_event"]
 
 
-def register_event(event_type):
+def register_event(event_type, include_subclasses=False):
     """
     Register a method to handle a specific `opsdroid.events.Event` object.
 
@@ -28,6 +28,8 @@ def register_event(event_type):
             func.__opsdroid_events__.append(event_type)
         else:
             func.__opsdroid_events__ = [event_type]
+
+        func.__opsdroid_match_subclasses__ = include_subclasses
         return func
 
     return decorator
@@ -68,7 +70,15 @@ class Connector:
                         "not a valid OpsDroid event type"
                     )
                     raise TypeError(err_msg.format(event_type=event_type))
-                cls.events[event_type] = event_method
+
+                if event_method.__opsdroid_match_subclasses__:
+                    # Register all event types which are a subclass of this
+                    # one.
+                    for event in Event.event_registry.values():
+                        if issubclass(event, event_type):
+                            cls.events[event] = event_method
+                else:
+                    cls.events[event_type] = event_method
 
         return super().__new__(cls)
 

--- a/opsdroid/constraints.py
+++ b/opsdroid/constraints.py
@@ -54,9 +54,7 @@ def constrain_connectors(connectors):
 
         def constraint_callback(message, connectors=connectors):
             """Check if the connectors is correct."""
-            print(message.connector.name)
-            print(connectors)
-            return message.connector.name in connectors
+            return message.connector and (message.connector.name in connectors)
 
         func = add_skill_attributes(func)
         func.constraints.append(constraint_callback)

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -308,7 +308,7 @@ class OpsDroid:
 
         if connectors:
             for connector in self.connectors:
-                await asyncio.wait(self.eventloop.create_task(connector.connect()))
+                await self.eventloop.create_task(connector.connect())
 
             for connector in self.connectors:
                 task = self.eventloop.create_task(connector.listen())

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -347,7 +347,7 @@ class OpsDroid:
                     _LOGGER.debug(_("Adding database: %s"), name)
                     database = cls(database_module["config"])
                     self.memory.databases.append(database)
-                    self.eventloop.run_until_complete(database.connect(self))
+                    self.eventloop.run_until_complete(database.connect())
 
     async def run_skill(self, skill, config, message):
         """Execute a skill."""

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -114,15 +114,14 @@ class OpsDroid:
     @staticmethod
     def handle_async_exception(loop, context):
         """Handle exceptions from async coroutines."""
+        print("ERROR: Unhandled exception in opsdroid, exiting...")
         if "future" in context:
             try:  # pragma: nocover
                 context["future"].result()
             # pylint: disable=broad-except
             except Exception:  # pragma: nocover
-                _LOGGER.exception(_("Caught exception"))
-        else:
-            _LOGGER.error(_("Caught exception"))
-        _LOGGER.error(context)
+                print("Caught exception")
+                print(context)
 
     def is_running(self):
         """Check whether opsdroid is running."""
@@ -164,6 +163,8 @@ class OpsDroid:
         self.start_connectors(self.modules["connectors"])
         self.cron_task = self.eventloop.create_task(parse_crontab(self))
         self.eventloop.create_task(self.web_server.start())
+
+        self.eventloop.create_task(self.parse(events.OpsdroidStarted()))
 
     async def unload(self, future=None):
         """Stop the event loop."""
@@ -303,7 +304,7 @@ class OpsDroid:
         if connectors:
             for connector in self.connectors:
                 if self.eventloop.is_running():
-                    self.eventloop.create_task(connector.connect())
+                    asyncio.wait(self.eventloop.create_task(connector.connect()))
                 else:
                     self.eventloop.run_until_complete(connector.connect())
             for connector in self.connectors:
@@ -346,7 +347,7 @@ class OpsDroid:
                     _LOGGER.debug(_("Adding database: %s"), name)
                     database = cls(database_module["config"])
                     self.memory.databases.append(database)
-                    self.eventloop.run_until_complete(database.connect())
+                    self.eventloop.run_until_complete(database.connect(self))
 
     async def run_skill(self, skill, config, message):
         """Execute a skill."""
@@ -360,15 +361,14 @@ class OpsDroid:
             else:
                 await skill(message)
         except Exception:
+            _LOGGER.exception(
+                _("Exception when running skill '%s' "), str(config["name"])
+            )
             if message:
                 await message.respond(
                     events.Message(_("Whoops there has been an error"))
                 )
                 await message.respond(events.Message(_("Check the log for details")))
-
-            _LOGGER.exception(
-                _("Exception when running skill '%s' "), str(config["name"])
-            )
 
     async def get_ranked_skills(self, skills, message):
         """Take a message and return a ranked list of matching skills."""

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -19,15 +19,16 @@ _LOGGER = logging.getLogger(__name__)
 
 class EventCreator:
     """Create opsdroid events from events detected by a connector."""
+
     def __init__(self, connector, dispatch_key="type"):
-        """Initialise the event creator"""
+        """Initialise the event creator."""
         self.connector = connector
         self.dispatch_key = dispatch_key
 
         self.event_types = defaultdict(lambda: self.skip)
 
     async def create_event(self, event, target):
-        """Dispatch any event type"""
+        """Dispatch any event type."""
         return await self.event_types[event[self.dispatch_key]](event, target)
 
     @staticmethod
@@ -158,8 +159,9 @@ class Event(metaclass=EventMetaClass):
         """
         self.entities[name] = {"value": value, "confidence": confidence}
 
+
 class OpsdroidStarted(Event):
-    """An event to indicate that Opsdroid has loaded"""
+    """An event to indicate that Opsdroid has loaded."""
 
 
 class Message(Event):
@@ -198,6 +200,7 @@ class Message(Event):
         self.raw_match = None
 
     def __repr__(self):
+        """Override Message's representation so you can see the text when you print it."""
         return f"<opsdroid.events.Message(text={self.text})>"
 
     async def _thinking_delay(self):
@@ -289,9 +292,16 @@ class Reaction(Event):
 class File(Event):
     """Event class to represent arbitrary files as bytes."""
 
-    def __init__(self, file_bytes=None, url=None, url_headers=None,
-                 name=None, mimetype=None,
-                 *args, **kwargs):  # noqa: D107
+    def __init__(
+        self,
+        file_bytes=None,
+        url=None,
+        url_headers=None,
+        name=None,
+        mimetype=None,
+        *args,
+        **kwargs,
+    ):  # noqa: D107
         if not (file_bytes or url) or (file_bytes and url):
             raise ValueError("Either file_bytes or url must be specified")
 
@@ -308,8 +318,7 @@ class File(Event):
         if not self._file_bytes and self.url:
             async with aiohttp.ClientSession() as session:
                 _LOGGER.debug(self._url_headers)
-                async with session.get(self.url,
-                                       headers=self._url_headers) as resp:
+                async with session.get(self.url, headers=self._url_headers) as resp:
                     self._file_bytes = await resp.read()
 
         return self._file_bytes

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -93,6 +93,7 @@ class Event(metaclass=EventMetaClass):
         raw_event: Raw event provided by chat service
         responded_to: Boolean initialized as False. True if event has been
             responded to
+        entities: Dictionary mapping of entities created by parsers
 
     """
 
@@ -114,6 +115,7 @@ class Event(metaclass=EventMetaClass):
         self.event_id = event_id
         self.raw_event = raw_event
         self.responded_to = False
+        self.entities = {}
 
     async def respond(self, event):
         """Respond to this event with another event.

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -301,6 +301,7 @@ class File(Event):
         self._mimetype = mimetype
         self._file_bytes = file_bytes
         self.url = url
+        self._url_headers = url_headers
 
     async def get_file_bytes(self):
         """Return the bytes representation of this file."""

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -71,7 +71,8 @@ class TestConnectorBaseClass(unittest.TestCase):
             def send_my_event(self, event):
                 pass
 
-        MyConnector({})
+        c = MyConnector({})
+        assert MyEvent in c.events
 
 
 class TestConnectorAsync(asynctest.TestCase):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -73,6 +73,7 @@ class TestConnectorBaseClass(unittest.TestCase):
 
         MyConnector({})
 
+
 class TestConnectorAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid connector base class."""
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -62,6 +62,16 @@ class TestConnectorBaseClass(unittest.TestCase):
         with self.assertRaises(TypeError):
             MyConnector()
 
+    def test_event_subclasses(self):
+        class MyEvent(Message):
+            pass
+
+        class MyConnector(Connector):
+            @register_event(Message, include_subclasses=True)
+            def send_my_event(self, event):
+                pass
+
+        MyConnector({})
 
 class TestConnectorAsync(asynctest.TestCase):
     """Test the async methods of the opsdroid connector base class."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -19,7 +19,7 @@ class TestEventCreator(asynctest.TestCase):
     async def test_create_event(self):
         creator = events.EventCreator(Connector({}))
 
-        self.assertEqual(None, await creator.create_event({'type': "NotAnEvent"}, ""))
+        self.assertEqual(None, await creator.create_event({"type": "NotAnEvent"}, ""))
 
 
 class TestEvent(asynctest.TestCase):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -10,6 +10,18 @@ from opsdroid.connector import Connector
 from opsdroid.__main__ import configure_lang
 
 
+class TestEventCreator(asynctest.TestCase):
+    """Test the opsdroid event creation class"""
+
+    async def setup(self):
+        pass
+
+    async def test_create_event(self):
+        creator = events.EventCreator(Connector({}))
+
+        self.assertEqual(None, await creator.create_event({'type': "NotAnEvent"}, ""))
+
+
 class TestEvent(asynctest.TestCase):
     """Test the opsdroid event class."""
 


### PR DESCRIPTION
# Description

This PR introduces some new and different Event types, in an effort to start branching out from standard message-type events that can be sent _in_ a chat room (`Message`, `Image`, etc) to more meta events that can change properties of rooms (things like setting a room avatar, topic, or permissions).

The general motivation is to be able to use opsdroid for community-management type tasks, creating and editing rooms and inviting users, and so on, as well as simply interacting with users in a small, pre-defined set of rooms.

This PR follows on from (and replaces) #951, which became nebulous and upleasant. Included here are tweaks to the core events functionality and additions of some generic event types. Connector-specific events and changes will follow in separate PRs.

~~Closes- https://github.com/SolarDrew/skill-picard/issues/26.~~
Edit: No it doesn't.

closes #999

## Status
**UNDER DEVELOPMENT**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


# How Has This Been Tested?

Coverage extended to the new functionality, nothing breaks.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

