### PR TITLE
Make load and start_connectors async

### DIFF
--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -68,7 +68,7 @@ def print_example_config(ctx, param, value):
 def edit_files(ctx, param, value):
     """Open config/log file with favourite editor."""
     if value == "config":
-        file = DEFAULT_CONFIG_PATH
+        file = f'"{DEFAULT_CONFIG_PATH}"'
     elif value == "log":
         file = DEFAULT_LOG_FILENAME
     else:
@@ -178,7 +178,6 @@ def main():
     welcome_message(config)
 
     with OpsDroid(config=config) as opsdroid:
-        opsdroid.load()
         opsdroid.run()
 
 

--- a/opsdroid/__main__.py
+++ b/opsdroid/__main__.py
@@ -68,7 +68,7 @@ def print_example_config(ctx, param, value):
 def edit_files(ctx, param, value):
     """Open config/log file with favourite editor."""
     if value == "config":
-        file = f'"{DEFAULT_CONFIG_PATH}"'
+        file = DEFAULT_CONFIG_PATH
     elif value == "log":
         file = DEFAULT_LOG_FILENAME
     else:

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -153,6 +153,7 @@ class OpsDroid:
             _LOGGER.error(_("Oops! Opsdroid is already running."))
 
     def sync_load(self):
+        """Run the load modules method synchronously."""
         self.eventloop.run_until_complete(self.load())
 
     async def load(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,8 +151,6 @@ class TestMain(unittest.TestCase):
         ) as mock_cl, mock.patch.object(
             opsdroid, "welcome_message"
         ) as mock_wm, mock.patch.object(
-            OpsDroid, "load"
-        ) as mock_load, mock.patch.object(
             web, "Web"
         ), mock.patch.object(
             OpsDroid, "run"
@@ -162,5 +160,4 @@ class TestMain(unittest.TestCase):
             self.assertTrue(mock_cd.called)
             self.assertTrue(mock_cl.called)
             self.assertTrue(mock_wm.called)
-            self.assertTrue(mock_load.called)
             self.assertTrue(mock_loop.called)


### PR DESCRIPTION
# Description

Make `opsdroid.OpsDroid.load` and `opsdroid.OpsDroid.start_connectors` async. This makes it easier to block on connector startup from within `start_connectors`.


## Status
**READY** 

