### PR TITLE
Replace third party slack library with official one

### DIFF
--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -4,8 +4,12 @@ A connector for [Slack](https://slack.com/).
 
 ## Requirements
 
- * A Slack account
- * The token from a [custom bot integration](https://my.slack.com/apps/A0F7YS25R-bots)
+* A Slack account
+* The token from a [Slack App bot token](https://api.slack.com/bot-users).
+  * Create a [new Slack App](https://api.slack.com/apps/new) and select the workspace you would like it in.
+  * Navigate to the "Bot Users" section and add a bot giving it a display name and username.
+  * Navigate to the "Install App" section and install the app in your workspace.
+  * Take note of the "Bot User OAuth Access Token" as this will be the `api-token` you need for your configuration.
 
 ## Configuration
 

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -5,9 +5,9 @@ A connector for [Slack](https://slack.com/).
 ## Requirements
 
 * A Slack account
-* The token from a [Slack App bot token](https://api.slack.com/bot-users).
+* A [Slack App bot token](https://api.slack.com/bot-users).
   * Create a [new Slack App](https://api.slack.com/apps/new) and select the workspace you would like it in.
-  * Navigate to the "Bot Users" section and add a bot giving it a display name and username.
+  * Navigate to the "Bot Users" section and add a bot, giving it a display name and username.
   * Navigate to the "Install App" section and install the app in your workspace.
   * Take note of the "Bot User OAuth Access Token" as this will be the `api-token` you need for your configuration.
 

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -35,9 +35,8 @@ class ConnectorSlack(Connector):
         self.listening = True
         self._message_id = 0
 
-        self.process_message = slack.RTMClient.run_on(event="message")(
-            self.process_message
-        )
+        # Register callbacks
+        slack.RTMClient.on(event="message", callback=self.process_message)
 
     async def connect(self):
         """Connect to the chat service."""

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -123,7 +123,7 @@ class ConnectorSlack(Connector):
         _LOGGER.debug("Responding with: '%s' in room  %s", message.text, message.target)
         await self.slack.api_call(
             "chat.postMessage",
-            json={
+            data={
                 "channel": message.target,
                 "text": message.text,
                 "as_user": False,
@@ -138,7 +138,7 @@ class ConnectorSlack(Connector):
         _LOGGER.debug("Responding with interactive blocks in room  %s", blocks.target)
         await self.slack.api_call(
             "chat.postMessage",
-            json={
+            data={
                 "channel": blocks.target,
                 "username": self.bot_name,
                 "blocks": blocks.blocks,
@@ -154,7 +154,7 @@ class ConnectorSlack(Connector):
         try:
             await self.slack.api_call(
                 "reactions.add",
-                json={
+                data={
                     "name": emoji,
                     "channel": reaction.target,
                     "timestamp": reaction.linked_event.raw_event["ts"],

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -1,13 +1,8 @@
 """A connector for Slack."""
 import logging
-import asyncio
-import json
 import re
 
-import aiohttp
-import websockets
-import slacker
-from aioslacker import Slacker
+import slack
 from emoji import demojize
 
 from opsdroid.connector import Connector, register_event
@@ -30,7 +25,8 @@ class ConnectorSlack(Connector):
         self.icon_emoji = config.get("icon-emoji", ":robot_face:")
         self.token = config["api-token"]
         self.timeout = config.get("connect-timeout", 10)
-        self.slacker = Slacker(token=self.token, timeout=self.timeout)
+        self.slack = slack.WebClient(token=self.token, run_async=True)
+        self.slack_rtm = slack.RTMClient(token=self.token, run_async=True)
         self.websocket = None
         self.bot_name = config.get("bot-name", "opsdroid")
         self.known_users = {}
@@ -39,28 +35,26 @@ class ConnectorSlack(Connector):
         self.listening = True
         self._message_id = 0
 
+        self.process_message = slack.RTMClient.run_on(event="message")(
+            self.process_message
+        )
+
     async def connect(self):
         """Connect to the chat service."""
         _LOGGER.info("Connecting to Slack")
 
         try:
-            connection = await self.slacker.rtm.start()
-            self.websocket = await websockets.connect(connection.body["url"])
+            # The slack library recommends you call `self.slack_rtm.start()`` here but it
+            # seems to mess with the event loop's signal handlers which breaks opsdroid.
+            # Therefore we need to directly call the private `_connect_and_read` method
+            # instead. This method also blocks so we need to dispatch it to the loop as a task.
+            self.opsdroid.eventloop.create_task(self.slack_rtm._connect_and_read())
 
             _LOGGER.debug("Connected as %s", self.bot_name)
             _LOGGER.debug("Using icon %s", self.icon_emoji)
             _LOGGER.debug("Default room is %s", self.default_target)
             _LOGGER.info("Connected successfully")
-
-            if self.keepalive is None or self.keepalive.done():
-                self.keepalive = self.opsdroid.eventloop.create_task(
-                    self.keepalive_websocket()
-                )
-        except aiohttp.ClientOSError as error:
-            _LOGGER.error(error)
-            _LOGGER.error("Failed to connect to Slack, retrying in 10")
-            await self.reconnect(10)
-        except slacker.Error as error:
+        except slack.errors.SlackApiError as error:
             _LOGGER.error(
                 "Unable to connect to Slack due to %s - "
                 "The Slack Connector will not be available.",
@@ -70,85 +64,65 @@ class ConnectorSlack(Connector):
             await self.disconnect()
             raise
 
-    async def reconnect(self, delay=None):
-        """Reconnect to the websocket."""
-        try:
-            self.reconnecting = True
-            if delay is not None:
-                await asyncio.sleep(delay)
-            await self.connect()
-        finally:
-            self.reconnecting = False
-
     async def disconnect(self):
         """Disconnect from Slack."""
-        await self.slacker.close()
+        self.listening = False
+        await self.slack_rtm.stop()
 
     async def listen(self):
         """Listen for and parse new messages."""
-        while self.listening:
-            try:
-                await self.receive_from_websocket()
-            except AttributeError:
-                break
 
-    async def receive_from_websocket(self):
-        """Get the next message from the websocket."""
-        try:
-            content = await self.websocket.recv()
-            await self.process_message(json.loads(content))
-        except websockets.exceptions.ConnectionClosed:
-            _LOGGER.info("Slack websocket closed, reconnecting...")
-            await self.reconnect(5)
-
-    async def process_message(self, message):
+    async def process_message(self, **payload):
         """Process a raw message and pass it to the parser."""
-        if "type" in message and message["type"] == "message" and "user" in message:
+        message = payload["data"]
 
-            # Ignore bot messages
-            if "subtype" in message and message["subtype"] == "bot_message":
-                return
+        # Ignore own messages
+        if "bot_id" in message and message["username"] == self.bot_name:
+            return
 
-            # Lookup username
-            _LOGGER.debug("Looking up sender username")
-            try:
-                user_info = await self.lookup_username(message["user"])
-            except ValueError:
-                return
+        # Lookup username
+        _LOGGER.debug("Looking up sender username")
+        try:
+            user_info = await self.lookup_username(message["user"])
+        except ValueError:
+            return
 
-            # Replace usernames in the message
-            _LOGGER.debug("Replacing userids in message with usernames")
-            message["text"] = await self.replace_usernames(message["text"])
+        # Replace usernames in the message
+        _LOGGER.debug("Replacing userids in message with usernames")
+        message["text"] = await self.replace_usernames(message["text"])
 
-            await self.opsdroid.parse(
-                Message(
-                    message["text"],
-                    user_info["name"],
-                    message["channel"],
-                    self,
-                    raw_event=message,
-                )
+        await self.opsdroid.parse(
+            Message(
+                message["text"],
+                user_info["name"],
+                message["channel"],
+                self,
+                raw_event=message,
             )
+        )
 
     @register_event(Message)
     async def send_message(self, message):
         """Respond with a message."""
         _LOGGER.debug("Responding with: '%s' in room  %s", message.text, message.target)
-        await self.slacker.chat.post_message(
-            message.target,
-            message.text,
-            as_user=False,
-            username=self.bot_name,
-            icon_emoji=self.icon_emoji,
+        await self.slack.api_call(
+            "chat.postMessage",
+            json={
+                "channel": message.target,
+                "text": message.text,
+                "as_user": False,
+                "username": self.bot_name,
+                "icon_emoji": self.icon_emoji,
+            },
         )
 
     @register_event(Blocks)
     async def send_blocks(self, blocks):
         """Respond with structured blocks."""
         _LOGGER.debug("Responding with interactive blocks in room  %s", blocks.target)
-        await self.slacker.chat.post(
+        await self.slack.api_call(
             "chat.postMessage",
-            data={
+            json={
                 "channel": blocks.target,
                 "username": self.bot_name,
                 "blocks": blocks.blocks,
@@ -162,50 +136,27 @@ class ConnectorSlack(Connector):
         emoji = demojize(reaction.emoji).replace(":", "")
         _LOGGER.debug("Reacting with: %s", emoji)
         try:
-            await self.slacker.reactions.post(
+            await self.slack.api_call(
                 "reactions.add",
-                data={
+                json={
                     "name": emoji,
                     "channel": reaction.target,
                     "timestamp": reaction.linked_event.raw_event["ts"],
                 },
             )
-        except slacker.Error as error:
-            if str(error) == "invalid_name":
+        except slack.errors.SlackApiError as error:
+            if "invalid_name" in str(error):
                 _LOGGER.warning("Slack does not support the emoji %s", emoji)
             else:
                 raise
-
-    async def keepalive_websocket(self):
-        """Keep pinging the websocket to keep it alive."""
-        while self.listening:
-            await self.ping_websocket()
-
-    async def ping_websocket(self):
-        """Ping the websocket."""
-        await asyncio.sleep(60)
-        self._message_id += 1
-        try:
-            await self.websocket.send(
-                json.dumps({"id": self._message_id, "type": "ping"})
-            )
-        except (
-            websockets.exceptions.InvalidState,
-            websockets.exceptions.ConnectionClosed,
-            aiohttp.ClientOSError,
-            TimeoutError,
-        ):
-            _LOGGER.info("Slack websocket closed, reconnecting...")
-            if not self.reconnecting:
-                await self.reconnect()
 
     async def lookup_username(self, userid):
         """Lookup a username and cache it."""
         if userid in self.known_users:
             user_info = self.known_users[userid]
         else:
-            response = await self.slacker.users.info(userid)
-            user_info = response.body["user"]
+            response = await self.slack.users_info(user=userid)
+            user_info = response.data["user"]
             if isinstance(user_info, dict):
                 self.known_users[userid] = user_info
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiohttp==3.6.1
 aioredis==1.3.0
-aioslacker==0.0.11
 aiosqlite==0.10.0
 appdirs==1.4.3
 arrow==0.15.2
@@ -19,6 +18,7 @@ puremagic==1.5
 pycron==1.0.0
 pyyaml==5.1.2
 setuptools==41.2.0
+slackclient==2.2.0
 websockets==8.0.2
-yamale==2.0.1
 webexteamssdk==1.2
+yamale==2.0.1

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -185,7 +185,7 @@ class TestConnectorSlackAsync(asynctest.TestCase):
             await prev_message.respond(Reaction("😀"))
         self.assertTrue(connector.slack.api_call)
         self.assertEqual(
-            connector.slack.api_call.call_args[1]["json"]["name"], "grinning_face"
+            connector.slack.api_call.call_args[1]["data"]["name"], "grinning_face"
         )
 
     async def test_react_invalid_name(self):

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -67,8 +67,10 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         opsdroid = amock.CoroutineMock()
         opsdroid.eventloop = self.loop
         connector.slack_rtm._connect_and_read = amock.CoroutineMock()
+        connector.slack.api_call = amock.CoroutineMock()
         await connector.connect()
         self.assertTrue(connector.slack_rtm._connect_and_read.called)
+        self.assertTrue(connector.slack.api_call.called)
 
     async def test_connect_auth_fail(self):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
@@ -119,11 +121,13 @@ class TestConnectorSlackAsync(asynctest.TestCase):
 
         connector.opsdroid.parse.reset_mock()
         message["bot_id"] = "abc"
-        message["username"] = "opsdroid"
+        message["subtype"] = "bot_message"
+        connector.bot_id = message["bot_id"]
         await connector.process_message(data=message)
         self.assertFalse(connector.opsdroid.parse.called)
         del message["bot_id"]
-        del message["username"]
+        del message["subtype"]
+        connector.bot_id = None
 
         connector.opsdroid.parse.reset_mock()
         connector.lookup_username.side_effect = ValueError

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -5,7 +5,7 @@ import unittest
 import unittest.mock as mock
 import asynctest
 import asynctest.mock as amock
-import slacker
+import slack
 
 from opsdroid.core import OpsDroid
 from opsdroid.connector.slack import ConnectorSlack
@@ -66,84 +66,37 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
         opsdroid = amock.CoroutineMock()
         opsdroid.eventloop = self.loop
-        connector.slacker.rtm.start = amock.CoroutineMock()
-        connector.keepalive_websocket = amock.CoroutineMock()
-        with amock.patch(
-            "websockets.connect", new=amock.CoroutineMock()
-        ) as mocked_websocket_connect:
-            await connector.connect()
-        self.assertTrue(connector.slacker.rtm.start.called)
-        self.assertTrue(mocked_websocket_connect.called)
-        self.assertTrue(connector.keepalive_websocket.called)
+        connector.slack_rtm._connect_and_read = amock.CoroutineMock()
+        await connector.connect()
+        self.assertTrue(connector.slack_rtm._connect_and_read.called)
 
     async def test_connect_auth_fail(self):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
         opsdroid = amock.CoroutineMock()
         opsdroid.eventloop = self.loop
-        connector.slacker.rtm.start = amock.CoroutineMock()
-        connector.slacker.rtm.start.side_effect = slacker.Error()
+        connector.slack_rtm._connect_and_read = amock.Mock()
+        connector.slack_rtm._connect_and_read.side_effect = slack.errors.SlackApiError(
+            message="", response=""
+        )
 
         await connector.connect()
         self.assertLogs("_LOGGER", "error")
 
-    async def test_reconnect_on_error(self):
-        import aiohttp
-
-        connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.slacker.rtm.start = amock.CoroutineMock()
-        connector.slacker.rtm.start.side_effect = aiohttp.ClientOSError()
-        connector.reconnect = amock.CoroutineMock()
-
-        await connector.connect()
-        self.assertTrue(connector.reconnect.called)
-
     async def test_abort_on_connection_error(self):
         connector = ConnectorSlack({"api-token": "abc123"})
-        connector.slacker.rtm.start = amock.CoroutineMock()
-        connector.slacker.rtm.start.side_effect = Exception()
-        connector.slacker.close = amock.CoroutineMock()
+        connector.slack_rtm._connect_and_read = amock.CoroutineMock()
+        connector.slack_rtm._connect_and_read.side_effect = Exception()
+        connector.slack_rtm.stop = amock.CoroutineMock()
 
         with self.assertRaises(Exception):
             await connector.connect()
-        self.assertTrue(connector.slacker.close.called)
+        self.assertTrue(connector.slack_rtm.stop.called)
 
     async def test_listen_loop(self):
         """Test that listening consumes from the socket."""
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.receive_from_websocket = amock.CoroutineMock()
-        connector.receive_from_websocket.side_effect = Exception()
-        with self.assertRaises(Exception):
-            await connector.listen()
-        self.assertTrue(connector.receive_from_websocket.called)
-
-    async def test_listen_break_loop(self):
-        """Test that listening consumes from the socket."""
-        connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.receive_from_websocket = amock.CoroutineMock()
-        connector.receive_from_websocket.side_effect = AttributeError
+        connector.listening = False
         await connector.listen()
-        self.assertTrue(connector.receive_from_websocket.called)
-
-    async def test_receive_from_websocket(self):
-        """Test receive_from_websocket receives and reconnects."""
-        import websockets
-
-        connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-
-        connector.websocket = amock.CoroutineMock()
-        connector.websocket.recv = amock.CoroutineMock()
-        connector.websocket.recv.return_value = "[]"
-        connector.process_message = amock.CoroutineMock()
-        await connector.receive_from_websocket()
-        self.assertTrue(connector.websocket.recv.called)
-        self.assertTrue(connector.process_message.called)
-
-        connector.websocket.recv.side_effect = websockets.exceptions.ConnectionClosed(
-            500, "Mock Error"
-        )
-        connector.reconnect = amock.CoroutineMock()
-        await connector.receive_from_websocket()
-        self.assertTrue(connector.reconnect.called)
 
     async def test_process_message(self):
         """Test processing a slack message."""
@@ -161,81 +114,55 @@ class TestConnectorSlackAsync(asynctest.TestCase):
             "ts": "1355517523.000005",
             "edited": {"user": "U2147483697", "ts": "1355517536.000001"},
         }
-        await connector.process_message(message)
+        await connector.process_message(data=message)
         self.assertTrue(connector.opsdroid.parse.called)
 
         connector.opsdroid.parse.reset_mock()
-        message["subtype"] = "bot_message"
-        await connector.process_message(message)
+        message["bot_id"] = "abc"
+        message["username"] = "opsdroid"
+        await connector.process_message(data=message)
         self.assertFalse(connector.opsdroid.parse.called)
-        del message["subtype"]
+        del message["bot_id"]
+        del message["username"]
 
         connector.opsdroid.parse.reset_mock()
         connector.lookup_username.side_effect = ValueError
-        await connector.process_message(message)
+        await connector.process_message(data=message)
         self.assertFalse(connector.opsdroid.parse.called)
-
-    async def test_keepalive_websocket_loop(self):
-        """Test that listening consumes from the socket."""
-        connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.ping_websocket = amock.CoroutineMock()
-        connector.ping_websocket.side_effect = Exception()
-        with self.assertRaises(Exception):
-            await connector.keepalive_websocket()
-        self.assertTrue(connector.ping_websocket.called)
-
-    async def test_ping_websocket(self):
-        """Test pinging the websocket."""
-        import websockets
-
-        connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        with amock.patch("asyncio.sleep", new=amock.CoroutineMock()) as mocked_sleep:
-            connector.websocket = amock.CoroutineMock()
-            connector.websocket.send = amock.CoroutineMock()
-            await connector.ping_websocket()
-            self.assertTrue(mocked_sleep.called)
-            self.assertTrue(connector.websocket.send.called)
-
-            connector.reconnect = amock.CoroutineMock()
-            connector.websocket.send.side_effect = websockets.exceptions.ConnectionClosed(
-                500, "Mock Error"
-            )
-            await connector.ping_websocket()
-            self.assertTrue(connector.reconnect.called)
 
     async def test_lookup_username(self):
         """Test that looking up a username works and that it caches."""
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.slacker.users.info = amock.CoroutineMock()
+        connector.slack.users_info = amock.CoroutineMock()
         mock_user = mock.Mock()
-        mock_user.body = {"user": {"name": "testuser"}}
-        connector.slacker.users.info.return_value = mock_user
+        mock_user.data = {"user": {"name": "testuser"}}
+        connector.slack.users_info.return_value = mock_user
 
         self.assertEqual(len(connector.known_users), 0)
 
         await connector.lookup_username("testuser")
         self.assertTrue(len(connector.known_users), 1)
-        self.assertTrue(connector.slacker.users.info.called)
+        self.assertTrue(connector.slack.users_info.called)
 
-        connector.slacker.users.info.reset_mock()
+        connector.slack.users_info.reset_mock()
         await connector.lookup_username("testuser")
         self.assertEqual(len(connector.known_users), 1)
-        self.assertFalse(connector.slacker.users.info.called)
+        self.assertFalse(connector.slack.users_info.called)
 
         with self.assertRaises(ValueError):
-            mock_user.body = {"user": None}
-            connector.slacker.users.info.return_value = mock_user
+            mock_user.data = {"user": None}
+            connector.slack.users_info.return_value = mock_user
             await connector.lookup_username("invaliduser")
 
     async def test_respond(self):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.slacker.chat.post_message = amock.CoroutineMock()
+        connector.slack.api_call = amock.CoroutineMock()
         await connector.send(Message("test", "user", "room", connector))
-        self.assertTrue(connector.slacker.chat.post_message.called)
+        self.assertTrue(connector.slack.api_call.called)
 
     async def test_send_blocks(self):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.slacker.chat.post = amock.CoroutineMock()
+        connector.slack.api_call = amock.CoroutineMock()
         await connector.send(
             Blocks(
                 [{"type": "section", "text": {"type": "mrkdwn", "text": "*Test*"}}],
@@ -244,26 +171,25 @@ class TestConnectorSlackAsync(asynctest.TestCase):
                 connector,
             )
         )
-        self.assertTrue(connector.slacker.chat.post.called)
+        self.assertTrue(connector.slack.api_call.called)
 
     async def test_react(self):
         connector = ConnectorSlack({"api-token": "abc123"})
-        connector.slacker.reactions.post = amock.CoroutineMock()
+        connector.slack.api_call = amock.CoroutineMock()
         prev_message = Message("test", "user", "room", connector, raw_event={"ts": 0})
         with OpsDroid() as opsdroid:
             await prev_message.respond(Reaction("😀"))
-        self.assertTrue(connector.slacker.reactions.post)
+        self.assertTrue(connector.slack.api_call)
         self.assertEqual(
-            connector.slacker.reactions.post.call_args[1]["data"]["name"],
-            "grinning_face",
+            connector.slack.api_call.call_args[1]["json"]["name"], "grinning_face"
         )
 
     async def test_react_invalid_name(self):
-        import slacker
+        import slack
 
         connector = ConnectorSlack({"api-token": "abc123"})
-        connector.slacker.reactions.post = amock.CoroutineMock(
-            side_effect=slacker.Error("invalid_name")
+        connector.slack.api_call = amock.CoroutineMock(
+            side_effect=slack.errors.SlackApiError("invalid_name", "invalid_name")
         )
         prev_message = Message("test", "user", "room", connector, raw_event={"ts": 0})
         with OpsDroid() as opsdroid:
@@ -271,25 +197,17 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         self.assertLogs("_LOGGER", "warning")
 
     async def test_react_unknown_error(self):
-        import slacker
+        import slack
 
         connector = ConnectorSlack({"api-token": "abc123"})
-        connector.slacker.reactions.post = amock.CoroutineMock(
-            side_effect=slacker.Error("unknown")
+        connector.slack.api_call = amock.CoroutineMock(
+            side_effect=slack.errors.SlackApiError("unknown", "unknown")
         )
-        with self.assertRaises(slacker.Error), OpsDroid() as opsdroid:
+        with self.assertRaises(slack.errors.SlackApiError), OpsDroid() as opsdroid:
             prev_message = Message(
                 "test", "user", "room", connector, raw_event={"ts": 0}
             )
             await prev_message.respond(Reaction("😀"))
-
-    async def test_reconnect(self):
-        connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
-        connector.connect = amock.CoroutineMock()
-        with amock.patch("asyncio.sleep") as mocked_sleep:
-            await connector.reconnect(10)
-            self.assertTrue(connector.connect.called)
-            self.assertTrue(mocked_sleep.called)
 
     async def test_replace_usernames(self):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())


### PR DESCRIPTION
# Description

Swapped out the third party slack library we were using for the [official one](https://github.com/slackapi/python-slackclient) now that it supports async. Users shouldn't notice a difference as these are under the hood changes.

Closes #1036 

**Also**
Closes #845 as it is likely no longer valid for this library
Closes #743 as the new library shouldn't have the memory leak (though it may have its own issues)
Closes #1000 as documentation has been updated with bot user instructions

This does not add support for the webhook based events API as the official library [does not support it](https://github.com/slackapi/python-slackclient#basic-usage-of-the-rtm-client). There is a [second official library](https://github.com/slackapi/python-slack-events-api) which does, however it assumes you are using Flask for your web server which we are not. We should make a separate issue for adding this support ourselves.