### PR TITLE
Remove Deprecation warning message

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -260,13 +260,6 @@ class OpsDroid:
         with contextlib.suppress(AttributeError):
             for skill in skills:
                 skill["module"].setup(self, self.config)
-                _LOGGER.warning(
-                    _(
-                        "<skill module>.setup() is deprecated and "
-                        "will be removed in a future release. "
-                        "Please use class-based skills instead."
-                    )
-                )
 
     async def train_parsers(self, skills):
         """Train the parsers."""

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -254,14 +254,6 @@ class OpsDroid:
                     continue
 
                 if hasattr(func, "skill"):
-                    _LOGGER.warning(
-                        _(
-                            "Function based skills are deprecated "
-                            "and will be removed in a future "
-                            "release. Please use class-based skills "
-                            "instead."
-                        )
-                    )
                     func.config = skill["config"]
                     self.skills.append(func)
 


### PR DESCRIPTION
# Description

Removed Deprecation warning for function based skills

Fixes #1093
Removed the following warning messages:

def setup_skills(self, skills):
                          : 
                    _LOGGER.warning(
                        _(
                            "Function based skills are deprecated "
                            "and will be removed in a future "
                            "release. Please use class-based skills "
                            "instead."
                        )
                    )

                _LOGGER.warning(
                    _(
                        "<skill module>.setup() is deprecated and "
                        "will be removed in a future release. "
                        "Please use class-based skills instead."
                    )
                )

## Status
**READY** | **UNDER DEVELOPMENT** | **ON HOLD**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Test A
- Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

