### PR TITLE
Await the OpsDroid.load coroutine

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -219,7 +219,7 @@ class OpsDroid:
                 "/etc/opsdroid/configuration.yaml",
             ]
         )
-        self.load()
+        await self.load()
 
     def setup_skills(self, skills):
         """Call the setup function on the loaded skills.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -260,7 +260,7 @@ class TestCoreAsync(asynctest.TestCase):
 
     async def test_reload(self):
         with OpsDroid() as opsdroid:
-            opsdroid.load = mock.Mock()
+            opsdroid.load = amock.CoroutineMock()
             opsdroid.unload = amock.CoroutineMock()
             await opsdroid.reload()
             self.assertTrue(opsdroid.load.called)


### PR DESCRIPTION
# Description

When running the [devtools](https://github.com/opsdroid/skill-devtools) skill using class-based functions it throws this runtime error:

`RuntimeWarning: coroutine 'OpsDroid.load' was never awaited`

when you call the `self.opsdroid.reload()` method i.e.

```
class DevTools(Skill):
    @match_regex(r"reload")
    async def reload(self, message):
        await message.respond("Reloading the skills")
        await self.opsdroid.reload() # this throws the error
```


## Status
**READY**

## Type of change

- Bugfix

# How Has This Been Tested?

Using the current version, when you create a class-based skill(as shown above) and call the `self.opsdroid.reload()` method, the runtime error occurs.

With this minor fix, the skills are reloaded successfully.


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

