### PR TITLE
Update pyyalm envvar test and remove test skip

### DIFF
--- a/tests/configs/minimal_with_envs.yaml
+++ b/tests/configs/minimal_with_envs.yaml
@@ -1,6 +1,7 @@
 
 connectors:
-  - name: $ENVVAR
+  - name: shell
+    bot-name: $ENVVAR
 
 skills:
   - name: hello

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -132,14 +132,13 @@ class TestLoader(unittest.TestCase):
             # If the command in exploit.yaml is echoed it will return 0
             self.assertNotEqual(config, 0)
 
-    @unittest.skip("old config type fails validation #770")
     def test_load_config_file_with_env_vars(self):
         opsdroid, loader = self.setup()
-        os.environ["ENVVAR"] = "shell"
+        os.environ["ENVVAR"] = "opsdroid"
         config = loader.load_config_file(
             [os.path.abspath("tests/configs/minimal_with_envs.yaml")]
         )
-        self.assertEqual(config["connectors"][0]["name"], os.environ["ENVVAR"])
+        self.assertEqual(config["connectors"][0]["bot-name"], os.environ["ENVVAR"])
 
     def test_create_default_config(self):
         test_config_path = os.path.join(


### PR DESCRIPTION
# Description

Whilst working on the codecov issue, I have noticed that the coverage was down a little bit so I decided to investigate and noticed that when #1003 was merged, for some reason the envvar and include tests got decorated with `@unittest.skip("old config type fails validation #770")`

With this PR I fix the failing test and still check for envvar and hopefully bump the coverage up.

Since these tests were being skipped, one of the updates to pyyaml broke the include constructor as well. I will try to fix the include constructor and hopefully get this one working again.

Fixes #<issue>


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

