### PR TITLE
Fix !include tag loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ ENV/
 .docker/
 
 .vscode/
+.mypy_cache
 .devcontainer/
 .idea/
 site/

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -352,7 +352,7 @@ class Loader:
             included_yaml = os.path.join(main_yaml_path, loader.construct_scalar(node))
 
             with open(included_yaml, "r") as included:
-                return yaml.safe_load(included)
+                return yaml.load(stream, Loader=yaml.SafeLoader)
 
         yaml.SafeLoader.add_constructor("!envvar", envvar_constructor)
         yaml.SafeLoader.add_constructor("!include", include_constructor)
@@ -364,7 +364,7 @@ class Loader:
                 schema = yamale.make_schema(schema_path)
                 data = yamale.make_data(config_path)
                 yamale.validate(schema, data)
-                return yaml.safe_load(stream)
+                return yaml.load(stream, Loader=yaml.SafeLoader)
 
         except ValueError as error:
             _LOGGER.critical(error)

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -43,6 +43,11 @@ _LOGGER = logging.getLogger(__name__)
 class Loader:
     """Class to load in config and modules."""
 
+    try:
+        loader = yaml.CSafeLoader
+    except AttributeError:
+        loader = yaml.SafeLoader
+
     def __init__(self, opsdroid):
         """Create object with opsdroid instance."""
         self.opsdroid = opsdroid
@@ -338,7 +343,7 @@ class Loader:
             config_path = cls.create_default_config(DEFAULT_CONFIG_PATH)
 
         env_var_pattern = re.compile(r"^\$([A-Z_]*)$")
-        yaml.SafeLoader.add_implicit_resolver("!envvar", env_var_pattern, first="$")
+        cls.loader.add_implicit_resolver("!envvar", env_var_pattern, first="$")
 
         def envvar_constructor(loader, node):
             """Yaml parser for env vars."""
@@ -352,11 +357,10 @@ class Loader:
             included_yaml = os.path.join(main_yaml_path, loader.construct_scalar(node))
 
             with open(included_yaml, "r") as included:
-                return yaml.load(stream, Loader=yaml.SafeLoader)
+                return yaml.load(stream, Loader=cls.loader)
 
-        yaml.SafeLoader.add_constructor("!envvar", envvar_constructor)
-        yaml.SafeLoader.add_constructor("!include", include_constructor)
-
+        cls.loader.add_constructor("!envvar", envvar_constructor)
+        cls.loader.add_constructor("!include", include_constructor)
         try:
             with open(config_path, "r") as stream:
                 _LOGGER.info(_("Loaded config from %s."), config_path)
@@ -364,7 +368,7 @@ class Loader:
                 schema = yamale.make_schema(schema_path)
                 data = yamale.make_data(config_path)
                 yamale.validate(schema, data)
-                return yaml.load(stream, Loader=yaml.SafeLoader)
+                return yaml.load(stream, Loader=cls.loader)
 
         except ValueError as error:
             _LOGGER.critical(error)

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -44,9 +44,9 @@ class Loader:
     """Class to load in config and modules."""
 
     try:
-        loader = yaml.CSafeLoader
+        yaml_loader = yaml.CSafeLoader
     except AttributeError:
-        loader = yaml.SafeLoader
+        yaml_loader = yaml.SafeLoader
 
     def __init__(self, opsdroid):
         """Create object with opsdroid instance."""
@@ -343,7 +343,7 @@ class Loader:
             config_path = cls.create_default_config(DEFAULT_CONFIG_PATH)
 
         env_var_pattern = re.compile(r"^\$([A-Z_]*)$")
-        cls.loader.add_implicit_resolver("!envvar", env_var_pattern, first="$")
+        cls.yaml_loader.add_implicit_resolver("!envvar", env_var_pattern, first="$")
 
         def envvar_constructor(loader, node):
             """Yaml parser for env vars."""
@@ -357,10 +357,10 @@ class Loader:
             included_yaml = os.path.join(main_yaml_path, loader.construct_scalar(node))
 
             with open(included_yaml, "r") as included:
-                return yaml.load(stream, Loader=cls.loader)
+                return yaml.load(included, Loader=cls.yaml_loader)
 
-        cls.loader.add_constructor("!envvar", envvar_constructor)
-        cls.loader.add_constructor("!include", include_constructor)
+        cls.yaml_loader.add_constructor("!envvar", envvar_constructor)
+        cls.yaml_loader.add_constructor("!include", include_constructor)
         try:
             with open(config_path, "r") as stream:
                 _LOGGER.info(_("Loaded config from %s."), config_path)
@@ -368,7 +368,7 @@ class Loader:
                 schema = yamale.make_schema(schema_path)
                 data = yamale.make_data(config_path)
                 yamale.validate(schema, data)
-                return yaml.load(stream, Loader=cls.loader)
+                return yaml.load(stream, Loader=cls.yaml_loader)
 
         except ValueError as error:
             _LOGGER.critical(error)

--- a/tests/configs/minimal_with_envs.yaml
+++ b/tests/configs/minimal_with_envs.yaml
@@ -1,6 +1,7 @@
 
 connectors:
-  - name: $ENVVAR
+  - name: shell
+    bot-name: $ENVVAR
 
 skills:
   - name: hello

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -132,14 +132,13 @@ class TestLoader(unittest.TestCase):
             # If the command in exploit.yaml is echoed it will return 0
             self.assertNotEqual(config, 0)
 
-    @unittest.skip("old config type fails validation #770")
     def test_load_config_file_with_env_vars(self):
         opsdroid, loader = self.setup()
-        os.environ["ENVVAR"] = "shell"
+        os.environ["ENVVAR"] = "opsdroid"
         config = loader.load_config_file(
             [os.path.abspath("tests/configs/minimal_with_envs.yaml")]
         )
-        self.assertEqual(config["connectors"][0]["name"], os.environ["ENVVAR"])
+        self.assertEqual(config["connectors"][0]["bot-name"], os.environ["ENVVAR"])
 
     def test_create_default_config(self):
         test_config_path = os.path.join(

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -111,7 +111,6 @@ class TestLoader(unittest.TestCase):
             self.assertRaises(YAMLError)
             unittest.main(exit=False)
 
-    @unittest.skip("old config type fails validation #770")
     def test_load_config_file_with_include(self):
         opsdroid, loader = self.setup()
         config = loader.load_config_file(


### PR DESCRIPTION
# Description

This issue is the same as by yaml/pyyaml#266.
To fix this all is needed is to replace `yaml.safe_load` with `yaml.oad(Loader=yaml.SafeLoader)`

Fixes #1113 


## Status
**READY**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

From running the configuration yaml file is loaded fine.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

