### PR TITLE
Adding user id Parmeter in Event class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,7 @@ repos:
     hooks:
       - id: black
         language_version: python3.6
-
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,4 @@ repos:
     hooks:
       - id: black
         language_version: python3.6
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-      - id: flake8
+

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -81,7 +81,11 @@ class ConnectorGitHub(Connector):
                 issue_number,
             )
             message = Message(
-                body, payload["sender"]["login"], issue, self, raw_event=payload
+                text=body,
+                user=payload["sender"]["login"],
+                target=issue,
+                connector=self,
+                raw_event=payload,
             )
             await self.opsdroid.parse(message)
         except KeyError as error:

--- a/opsdroid/connector/gitter/__init__.py
+++ b/opsdroid/connector/gitter/__init__.py
@@ -79,7 +79,10 @@ class ConnectorGitter(Connector):
             _LOGGER.debug(message)
             try:
                 return Message(
-                    message["text"], message["fromUser"]["username"], self.room_id, self
+                    text=message["text"],
+                    user=message["fromUser"]["username"],
+                    target=self.room_id,
+                    connector=self,
                 )
             except KeyError as err:
                 _LOGGER.error("Unable to parse message %s", err)

--- a/opsdroid/connector/matrix/create_events.py
+++ b/opsdroid/connector/matrix/create_events.py
@@ -48,6 +48,7 @@ class MatrixEventCreator:
         """Send a Message event."""
         return events.Message(
             text=event["content"]["body"],
+            user_id=event["sender"],
             user=await self.connector.get_nick(roomid, event["sender"]),
             target=roomid,
             connector=self.connector,
@@ -60,6 +61,7 @@ class MatrixEventCreator:
         return dict(
             url=url,
             name=event["content"]["body"],
+            user_id=event["sender"],
             user=await self.connector.get_nick(roomid, event["sender"]),
             target=roomid,
             connector=self.connector,

--- a/opsdroid/connector/matrix/create_events.py
+++ b/opsdroid/connector/matrix/create_events.py
@@ -47,10 +47,10 @@ class MatrixEventCreator:
     async def create_message(self, event, roomid):
         """Send a Message event."""
         return events.Message(
-            event["content"]["body"],
-            await self.connector.get_nick(roomid, event["sender"]),
-            roomid,
-            self.connector,
+            text=event["content"]["body"],
+            user=await self.connector.get_nick(roomid, event["sender"]),
+            target=roomid,
+            connector=self.connector,
             event_id=event["event_id"],
             raw_event=event,
         )

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -94,10 +94,10 @@ class RocketChat(Connector):
         """
         if response["messages"]:
             message = Message(
-                response["messages"][0]["msg"],
-                response["messages"][0]["u"]["username"],
-                response["messages"][0]["rid"],
-                self,
+                text=response["messages"][0]["msg"],
+                user=response["messages"][0]["u"]["username"],
+                target=response["messages"][0]["rid"],
+                connector=self,
             )
             _LOGGER.debug(
                 "Received message from Rocket.Chat %s", response["messages"][0]["msg"]

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -97,6 +97,7 @@ class RocketChat(Connector):
         if response["messages"]:
             message = Message(
                 text=response["messages"][0]["msg"],
+                user_id=response["messages"][0]["u"]["_id"],
                 user=response["messages"][0]["u"]["username"],
                 target=response["messages"][0]["rid"],
                 connector=self,

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -109,10 +109,10 @@ class ConnectorSlack(Connector):
 
         await self.opsdroid.parse(
             Message(
-                message["text"],
-                user_info["name"],
-                message["channel"],
-                self,
+                text=message["text"],
+                user=user_info["name"],
+                target=message["channel"],
+                connector=self,
                 raw_event=message,
             )
         )

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -59,13 +59,16 @@ class ConnectorTelegram(Connector):
 
         """
         user = None
+        user_id = None
+
         if "username" in response["message"]["from"]:
             user = response["message"]["from"]["username"]
 
         elif "first_name" in response["message"]["from"]:
             user = response["message"]["from"]["first_name"]
+        user_id = response["message"]["from"]["id"]
 
-        return user
+        return user, user_id
 
     def handle_user_permission(self, response, user):
         """Handle user permissions.
@@ -162,10 +165,11 @@ class ConnectorTelegram(Connector):
                     _("Channel message parsing not supported " "- Ignoring message")
                 )
             elif "message" in result and "text" in result["message"]:
-                user = self.get_user(result)
+                user, user_id = self.get_user(result)
                 message = Message(
                     text=result["message"]["text"],
                     user=user,
+                    user_id=user_id,
                     target=result["message"]["chat"],
                     connector=self,
                 )

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -162,7 +162,10 @@ class ConnectorTelegram(Connector):
             elif "message" in result and "text" in result["message"]:
                 user = self.get_user(result)
                 message = Message(
-                    result["message"]["text"], user, result["message"]["chat"], self
+                    text=result["message"]["text"],
+                    user=user,
+                    target=result["message"]["chat"],
+                    connector=self,
                 )
 
                 if self.handle_user_permission(result, user):

--- a/opsdroid/connector/webexteams/__init__.py
+++ b/opsdroid/connector/webexteams/__init__.py
@@ -56,10 +56,10 @@ class ConnectorWebexTeams(Connector):
 
             try:
                 message = Message(
-                    msg.text,
-                    person.displayName,
-                    {"id": msg.roomId, "type": msg.roomType},
-                    self,
+                    text=msg.text,
+                    user=person.displayName,
+                    target={"id": msg.roomId, "type": msg.roomType},
+                    connector=self,
                 )
                 await self.opsdroid.parse(message)
             except KeyError as error:

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -136,7 +136,8 @@ class Event(metaclass=EventMetaClass):
 
         # Inherit the user, target and event from the event we are responding
         # to if they are not explicitly provided by this Event
-        event.user_id = event.user_id or self.user_id
+        event.user = event.user or self.user
+        event.user_id = event.user_id or self.user_id or event.user
         event.user = event.user or self.user
         event.target = event.target or self.target
         event.connector = event.connector or self.connector

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -73,6 +73,7 @@ class Event(metaclass=EventMetaClass):
     creation.
 
     Args:
+        user_id (string, optional): String id of user sending message
         user (string, optional): String name of user sending message
         room (string, optional): String name of the room or chat channel in
                                  which message was sent
@@ -100,6 +101,7 @@ class Event(metaclass=EventMetaClass):
 
     def __init__(
         self,
+        user_id=None,
         user=None,
         target=None,
         connector=None,
@@ -107,6 +109,7 @@ class Event(metaclass=EventMetaClass):
         event_id=None,
         linked_event=None,
     ):  # noqa: D107
+        self.user_id = user_id
         self.user = user
         self.target = target
         self.connector = connector
@@ -128,6 +131,7 @@ class Event(metaclass=EventMetaClass):
 
         # Inherit the user, target and event from the event we are responding
         # to if they are not explicitly provided by this Event
+        event.user_id = event.user_id or self.user_id
         event.user = event.user or self.user
         event.target = event.target or self.target
         event.connector = event.connector or self.connector

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -138,7 +138,6 @@ class Event(metaclass=EventMetaClass):
         # to if they are not explicitly provided by this Event
         event.user = event.user or self.user
         event.user_id = event.user_id or self.user_id or event.user
-        event.user = event.user or self.user
         event.target = event.target or self.target
         event.connector = event.connector or self.connector
         event.linked_event = event.linked_event or self

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -22,9 +22,11 @@ class Message(NewMessage):
     # Skip registering this class with Event
     _no_register = True
 
-    def __init__(self, text, user, room, connector, raw_message=None):  # noqa: D401
+    def __init__(
+        self, text, user_id, user, room, connector, raw_message=None
+    ):  # noqa: D401
         """Deprecated opsdroid.message.Message object."""
-        super().__init__(text, user, room, connector, raw_event=raw_message)
+        super().__init__(text, user_id, user, room, connector, raw_event=raw_message)
 
     @property
     def room(self):  # noqa: D401

--- a/opsdroid/message.py
+++ b/opsdroid/message.py
@@ -22,11 +22,15 @@ class Message(NewMessage):
     # Skip registering this class with Event
     _no_register = True
 
-    def __init__(
-        self, text, user_id, user, room, connector, raw_message=None
-    ):  # noqa: D401
+    def __init__(self, text, user, room, connector, raw_message=None):  # noqa: D401
         """Deprecated opsdroid.message.Message object."""
-        super().__init__(text, user_id, user, room, connector, raw_event=raw_message)
+        super().__init__(
+            text=text,
+            user=user,
+            target=room,
+            connector=connector,
+            raw_event=raw_message,
+        )
 
     @property
     def room(self):  # noqa: D401

--- a/tests/test_connector_github.py
+++ b/tests/test_connector_github.py
@@ -176,7 +176,12 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(mockresponse)
             resp = await self.connector.send(
-                Message("test", "jacobtomlinson", "opsdroid/opsdroid#1", self.connector)
+                Message(
+                    text="test",
+                    user="jacobtomlinson",
+                    target="opsdroid/opsdroid#1",
+                    connector=self.connector,
+                )
             )
             self.assertTrue(patched_request.called)
             self.assertTrue(resp)
@@ -189,7 +194,12 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             patched_request.return_value.set_result(mockresponse)
             self.connector.github_username = "opsdroid-bot"
             resp = await self.connector.send(
-                Message("test", "opsdroid-bot", "opsdroid/opsdroid#1", self.connector)
+                Message(
+                    text="test",
+                    user="opsdroid-bot",
+                    target="opsdroid/opsdroid#1",
+                    connector=self.connector,
+                )
             )
             self.assertFalse(patched_request.called)
             self.assertTrue(resp)
@@ -204,7 +214,12 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(mockresponse)
             resp = await self.connector.send(
-                Message("test", "opsdroid-bot", "opsdroid/opsdroid#1", self.connector)
+                Message(
+                    text="test",
+                    user="opsdroid-bot",
+                    target="opsdroid/opsdroid#1",
+                    connector=self.connector,
+                )
             )
             self.assertTrue(patched_request.called)
             self.assertFalse(resp)

--- a/tests/test_connector_shell.py
+++ b/tests/test_connector_shell.py
@@ -153,7 +153,7 @@ class TestConnectorShellAsync(asynctest.TestCase):
 
     async def test_respond(self):
         message = Message(
-            text="Hi", user="opsdroid", user_id="test_id" room="test", connector=self.connector
+            text="Hi", user="opsdroid", room="test", connector=self.connector
         )
         self.connector.prompt_length = 1
 

--- a/tests/test_connector_shell.py
+++ b/tests/test_connector_shell.py
@@ -153,7 +153,7 @@ class TestConnectorShellAsync(asynctest.TestCase):
 
     async def test_respond(self):
         message = Message(
-            text="Hi", user="opsdroid", room="test", connector=self.connector
+            text="Hi", user="opsdroid", user_id="test_id" room="test", connector=self.connector
         )
         self.connector.prompt_length = 1
 

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -161,7 +161,9 @@ class TestConnectorSlackAsync(asynctest.TestCase):
     async def test_respond(self):
         connector = ConnectorSlack({"api-token": "abc123"}, opsdroid=OpsDroid())
         connector.slack.api_call = amock.CoroutineMock()
-        await connector.send(Message("test", "user", "room", connector))
+        await connector.send(
+            Message(text="test", user="user", target="room", connector=connector)
+        )
         self.assertTrue(connector.slack.api_call.called)
 
     async def test_send_blocks(self):
@@ -180,7 +182,13 @@ class TestConnectorSlackAsync(asynctest.TestCase):
     async def test_react(self):
         connector = ConnectorSlack({"api-token": "abc123"})
         connector.slack.api_call = amock.CoroutineMock()
-        prev_message = Message("test", "user", "room", connector, raw_event={"ts": 0})
+        prev_message = Message(
+            text="test",
+            user="user",
+            target="room",
+            connector=connector,
+            raw_event={"ts": 0},
+        )
         with OpsDroid() as opsdroid:
             await prev_message.respond(Reaction("😀"))
         self.assertTrue(connector.slack.api_call)
@@ -195,7 +203,13 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         connector.slack.api_call = amock.CoroutineMock(
             side_effect=slack.errors.SlackApiError("invalid_name", "invalid_name")
         )
-        prev_message = Message("test", "user", "room", connector, raw_event={"ts": 0})
+        prev_message = Message(
+            text="test",
+            user="user",
+            target="room",
+            connector=connector,
+            raw_event={"ts": 0},
+        )
         with OpsDroid() as opsdroid:
             await prev_message.respond(Reaction("😀"))
         self.assertLogs("_LOGGER", "warning")
@@ -209,7 +223,11 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         )
         with self.assertRaises(slack.errors.SlackApiError), OpsDroid() as opsdroid:
             prev_message = Message(
-                "test", "user", "room", connector, raw_event={"ts": 0}
+                text="test",
+                user="user",
+                target="room",
+                connector=connector,
+                raw_event={"ts": 0},
             )
             await prev_message.respond(Reaction("😀"))
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -29,7 +29,9 @@ class TestConstraints(asynctest.TestCase):
             skill = constraints.constrain_rooms(["#general"])(skill)
             opsdroid.skills.append(skill)
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#random", None))
+            tasks = await opsdroid.parse(
+                Message(text="Hello", user="user", target="#random", connector=None)
+            )
             self.assertEqual(len(tasks), 1)  # Just match_always
 
     async def test_constrain_rooms_skips(self):
@@ -40,7 +42,9 @@ class TestConstraints(asynctest.TestCase):
             skill = constraints.constrain_rooms(["#general"])(skill)
             opsdroid.skills.append(skill)
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#general", None))
+            tasks = await opsdroid.parse(
+                Message(text="Hello", user="user", target="#general", connector=None)
+            )
             self.assertEqual(len(tasks), 2)  # match_always and the skill
 
     async def test_constrain_rooms_inverted(self):
@@ -51,7 +55,9 @@ class TestConstraints(asynctest.TestCase):
             skill = constraints.constrain_rooms(["#general"], invert=True)(skill)
             opsdroid.skills.append(skill)
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#general", None))
+            tasks = await opsdroid.parse(
+                Message(text="Hello", user="user", target="#general", connector=None)
+            )
             self.assertEqual(len(tasks), 1)  # match_always only
 
     async def test_constrain_users_constrains(self):
@@ -63,7 +69,9 @@ class TestConstraints(asynctest.TestCase):
             opsdroid.skills.append(skill)
 
             tasks = await opsdroid.parse(
-                Message("Hello", "otheruser", "#general", None)
+                Message(
+                    text="Hello", user="otheruser", target="#general", connector=None
+                )
             )
             self.assertEqual(len(tasks), 1)  # Just match_always
 
@@ -75,7 +83,9 @@ class TestConstraints(asynctest.TestCase):
             skill = constraints.constrain_users(["user"])(skill)
             opsdroid.skills.append(skill)
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#general", None))
+            tasks = await opsdroid.parse(
+                Message(text="Hello", user="user", target="#general", connector=None)
+            )
             self.assertEqual(len(tasks), 2)  # match_always and the skill
 
     async def test_constrain_users_inverted(self):
@@ -86,7 +96,9 @@ class TestConstraints(asynctest.TestCase):
             skill = constraints.constrain_users(["user"], invert=True)(skill)
             opsdroid.skills.append(skill)
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#general", None))
+            tasks = await opsdroid.parse(
+                Message(text="Hello", user="user", target="#general", connector=None)
+            )
             self.assertEqual(len(tasks), 1)  # match_always only
 
     async def test_constrain_connectors_constrains(self):
@@ -99,7 +111,11 @@ class TestConstraints(asynctest.TestCase):
             connector = mock.Mock()
             connector.configure_mock(name="twitter")
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#random", connector))
+            tasks = await opsdroid.parse(
+                Message(
+                    text="Hello", user="user", target="#random", connector=connector
+                )
+            )
             self.assertEqual(len(tasks), 1)  # Just match_always
 
     async def test_constrain_connectors_skips(self):
@@ -113,7 +129,9 @@ class TestConstraints(asynctest.TestCase):
             connector.configure_mock(name="slack")
 
             tasks = await opsdroid.parse(
-                Message("Hello", "user", "#general", connector)
+                Message(
+                    text="Hello", user="user", target="#general", connector=connector
+                )
             )
             self.assertEqual(len(tasks), 2)  # match_always and the skill
 
@@ -128,7 +146,9 @@ class TestConstraints(asynctest.TestCase):
             connector.configure_mock(name="slack")
 
             tasks = await opsdroid.parse(
-                Message("Hello", "user", "#general", connector)
+                Message(
+                    text="Hello", user="user", target="#general", connector=connector
+                )
             )
             self.assertEqual(len(tasks), 1)  # match_always only
 
@@ -140,13 +160,19 @@ class TestConstraints(asynctest.TestCase):
             skill = constraints.constrain_users(["user"])(skill)
             opsdroid.skills.append(skill)
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#general", None))
+            tasks = await opsdroid.parse(
+                Message(text="Hello", user="user", target="#general", connector=None)
+            )
             self.assertEqual(len(tasks), 2)  # match_always and the skill
 
             tasks = await opsdroid.parse(
-                Message("Hello", "otheruser", "#general", None)
+                Message(
+                    text="Hello", user="otheruser", target="#general", connector=None
+                )
             )
             self.assertEqual(len(tasks), 1)  # Just match_always
 
-            tasks = await opsdroid.parse(Message("Hello", "user", "#general", None))
+            tasks = await opsdroid.parse(
+                Message(text="Hello", user="user", target="#general", connector=None)
+            )
             self.assertEqual(len(tasks), 2)  # match_always and the skill

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -273,7 +273,12 @@ class TestCoreAsync(asynctest.TestCase):
             mock_connector.send = amock.CoroutineMock()
             skill = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex)(skill))
-            message = Message("Hello World", "user", "default", mock_connector)
+            message = Message(
+                text="Hello World",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
             tasks = await opsdroid.parse(message)
             for task in tasks:
                 await task
@@ -286,7 +291,12 @@ class TestCoreAsync(asynctest.TestCase):
             mock_connector.send = amock.CoroutineMock()
             skill = await self.getMockMethodSkill()
             opsdroid.skills.append(match_regex(regex)(skill))
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
             tasks = await opsdroid.parse(message)
             for task in tasks:
                 await task
@@ -299,7 +309,12 @@ class TestCoreAsync(asynctest.TestCase):
             mock_connector.send = amock.CoroutineMock()
             skill = await self.getMockSkill()
             opsdroid.skills.append(match_regex(regex, case_sensitive=False)(skill))
-            message = Message("HELLO world", "user", "default", mock_connector)
+            message = Message(
+                text="HELLO world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
             tasks = await opsdroid.parse(message)
             for task in tasks:
                 await task
@@ -312,7 +327,12 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_dialogflow_action(dialogflow_action)(skill)
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
             with amock.patch("opsdroid.parsers.dialogflow.parse_dialogflow"):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -333,7 +353,12 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_luisai_intent(luisai_intent)(skill)
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
             with amock.patch("opsdroid.parsers.luisai.parse_luisai"):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -347,7 +372,9 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_rasanlu(rasanlu_intent)(skill)
-            message = Message("Hello", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
             with amock.patch("opsdroid.parsers.rasanlu.parse_rasanlu"):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -361,7 +388,9 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_sapcai(sapcai_intent)(skill)
-            message = Message("Hello", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
             with amock.patch("opsdroid.parsers.sapcai.parse_sapcai"):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -375,7 +404,12 @@ class TestCoreAsync(asynctest.TestCase):
             skill = amock.CoroutineMock()
             mock_connector = Connector({}, opsdroid=opsdroid)
             match_witai(witai_intent)(skill)
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
             with amock.patch("opsdroid.parsers.witai.parse_witai"):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
@@ -428,7 +462,7 @@ class TestCoreAsync(asynctest.TestCase):
 
             opsdroid.connectors = [connector, connector2]
 
-            input_message = Message("Test", connector="shell")
+            input_message = Message(text="Test", connector="shell")
             await opsdroid.send(input_message)
 
             message = patched_send.call_args[0][0]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -31,8 +31,9 @@ class TestEvent(asynctest.TestCase):
     async def test_event(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        event = events.Event("user", "default", mock_connector)
+        event = events.Event("user_id", "user", "default", mock_connector)
 
+        self.assertEqual(event.user_id, "user_id")
         self.assertEqual(event.user, "user")
         self.assertEqual(event.target, "default")
 
@@ -58,16 +59,23 @@ class TestMessage(asynctest.TestCase):
             mock_connector = Connector({}, opsdroid=opsdroid)
             raw_message = {
                 "text": "Hello world",
+                "user_id": "user_id",
                 "user": "user",
                 "room": "default",
                 "timestamp": "01/01/2000 19:23:00",
                 "messageId": "101",
             }
             message = events.Message(
-                "Hello world", "user", "default", mock_connector, raw_event=raw_message
+                text="Hello world",
+                user_id="user_id",
+                user="user",
+                target="default",
+                connector=mock_connector,
+                raw_event=raw_message,
             )
 
             self.assertEqual(message.text, "Hello world")
+            self.assertEqual(message.user_id, "user_id")
             self.assertEqual(message.user, "user")
             self.assertEqual(message.target, "default")
             self.assertEqual(message.raw_event["timestamp"], "01/01/2000 19:23:00")
@@ -85,7 +93,9 @@ class TestMessage(asynctest.TestCase):
         with OpsDroid() as opsdroid:
             mock_connector = Connector({}, opsdroid=opsdroid)
             message_text = "Hello world"
-            message = events.Message(message_text, "user", "default", mock_connector)
+            message = events.Message(
+                message_text, "user_id", "user", "default", mock_connector
+            )
             with self.assertRaises(TypeError):
                 await message.respond("Goodbye world")
             self.assertEqual(message_text, message.text)
@@ -103,7 +113,9 @@ class TestMessage(asynctest.TestCase):
             )
 
             with amock.patch("opsdroid.events.Message._thinking_delay") as logmock:
-                message = events.Message("hi", "user", "default", mock_connector)
+                message = events.Message(
+                    "hi", "user_id", "user", "default", mock_connector
+                )
                 with self.assertRaises(TypeError):
                     await message.respond("Hello there")
 
@@ -122,7 +134,9 @@ class TestMessage(asynctest.TestCase):
             )
 
             with amock.patch("asyncio.sleep") as mocksleep_int:
-                message = events.Message("hi", "user", "default", mock_connector_int)
+                message = events.Message(
+                    "hi", "user_id", "user", "default", mock_connector_int
+                )
                 with self.assertRaises(TypeError):
                     await message.respond("Hello there")
 
@@ -141,7 +155,9 @@ class TestMessage(asynctest.TestCase):
             )
 
             with amock.patch("asyncio.sleep") as mocksleep_list:
-                message = events.Message("hi", "user", "default", mock_connector_list)
+                message = events.Message(
+                    "hi", "user_id", "user", "default", mock_connector_list
+                )
                 with self.assertRaises(TypeError):
                     await message.respond("Hello there")
 
@@ -160,7 +176,9 @@ class TestMessage(asynctest.TestCase):
             )
             with amock.patch("opsdroid.events.Message._typing_delay") as logmock:
                 with amock.patch("asyncio.sleep") as mocksleep:
-                    message = events.Message("hi", "user", "default", mock_connector)
+                    message = events.Message(
+                        "hi", "user_id", "user", "default", mock_connector
+                    )
                     with self.assertRaises(TypeError):
                         await message.respond("Hello there")
 
@@ -180,7 +198,9 @@ class TestMessage(asynctest.TestCase):
             )
 
             with amock.patch("asyncio.sleep") as mocksleep_list:
-                message = events.Message("hi", "user", "default", mock_connector_list)
+                message = events.Message(
+                    "hi", "user_id", "user", "default", mock_connector_list
+                )
                 with self.assertRaises(TypeError):
                     await message.respond("Hello there")
 
@@ -198,7 +218,9 @@ class TestMessage(asynctest.TestCase):
                 opsdroid=opsdroid,
             )
             with amock.patch("asyncio.sleep") as mocksleep:
-                message = events.Message("hi", "user", "default", mock_connector)
+                message = events.Message(
+                    "hi", "user_id", "user", "default", mock_connector
+                )
                 with self.assertRaises(TypeError):
                     await message.respond("Hello there")
 
@@ -212,7 +234,7 @@ class TestMessage(asynctest.TestCase):
             )
             with amock.patch("asyncio.sleep") as mocksleep:
                 message = events.Message(
-                    "Hello world", "user", "default", mock_connector
+                    "Hello world", "user_id", "user", "default", mock_connector
                 )
                 with self.assertRaises(TypeError):
                     await message.respond(events.Reaction("emoji"))
@@ -230,11 +252,13 @@ class TestFile(asynctest.TestCase):
         mock_connector = Connector({}, opsdroid=opsdroid)
         event = events.File(
             bytes("some file contents", "utf-8"),
+            user_id="user_id",
             user="user",
             target="default",
             connector=mock_connector,
         )
 
+        self.assertEqual(event.user_id, "user_id")
         self.assertEqual(event.user, "user")
         self.assertEqual(event.target, "default")
         self.assertEqual((await event.get_file_bytes()).decode(), "some file contents")
@@ -280,9 +304,14 @@ class TestImage(asynctest.TestCase):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
         event = events.Image(
-            self.gif_bytes, user="user", target="default", connector=mock_connector
+            self.gif_bytes,
+            user_id="user_id",
+            user="user",
+            target="default",
+            connector=mock_connector,
         )
 
+        self.assertEqual(event.user_id, "user_id")
         self.assertEqual(event.user, "user")
         self.assertEqual(event.target, "default")
         self.assertEqual(await event.get_file_bytes(), self.gif_bytes)
@@ -294,6 +323,7 @@ class TestImage(asynctest.TestCase):
         mock_connector = Connector({}, opsdroid=opsdroid)
         event = events.Image(
             self.gif_bytes,
+            user_id="user_id",
             user="user",
             target="default",
             mimetype="image/jpeg",
@@ -306,7 +336,11 @@ class TestImage(asynctest.TestCase):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
         event = events.Image(
-            b"aslkdjsalkdjlaj", user="user", target="default", connector=mock_connector
+            b"aslkdjsalkdjlaj",
+            user_id="user_id",
+            user="user",
+            target="default",
+            connector=mock_connector,
         )
 
         self.assertEqual(await event.get_mimetype(), "")

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -41,7 +41,7 @@ class TestMessage(asynctest.TestCase):
 
     def test_depreacted_properties(self):
         message = Message(
-            text="hello", user_id="user_id", user="user", target="", connector=""
+            text="hello", user_id="user_id", user="user", room="", connector=""
         )
 
         message.target = "spam"

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -23,10 +23,11 @@ class TestMessage(asynctest.TestCase):
                 "messageId": "101",
             }
             message = Message(
-                "Hello world",
-                "user",
-                "default",
-                mock_connector,
+                text="Hello world",
+                user_id="user_id",
+                user="user",
+                room="default",
+                connector=mock_connector,
                 raw_message=raw_message,
             )
 
@@ -39,7 +40,9 @@ class TestMessage(asynctest.TestCase):
                 await message.respond("Goodbye world")
 
     def test_depreacted_properties(self):
-        message = Message("hello", "user", "", "")
+        message = Message(
+            text="hello", user_id="user_id", user="user", target="", connector=""
+        )
 
         message.target = "spam"
         with self.assertWarns(DeprecationWarning):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -24,7 +24,6 @@ class TestMessage(asynctest.TestCase):
             }
             message = Message(
                 text="Hello world",
-                user_id="user_id",
                 user="user",
                 room="default",
                 connector=mock_connector,
@@ -40,9 +39,7 @@ class TestMessage(asynctest.TestCase):
                 await message.respond("Goodbye world")
 
     def test_depreacted_properties(self):
-        message = Message(
-            text="hello", user_id="user_id", user="user", room="", connector=""
-        )
+        message = Message(text="hello", user="user", room="", connector="")
 
         message.target = "spam"
         with self.assertWarns(DeprecationWarning):

--- a/tests/test_parser_always.py
+++ b/tests/test_parser_always.py
@@ -35,7 +35,12 @@ class TestParserAlways(asynctest.TestCase):
             opsdroid.run_skill = amock.CoroutineMock()
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             await parse_always(opsdroid, message)
 
@@ -48,7 +53,12 @@ class TestParserAlways(asynctest.TestCase):
             opsdroid.run_skill = amock.CoroutineMock()
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             await parse_always(opsdroid, message)
 
@@ -63,7 +73,12 @@ class TestParserAlways(asynctest.TestCase):
 
             mock_connector = amock.MagicMock()
             mock_connector.send = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             await parse_always(opsdroid, message)
             self.assertLogs("_LOGGER", "exception")

--- a/tests/test_parser_dialogflow.py
+++ b/tests/test_parser_dialogflow.py
@@ -35,7 +35,9 @@ class TestParserDialogflow(asynctest.TestCase):
     async def test_call_dialogflow(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("Hello world", "user", "default", mock_connector)
+        message = Message(
+            text="Hello", user="user", target="default", connector=mock_connector
+        )
         config = {"name": "dialogflow", "access-token": "test"}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
@@ -60,7 +62,9 @@ class TestParserDialogflow(asynctest.TestCase):
             opsdroid.skills.append(match_dialogflow_action("myaction")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(
                 dialogflow, "call_dialogflow"
@@ -87,7 +91,10 @@ class TestParserDialogflow(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "I want some good French food", "user", "default", mock_connector
+                text="I want some good French food",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(
@@ -140,7 +147,12 @@ class TestParserDialogflow(asynctest.TestCase):
 
             mock_connector = amock.MagicMock()
             mock_connector.send = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(
                 dialogflow, "call_dialogflow"
@@ -166,7 +178,9 @@ class TestParserDialogflow(asynctest.TestCase):
             match_dialogflow_action("myaction")(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(
                 dialogflow, "call_dialogflow"
@@ -189,7 +203,9 @@ class TestParserDialogflow(asynctest.TestCase):
             match_dialogflow_action("myaction")(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(
                 dialogflow, "call_dialogflow"
@@ -213,7 +229,9 @@ class TestParserDialogflow(asynctest.TestCase):
             match_dialogflow_action("myaction")(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello world", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(dialogflow, "call_dialogflow") as mocked_call:
                 mocked_call.side_effect = ClientOSError()

--- a/tests/test_parser_luisai.py
+++ b/tests/test_parser_luisai.py
@@ -35,7 +35,12 @@ class TestParserLuisai(asynctest.TestCase):
     async def test_call_luisai(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("schedule meeting", "user", "default", mock_connector)
+        message = Message(
+            text="schedule meeting",
+            user="user",
+            target="default",
+            connector=mock_connector,
+        )
         config = {"name": "luisai", "appid": "test", "appkey": "test", "verbose": True}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
@@ -61,7 +66,12 @@ class TestParserLuisai(asynctest.TestCase):
             opsdroid.skills.append(match_luisai_intent("Calendar.Add")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("schedule meeting", "user", "default", mock_connector)
+            message = Message(
+                text="schedule meeting",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(luisai, "call_luisai") as mocked_call_luisai:
                 mocked_call_luisai.return_value = {
@@ -88,7 +98,12 @@ class TestParserLuisai(asynctest.TestCase):
             opsdroid.skills.append(match_luisai_intent("Calendar.Add")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("schedule meeting", "user", "default", mock_connector)
+            message = Message(
+                text="schedule meeting",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(luisai, "call_luisai") as mocked_call_luisai:
                 mocked_call_luisai.return_value = {
@@ -115,7 +130,12 @@ class TestParserLuisai(asynctest.TestCase):
 
             mock_connector = amock.MagicMock()
             mock_connector.send = amock.CoroutineMock()
-            message = Message("schedule meeting", "user", "default", mock_connector)
+            message = Message(
+                text="schedule meeting",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(luisai, "call_luisai") as mocked_call_luisai:
                 mocked_call_luisai.return_value = {
@@ -144,7 +164,12 @@ class TestParserLuisai(asynctest.TestCase):
             match_luisai_intent("Calendar.Add")(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("schedule meeting", "user", "default", mock_connector)
+            message = Message(
+                text="schedule meeting",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(luisai, "call_luisai") as mocked_call_luisai:
                 mocked_call_luisai.return_value = {"statusCode": 401}
@@ -168,7 +193,12 @@ class TestParserLuisai(asynctest.TestCase):
             match_luisai_intent("Calendar.Add")(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("schedule meeting", "user", "default", mock_connector)
+            message = Message(
+                text="schedule meeting",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(luisai, "call_luisai") as mocked_call_luisai:
                 mocked_call_luisai.return_value = {
@@ -201,7 +231,12 @@ class TestParserLuisai(asynctest.TestCase):
             match_luisai_intent("Calendar.Add")(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("schedule meeting", "user", "default", mock_connector)
+            message = Message(
+                text="schedule meeting",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(luisai, "call_luisai") as mocked_call:
                 mocked_call.side_effect = ClientOSError()
@@ -223,7 +258,10 @@ class TestParserLuisai(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "whats the weather in london", "user", "default", mock_connector
+                text="whats the weather in london",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(luisai, "call_luisai") as mocked_call_luisai:

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -37,7 +37,10 @@ class TestParserRasaNLU(asynctest.TestCase):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message(
-            "how's the weather outside", "user", "default", mock_connector
+            text="how's the weather outside",
+            user="user",
+            target="default",
+            connector=mock_connector,
         )
         config = {
             "name": "rasanlu",
@@ -76,7 +79,10 @@ class TestParserRasaNLU(asynctest.TestCase):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message(
-            "how's the weather outside", "user", "default", mock_connector
+            text="how's the weather outside",
+            user="user",
+            target="default",
+            connector=mock_connector,
         )
         config = {"name": "rasanlu", "access-token": "test", "min-score": 0.3}
         result = amock.Mock()
@@ -94,7 +100,10 @@ class TestParserRasaNLU(asynctest.TestCase):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message(
-            "how's the weather outside", "user", "default", mock_connector
+            text="how's the weather outside",
+            user="user",
+            target="default",
+            connector=mock_connector,
         )
         config = {"name": "rasanlu", "access-token": "test", "min-score": 0.3}
         result = amock.Mock()
@@ -154,7 +163,10 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "show me chinese restaurants", "user", "default", mock_connector
+                text="show me chinese restaurants",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
@@ -195,7 +207,10 @@ class TestParserRasaNLU(asynctest.TestCase):
             mock_connector = amock.MagicMock()
             mock_connector.send = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
@@ -235,7 +250,10 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
@@ -255,7 +273,10 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
@@ -290,7 +311,9 @@ class TestParserRasaNLU(asynctest.TestCase):
             match_rasanlu("get_weather")(mock_skill)
 
             mock_connector = amock.CoroutineMock()
-            message = Message("hi", "user", "default", mock_connector)
+            message = Message(
+                text="hi", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
                 mocked_call_rasanlu.return_value = {
@@ -315,7 +338,10 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
@@ -341,7 +367,10 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call:

--- a/tests/test_parser_sapcai.py
+++ b/tests/test_parser_sapcai.py
@@ -35,7 +35,9 @@ class TestParserRecastAi(asynctest.TestCase):
     async def test_call_sapcai(self):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
-        message = Message("Hello" "user", "default", mock_connector)
+        message = Message(
+            text="Hello", user="user", target="default", connector=mock_connector
+        )
         config = {"name": "recastai", "access-token": "test"}
         result = amock.Mock()
         result.json = amock.CoroutineMock()
@@ -70,7 +72,9 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai("greetings")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello" "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(sapcai, "call_sapcai") as mocked_call_sapcai:
                 mocked_call_sapcai.return_value = {
@@ -103,7 +107,9 @@ class TestParserRecastAi(asynctest.TestCase):
 
             mock_connector = amock.MagicMock()
             mock_connector.send = amock.CoroutineMock()
-            message = Message("Hello", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(sapcai, "call_sapcai") as mocked_call_sapcai:
                 mocked_call_sapcai.return_value = {
@@ -139,7 +145,9 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai("greetings")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("", "user", "default", mock_connector)
+            message = Message(
+                text="", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(sapcai, "call_sapcai") as mocked_call_sapcai:
                 mocked_call_sapcai.return_value = {
@@ -159,7 +167,12 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai("greetings")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("kdjiruetosakdg", "user", "default", mock_connector)
+            message = Message(
+                text="kdjiruetosakdg",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
 
             with amock.patch.object(sapcai, "call_sapcai") as mocked_call_sapcai:
                 mocked_call_sapcai.return_value = {
@@ -195,7 +208,9 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai("intent")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(sapcai, "call_sapcai") as mocked_call_sapcai:
                 mocked_call_sapcai.return_value = {
@@ -226,7 +241,9 @@ class TestParserRecastAi(asynctest.TestCase):
             opsdroid.skills.append(match_sapcai("greetings")(mock_skill))
 
             mock_connector = amock.CoroutineMock()
-            message = Message("Hello", "user", "default", mock_connector)
+            message = Message(
+                text="Hello", user="user", target="default", connector=mock_connector
+            )
 
             with amock.patch.object(sapcai, "call_sapcai") as mocked_call:
                 mocked_call.side_effect = ClientOSError()
@@ -245,7 +262,10 @@ class TestParserRecastAi(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "whats the weather in london" "user", "default", mock_connector
+                text="whats the weather in london",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(sapcai, "call_sapcai") as mocked_call_sapcai:

--- a/tests/test_parser_witai.py
+++ b/tests/test_parser_witai.py
@@ -36,7 +36,10 @@ class TestParserWitai(asynctest.TestCase):
         opsdroid = amock.CoroutineMock()
         mock_connector = Connector({}, opsdroid=opsdroid)
         message = Message(
-            "how's the weather outside", "user", "default", mock_connector
+            text="how's the weather outside",
+            user="user",
+            target="default",
+            connector=mock_connector,
         )
         config = {"name": "witai", "access-token": "test", "min-score": 0.3}
         result = amock.Mock()
@@ -64,7 +67,10 @@ class TestParserWitai(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(witai, "call_witai") as mocked_call_witai:
@@ -94,7 +100,10 @@ class TestParserWitai(asynctest.TestCase):
             mock_connector = amock.MagicMock()
             mock_connector.send = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(witai, "call_witai") as mocked_call_witai:
@@ -125,7 +134,10 @@ class TestParserWitai(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(witai, "call_witai") as mocked_call_witai:
@@ -148,7 +160,10 @@ class TestParserWitai(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(witai, "call_witai") as mocked_call_witai:
@@ -198,7 +213,10 @@ class TestParserWitai(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(witai, "call_witai") as mocked_call_witai:
@@ -223,7 +241,10 @@ class TestParserWitai(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "how's the weather outside", "user", "default", mock_connector
+                text="how's the weather outside",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(witai, "call_witai") as mocked_call:
@@ -245,7 +266,10 @@ class TestParserWitai(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message = Message(
-                "what is the weather in london", "user", "default", mock_connector
+                text="what is the weather in london",
+                user="user",
+                target="default",
+                connector=mock_connector,
             )
 
             with amock.patch.object(witai, "call_witai") as mocked_call_witai:


### PR DESCRIPTION
# Description

_Adding user_id keyword in Event class. This is generally implemented as the human readable name of the user. For a number of events, we also need the machine readable user id for the event._

Fixes #1082


## Status
 **Ready**


## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Test A
- Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

