### PR TITLE
Fix test warnings and bump coverage

### DIFF
--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -160,7 +160,7 @@ class RocketChat(Connector):
         cancel the task.
 
         """
-        message_getter = self.loop.create_task(self.get_messages_loop())
+        message_getter = self.loop.create_task(await self.get_messages_loop())
         await self._closing.wait()
         message_getter.cancel()
 

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -247,7 +247,7 @@ class ConnectorTelegram(Connector):
         cancel the task.
 
         """
-        message_getter = self.loop.create_task(self.get_messages_loop())
+        message_getter = self.loop.create_task(await self.get_messages_loop())
         await self._closing.wait()
         message_getter.cancel()
 

--- a/opsdroid/connector/webexteams/__init__.py
+++ b/opsdroid/connector/webexteams/__init__.py
@@ -24,7 +24,7 @@ class ConnectorWebexTeams(Connector):
         self.name = "webexteams"
         self.config = config
         self.opsdroid = opsdroid
-        self.default_room = None
+        self.default_target = None
         self.bot_name = config.get("bot-name", "opsdroid")
         self.bot_webex_id = None
         self.secret = uuid.uuid4().hex

--- a/tests/test_connector_rocketchat.py
+++ b/tests/test_connector_rocketchat.py
@@ -78,9 +78,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             "success": True,
         }
 
-        with OpsDroid() as opsdroid, amock.patch(
-            "aiohttp.ClientSession.get"
-        ) as patched_request:
+        with amock.patch("aiohttp.ClientSession.get") as patched_request:
 
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(connect_response)
@@ -95,9 +93,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
         result = amock.MagicMock()
         result.status = 401
 
-        with OpsDroid() as opsdroid, amock.patch(
-            "aiohttp.ClientSession.get"
-        ) as patched_request:
+        with amock.patch("aiohttp.ClientSession.get") as patched_request:
 
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(result)
@@ -136,7 +132,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             ]
         }
 
-        with OpsDroid() as opsdroid, amock.patch.object(
+        with amock.patch.object(
             self.connector.session, "get"
         ) as patched_request, amock.patch.object(
             self.connector, "_parse_message"
@@ -181,7 +177,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             ]
         }
 
-        with OpsDroid() as opsdroid, amock.patch(
+        with amock.patch.object(self.connector, "get_messages_loop"), amock.patch(
             "opsdroid.core.OpsDroid.parse"
         ) as mocked_parse:
             await self.connector._parse_message(response)
@@ -194,7 +190,9 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
             self.connector.loop, "create_task"
         ) as mocked_task, amock.patch.object(
             self.connector._closing, "wait"
-        ) as mocked_event:
+        ) as mocked_event, amock.patch.object(
+            self.connector, "get_messages_loop"
+        ):
             mocked_event.return_value = asyncio.Future()
             mocked_event.return_value.set_result(True)
             mocked_task.return_value = asyncio.Future()
@@ -207,9 +205,7 @@ class TestConnectorRocketChatAsync(asynctest.TestCase):
         listen_response = amock.Mock()
         listen_response.status = 401
 
-        with OpsDroid() as opsdroid, amock.patch.object(
-            self.connector.session, "get"
-        ) as patched_request:
+        with amock.patch.object(self.connector.session, "get") as patched_request:
 
             patched_request.return_value = asyncio.Future()
             patched_request.return_value.set_result(listen_response)

--- a/tests/test_connector_webexteams.py
+++ b/tests/test_connector_webexteams.py
@@ -2,13 +2,12 @@
 import asyncio
 
 import unittest
-import unittest.mock as mock
 import asynctest
 import asynctest.mock as amock
 
 from opsdroid.core import OpsDroid
 from opsdroid.connector.webexteams import ConnectorWebexTeams
-from opsdroid.events import Message, Reaction
+from opsdroid.events import Message
 from opsdroid.cli.start import configure_lang
 
 
@@ -46,9 +45,7 @@ class TestConnectorCiscoSparkAsync(asynctest.TestCase):
         connector.subscribe_to_rooms = amock.CoroutineMock()
         connector.set_own_id = amock.CoroutineMock()
 
-        with amock.patch(
-            "websockets.connect", new=amock.CoroutineMock()
-        ) as mocked_websocket_connect:
+        with amock.patch("websockets.connect", new=amock.CoroutineMock()):
             await connector.connect()
 
         self.assertTrue(connector.clean_up_webhooks.called)
@@ -118,7 +115,7 @@ class TestConnectorCiscoSparkAsync(asynctest.TestCase):
             target={"id": "3vABZrQgDzfcz7LZi"},
             connector=None,
         )
-        await connector.respond(message)
+        await connector.send(message)
         self.assertTrue(connector.api.messages.create.called)
 
     async def test_get_person(self):

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -33,7 +33,7 @@ class TestConstraints(asynctest.TestCase):
             self.assertEqual(len(tasks), 1)  # Just match_always
 
     async def test_constrain_rooms_skips(self):
-        with OpsDroid() as opsdroid:
+        with OpsDroid() as opsdroid, mock.patch("opsdroid.parsers.always.parse_always"):
             opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -437,7 +437,7 @@ class TestCoreAsync(asynctest.TestCase):
 
     async def test_start_connectors(self):
         with OpsDroid() as opsdroid:
-            opsdroid.start_connectors([])
+            await opsdroid.start_connectors([])
 
             module = {}
             module["config"] = {}
@@ -457,7 +457,7 @@ class TestCoreAsync(asynctest.TestCase):
 
     async def test_start_connectors_not_implemented(self):
         with OpsDroid() as opsdroid:
-            opsdroid.start_connectors([])
+            await opsdroid.start_connectors([])
 
             module = {}
             module["config"] = {}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -376,6 +376,22 @@ class TestLoader(unittest.TestCase):
             loaded = loader._load_modules("database", modules)
             self.assertEqual(loaded[0]["config"]["name"], "myep")
 
+    def test_load_config_move_to_appdir(self):
+        opsdroid, loader = self.setup()
+        loader._load_modules = mock.MagicMock()
+        loader._setup_modules = mock.MagicMock()
+        config = {}
+        config["databases"] = mock.MagicMock()
+        config["skills"] = mock.MagicMock()
+        config["connectors"] = mock.MagicMock()
+        config["module-path"] = os.path.join(self._tmp_dir, "opsdroid")
+
+        with mock.patch("opsdroid.helper.move_config_to_appdir") as mocked_move:
+            mocked_move.side_effect = FileNotFoundError()
+            loader.load_modules_from_config(config)
+            self.assertLogs("_LOGGER", "info")
+            self.assertEqual(len(loader._load_modules.mock_calls), 3)
+
     def test_load_config(self):
         opsdroid, loader = self.setup()
         loader._load_modules = mock.MagicMock()
@@ -387,6 +403,7 @@ class TestLoader(unittest.TestCase):
         config["module-path"] = os.path.join(self._tmp_dir, "opsdroid")
 
         loader.load_modules_from_config(config)
+        self.assertLogs("_LOGGER", "info")
         self.assertEqual(len(loader._load_modules.mock_calls), 3)
 
     def test_load_empty_config(self):
@@ -429,6 +446,27 @@ class TestLoader(unittest.TestCase):
 
         modules_type = "test"
         modules = [{"name": "testmodule"}]
+        mockedmodule = mock.Mock(return_value={"name": "testmodule"})
+
+        with tempfile.TemporaryDirectory() as tmp_dep_path:
+            with mock.patch.object(
+                loader, "_install_module"
+            ) as mockinstall, mock.patch(
+                "opsdroid.loader.DEFAULT_MODULE_DEPS_PATH",
+                os.path.join(tmp_dep_path, "site-packages"),
+            ), mock.patch.object(
+                loader, "import_module", mockedmodule
+            ) as mockimport:
+                loader.setup_modules_directory({})
+                loader._load_modules(modules_type, modules)
+                self.assertTrue(mockinstall.called)
+                self.assertTrue(mockimport.called)
+
+    def test_load_modules_not_instance_Mapping(self):
+        opsdroid, loader = self.setup()
+
+        modules_type = "test"
+        modules = ["testmodule"]
         mockedmodule = mock.Mock(return_value={"name": "testmodule"})
 
         with tempfile.TemporaryDirectory() as tmp_dep_path:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -47,7 +47,7 @@ class TestLoader(unittest.TestCase):
         )
         self.assertIsNotNone(config)
 
-    def test_load_config_valid_without_wellcome_message(self):
+    def test_load_config_valid_without_welcome_message(self):
         opsdroid, loader = self.setup()
         config = loader.load_config_file(
             [os.path.abspath("tests/configs/valid_without_wellcome_message.yaml")]


### PR DESCRIPTION
# Description

The tests were giving a lot of warning when run so I tried to tackle as many as possible and reduce the clutter in the logs. Some I haven't been able to fix since everything that I tried wasn't working.

I've also created two tests that should bump the coverage back to 99% on the loader.py.


Fixes #<issue>


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green less warnings shown
- Ran opsdroid - all good

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

