### PR TITLE
Documentation Fixes.

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -34,7 +34,7 @@ For configuration, opsdroid uses a single YAML file named `configuration.yaml`. 
   - Windows: `C:\<User>\<Application Data>\<Local Settings>\opsdroid\` or
              `C:\Users\<User>\AppData\Local\opsdroid`
 
-_Note: If no file named `configuration.yaml` can be found on one of these folders one will be created for you taken from the [example configuration file](../opsdroid/configuration/example_configuration.yaml)_
+_Note: If no file named `configuration.yaml` can be found on one of these folders one will be created for you taken from the [example configuration file](https://github.com/opsdroid/opsdroid/blob/master/opsdroid/configuration/example_configuration.yaml)_
 
 If you are using one of the default locations you can run the command `opsdroid -e` or `opsdroid --edit-config` to open the configuration with your favorite editor(taken from the environment variable `EDITOR`) or the default editor [vim](tutorials/introduction-vim.md).
 
@@ -82,7 +82,7 @@ skills:
     repo: "https://github.com/username/myawesomeskill.git"
 ```
 
-In this configuration, we are using the [slack connector](/connectors/slack.md) with a slack [auth token](https://api.slack.com/tokens) supplied, a built-in mongo database connection for persisting data, `hello` and `seen` skills from the official repos and finally a custom skill hosted on GitHub.
+In this configuration, we are using the [slack connector](connectors/slack.md) with a slack [auth token](https://api.slack.com/tokens) supplied, a built-in mongo database connection for persisting data, `hello` and `seen` skills from the official repos and finally a custom skill hosted on GitHub.
 
 Configuration options such as the `token` in the slack connector or the `host`, `port` and `database` options in the mongo database are specific to those modules. Ensure you check each module's required configuration items before you use them.
 
@@ -94,14 +94,14 @@ Opsdroid comes with some built-in connectors out of the box. A connector is a mo
 
 The built-in connectors are:
 
-- [Facebook](/connectors/facebook.md)
-- [GitHub](/connectors/github.md)
-- [Matrix](/connectors/matrix.md)
-- [Rocket.Chat](/connectors/rocketchat.md)
-- [Slack](/connectors/slack.md)
-- [Telegram](/connectors/telegram.md)
-- [Websockets](/connectors/websocket.md)
-- [Webex Teams](/connectors/webexteams.md)
+- [Facebook](connectors/facebook.md)
+- [GitHub](connectors/github.md)
+- [Matrix](connectors/matrix.md)
+- [Rocket.Chat](connectors/rocketchat.md)
+- [Slack](connectors/slack.md)
+- [Telegram](connectors/telegram.md)
+- [Websockets](connectors/websocket.md)
+- [Webex Teams](connectors/webexteams.md)
 
 _Note: More connectors will be added as built-in connectors into the opsdroid over time._
 
@@ -146,8 +146,8 @@ Skills can store data in opsdroid's "memory", this is a dictionary which can be 
 
 The built-in databases are:
 
-- [Mongo DB](/databases/mongo.md)
-- [SQLite](/databases/sqlite.md)
+- [Mongo DB](databases/mongo.md)
+- [SQLite](databases/sqlite.md)
 
 _Config options of the databases themselves differ between databases, see the database documentation for details._
 
@@ -404,7 +404,7 @@ lang: <ISO 639-1 code -  example: 'en'>
 
 Configure the REST API in opsdroid.
 
-By default, opsdroid will start a web server on port `8080` (or `8443` if SSL details are provided). For more information see the [REST API docs](rest-api).
+By default, opsdroid will start a web server on port `8080` (or `8443` if SSL details are provided). For more information see the [REST API docs](rest-api.md).
 
 ```yaml
 web:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -206,7 +206,7 @@ We try to tackle issues as fast as possible, but help would be greatly appreciat
 ### Contributors
 
 Thank you to all the people who have already contributed to opsdroid!
-<a href="graphs/contributors"><img src="https://opencollective.com/opsdroid/contributors.svg?width=890" /></a>
+<a href="https://github.com/opsdroid/opsdroid/graphs/contributors"><img src="https://opencollective.com/opsdroid/contributors.svg?width=890" /></a>
 
 
 ### Backers

--- a/docs/extending/connectors.md
+++ b/docs/extending/connectors.md
@@ -92,5 +92,5 @@ class MyConnector(Connector):
 ```
 
 ---
-You might also be interested in reading the [configuration reference - Connector Modules](../configuration-reference.md/#connector-modules) in the documentation.
+You might also be interested in reading the [configuration reference - Connector Modules](../configuration-reference.md#connector-modules) in the documentation.
 *If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*

--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -39,7 +39,7 @@ In opsdroid when events are received the connector emits `Event` objects which c
 _Note: Not all connectors support all event types. To find out which events a connector will emit you can access the `.events` attribute of a connector._
 
 
-The base `Event` class has the following attributes. Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](tutorials/introduction.md#matchers-available) for more details.
+The base `Event` class has the following attributes. Also depending on the matcher it may have parser specific properties too. See the [matchers documentation](../tutorials/introduction.md#matchers-available) for more details.
 
 
 * `user`: A _string_ containing the username of the user who wrote the message.

--- a/docs/matchers/parse_format.md
+++ b/docs/matchers/parse_format.md
@@ -2,7 +2,7 @@
 
 ## Configuring opsdroid
 
-As in [regex matcher](/matchers/regex.md), in order to enable parse format skills, you must set the `enabled` parameter to true in the parsers section of the opsdroid configuration file.
+As in [regex matcher](../matchers/regex.md), in order to enable parse format skills, you must set the `enabled` parameter to true in the parsers section of the opsdroid configuration file.
 
 ```yaml
 parsers:
@@ -160,4 +160,4 @@ Read [parse format specification](https://github.com/r1chardj0n3s/parse#format-s
 
 ## Score factor
 
-As in [regex matcher](/matchers/regex.md), you can use the keyword argument `score_factor` in parse format skills to modify the score calculation.
+As in [regex matcher](../matchers/regex.md), you can use the keyword argument `score_factor` in parse format skills to modify the score calculation.

--- a/docs/matchers/rasanlu.md
+++ b/docs/matchers/rasanlu.md
@@ -22,9 +22,9 @@ parsers:
 
 ##
 
-[Rasa NLU](https://github.com/RasaHQ/rasa_nlu) is an open source tool for running your own NLP API for matching strings to [intents](https://rasahq.github.io/rasa_nlu/). This is the recommended parser if you have privacy concerns but want the power of a full NLU parsing engine.
+[Rasa NLU](https://github.com/RasaHQ/rasa_nlu) is an open source tool for running your own NLP API for matching strings to [intents](https://rasa.com/docs/rasa/). This is the recommended parser if you have privacy concerns but want the power of a full NLU parsing engine.
 
-Rasa NLU is also trained via the API and so opsdroid can do the training for you if you provide an intents [markdown file](https://rasahq.github.io/rasa_nlu/dataformat.html#markdown-format) along with your skill. This file must contain headers in the format `## intent:<intent name>` followed by a list of example phrases for that intent. Rasa NLU will then use those examples to build a statistical model for matching new and unseen variations on those sentences.
+Rasa NLU is also trained via the API and so opsdroid can do the training for you if you provide an intents [markdown file](https://rasa.com/docs/rasa/nlu/training-data-format/#data-formats) along with your skill. This file must contain headers in the format `## intent:<intent name>` followed by a list of example phrases for that intent. Rasa NLU will then use those examples to build a statistical model for matching new and unseen variations on those sentences.
 
 > ⚠️ **Warning** - Rasa NLU requires 4GB of memory, 2GB for training models and 2GB for serving requests. If you do not provide enough it will hang and cause timeouts in opsdroid.
 

--- a/docs/matchers/regex.md
+++ b/docs/matchers/regex.md
@@ -14,7 +14,7 @@ parsers:
 
 ## About Regular Expression Matcher
 
-This is [almost](/matchers/parse_format.md) the simplest matcher available in opsdroid. It matches the message from the user against a regular expression. If the regex matches then the function is called.
+This is [almost](../matchers/parse_format.md) the simplest matcher available in opsdroid. It matches the message from the user against a regular expression. If the regex matches then the function is called.
 
 You can specify to the regex matcher which kind of matching you want to apply through the `matching_condition` kwarg (*match* matching is the default). This kwarg should give you more control on how to use the regex matcher.
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,6 +1,6 @@
 # REST API
 
-There is a RESTful API for opsdroid accessible on port `8080`. See the [configuration reference](configuration-reference#web) for config options.
+There is a RESTful API for opsdroid accessible on port `8080`. See the [configuration reference](configuration-reference.md#web) for config options.
 
 ## Methods
 
@@ -42,7 +42,7 @@ This method returns runtime statistics which could be useful in monitoring.
 
 ### `/skill/{skillname}/{webhookname}` _[POST]_
 
-This method family will call skills which have been decorated with the [webhook matcher](parsers/webhook). The URI format includes the name of the skill from the `configuration.yaml` and the name of the webhook set in the decorator.
+This method family will call skills which have been decorated with the [webhook matcher](../matchers/webhook). The URI format includes the name of the skill from the `configuration.yaml` and the name of the webhook set in the decorator.
 
 The response includes information on whether a skill was successfully triggered or not.
 

--- a/docs/tutorials/basic-skill.md
+++ b/docs/tutorials/basic-skill.md
@@ -1,5 +1,5 @@
 # Creating a Basic Skill
-We will create a basic skill that makes opsdroid answer the text "how are you". This skill will be very similar to the [hello skill](docs/extending/skills/#hello-world) found in the documentation.
+We will create a basic skill that makes opsdroid answer the text "how are you". This skill will be very similar to the [hello skill](../extending/skills.md#hello-world) found in the documentation.
 The video tutorial for creating your own skill is also available [here](https://www.youtube.com/watch?v=gk7JN4e5l_4&index=3&list=PLViQCHlMbEq5nZL6VNrUxu--Of1uCpflq)
 
 *If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
@@ -44,7 +44,7 @@ class MySkill(Skill):
     @match_regex('how are you?')
 ```
 
-The [regex matcher](/matchers/regex.md) takes a regular expression and searches for it on every message sent by a user. So if the user types `how are you?` opsdroid will trigger the function underneath the `match_regex` decorator.
+The [regex matcher](../matchers/regex.md) takes a regular expression and searches for it on every message sent by a user. So if the user types `how are you?` opsdroid will trigger the function underneath the `match_regex` decorator.
 
 _Note: Opsdroid won't trigger with the text `how are you` because the question mark is missing._
 
@@ -98,5 +98,5 @@ skills:
     path: /Users/username/documents/skill-howareyou
 ```
 
-As mentioned in the [introduction](introduction.md/), the indentation and the use of spaces instead of tabs is very important. If you have any issues when running opsdroid check both of this things, it might be a problem with a space.
+As mentioned in the [introduction](introduction.md), the indentation and the use of spaces instead of tabs is very important. If you have any issues when running opsdroid check both of this things, it might be a problem with a space.
 

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -129,10 +129,10 @@ Matchers are used to match a message, sent by a user, to a connector and a skill
   * Basic matcher
     * [Regular Expressions](../matchers/regex.md)
   * NLP Matchers
-    * [Dialogflow(previous Api.ai)](../matchers/dialogflow.md)
+    * [Dialogflow (previous Api.ai)](../matchers/dialogflow.md)
     * [Wit.ai](../matchers/wit.ai.md)
     * [Luis.ai](../matchers/luis.ai.md)
-    * [Recast.ai](../matchers/recast.ai.md)
+    * [SAP Conversational AI (previously Recast.ai)](../matchers/sapcai.md)
   * NLU Matcher
     * [Rasa_NLU](../matchers/rasanlu.md)
   * Special Matcher


### PR DESCRIPTION
+ Skills link on tutorial page updated with correct slash (to make absolute url).
+ graphs/contrinutors has now link to github.
+ RASA NLU project link updated.
+ Correct link to matcher/webhook from pager/webhook
+ Correct links to markdown (at multiple files)

# Description
Fixes #1120 (brokenlinks in documentation)

## Status
**READY**.


## Type of change

- Bug fix (non-breaking change which fixes an issue) 
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?
- running against `deadlinks` (butuzov/deadlinks)
- generating documentation and running again same tool.


# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

