### PR TITLE
Make remaining logging messages translatable

### DIFF
--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -32,7 +32,7 @@ class ConnectorFacebook(Connector):
     def __init__(self, config, opsdroid=None):
         """Connector Setup."""
         super().__init__(config, opsdroid=opsdroid)
-        _LOGGER.debug("Starting facebook connector")
+        _LOGGER.debug(_("Starting facebook connector"))
         self.name = self.config.get("name", "facebook")
         self.bot_name = config.get("bot-name", "opsdroid")
 
@@ -100,7 +100,7 @@ class ConnectorFacebook(Connector):
     @register_event(Message)
     async def send_message(self, message):
         """Respond with a message."""
-        _LOGGER.debug("Responding to facebook")
+        _LOGGER.debug(_("Responding to facebook"))
         url = _FACEBOOK_SEND_URL.format(self.config.get("page-access-token"))
         headers = {"content-type": "application/json"}
         payload = {
@@ -114,4 +114,4 @@ class ConnectorFacebook(Connector):
             else:
                 _LOGGER.debug(resp.status)
                 _LOGGER.debug(await resp.text())
-                _LOGGER.error("Unable to respond to facebook")
+                _LOGGER.error(_("Unable to respond to facebook"))

--- a/opsdroid/connector/facebook/__init__.py
+++ b/opsdroid/connector/facebook/__init__.py
@@ -110,7 +110,7 @@ class ConnectorFacebook(Connector):
         async with aiohttp.ClientSession() as session:
             resp = await session.post(url, data=json.dumps(payload), headers=headers)
             if resp.status < 300:
-                _LOGGER.info("Responded with: %s", message.text)
+                _LOGGER.info(_("Responded with: %s"), message.text)
             else:
                 _LOGGER.debug(resp.status)
                 _LOGGER.debug(await resp.text())

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -35,7 +35,7 @@ class ConnectorGitHub(Connector):
         async with aiohttp.ClientSession() as session:
             response = await session.get(url)
             if response.status >= 300:
-                _LOGGER.error("Error connecting to github: %s", response.text())
+                _LOGGER.error(_("Error connecting to github: %s"), response.text())
                 return False
             _LOGGER.debug(_("Reading bot information..."))
             bot_data = await response.json()
@@ -87,7 +87,7 @@ class ConnectorGitHub(Connector):
             )
             await self.opsdroid.parse(message)
         except KeyError as error:
-            _LOGGER.error("Key %s not found in payload", error)
+            _LOGGER.error(_("Key %s not found in payload"), error)
             _LOGGER.debug(payload)
         return aiohttp.web.Response(text=json.dumps("Received"), status=201)
 

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -22,7 +22,9 @@ class ConnectorGitHub(Connector):
         try:
             self.github_token = config["token"]
         except KeyError:
-            _LOGGER.error("Missing auth token!" "You must set 'token' in your config")
+            _LOGGER.error(
+                _("Missing auth token!" "You must set 'token' in your config")
+            )
         self.name = self.config.get("name", "github")
         self.opsdroid = opsdroid
         self.github_username = None
@@ -35,9 +37,9 @@ class ConnectorGitHub(Connector):
             if response.status >= 300:
                 _LOGGER.error("Error connecting to github: %s", response.text())
                 return False
-            _LOGGER.debug("Reading bot information...")
+            _LOGGER.debug(_("Reading bot information..."))
             bot_data = await response.json()
-        _LOGGER.debug("Done.")
+        _LOGGER.debug(_("Done."))
         self.github_username = bot_data["login"]
 
         self.opsdroid.web_server.web_app.router.add_post(
@@ -69,7 +71,7 @@ class ConnectorGitHub(Connector):
                 issue_number = payload["pull_request"]["number"]
                 body = payload["pull_request"]["body"]
             else:
-                _LOGGER.debug("No message to respond to.")
+                _LOGGER.debug(_("No message to respond to."))
                 _LOGGER.debug(payload)
                 return aiohttp.web.Response(
                     text=json.dumps("No message to respond to."), status=200
@@ -95,14 +97,14 @@ class ConnectorGitHub(Connector):
         # stop immediately if the message is from the bot itself.
         if message.user == self.github_username:
             return True
-        _LOGGER.debug("Responding via GitHub")
+        _LOGGER.debug(_("Responding via GitHub"))
         repo, issue = message.target.split("#")
         url = "{}/repos/{}/issues/{}/comments".format(GITHUB_API_URL, repo, issue)
         headers = {"Authorization": " token {}".format(self.github_token)}
         async with aiohttp.ClientSession() as session:
             resp = await session.post(url, json={"body": message.text}, headers=headers)
             if resp.status == 201:
-                _LOGGER.info("Message sent.")
+                _LOGGER.info(_("Message sent."))
                 return True
             _LOGGER.error(await resp.json())
             return False

--- a/opsdroid/connector/gitter/__init__.py
+++ b/opsdroid/connector/gitter/__init__.py
@@ -82,7 +82,7 @@ class ConnectorGitter(Connector):
                     message["text"], message["fromUser"]["username"], self.room_id, self
                 )
             except KeyError as err:
-                _LOGGER.error("Unable to parse message %s", err)
+                _LOGGER.error(_("Unable to parse message %s"), err)
                 _LOGGER.error(err)
 
     @register_event(Message)

--- a/opsdroid/connector/gitter/__init__.py
+++ b/opsdroid/connector/gitter/__init__.py
@@ -19,7 +19,7 @@ class ConnectorGitter(Connector):
     def __init__(self, config, opsdroid=None):
         """Create the connector."""
         super().__init__(config, opsdroid=opsdroid)
-        _LOGGER.debug("Starting Gitter connector")
+        _LOGGER.debug(_("Starting Gitter connector"))
         self.name = "gitter"
         self.session = None
         self.response = None
@@ -34,7 +34,7 @@ class ConnectorGitter(Connector):
         """Create the connection."""
 
         # Create connection object with chat library
-        _LOGGER.debug("Connecting with gitter stream")
+        _LOGGER.debug(_("Connecting with gitter stream"))
         self.session = aiohttp.ClientSession()
         gitter_url = self.build_url(
             GITTER_STREAM_API,
@@ -56,7 +56,7 @@ class ConnectorGitter(Connector):
 
     async def listen(self):
         """Keep listing to the gitter channel."""
-        _LOGGER.debug("Listening with gitter stream")
+        _LOGGER.debug(_("Listening with gitter stream"))
         while self.listening:
             try:
                 await self._get_messages()
@@ -98,9 +98,9 @@ class ConnectorGitter(Connector):
         payload = {"text": message.text}
         resp = await self.session.post(url, json=payload, headers=headers)
         if resp.status == 200:
-            _LOGGER.info("Successfully responded")
+            _LOGGER.info(_("Successfully responded"))
         else:
-            _LOGGER.error("Unable to respond.")
+            _LOGGER.error(_("Unable to respond."))
 
     async def disconnect(self):
         """Disconnect the gitter."""

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -132,7 +132,7 @@ class ConnectorMatrix(Connector):
                 # We can safely ignore timeout errors. The non-standard error
                 # codes are returned by Cloudflare.
                 if mre.code in [504, 522, 524]:
-                    _LOGGER.info(_("Matrix Sync Timeout (code: %d)", mre.code))
+                    _LOGGER.info(_("Matrix Sync Timeout (code: %d)"), mre.code)
                     continue
 
                 _LOGGER.exception(_("Matrix Sync Error"))

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -135,11 +135,11 @@ class ConnectorMatrix(Connector):
                     _LOGGER.info(_("Matrix Sync Timeout (code: %d)", mre.code))
                     continue
 
-                _LOGGER.exception("Matrix Sync Error")
+                _LOGGER.exception(_("Matrix Sync Error"))
             except CancelledError:
                 raise
             except Exception:  # pylint: disable=W0703
-                _LOGGER.exception("Matrix Sync Error")
+                _LOGGER.exception(_("Matrix Sync Error"))
 
     async def get_nick(self, roomid, mxid):
         """

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -123,7 +123,7 @@ class ConnectorMatrix(Connector):
                     timeout_ms=int(60 * 1e3),  # 1m in ms
                     filter=self.filter_id,
                 )
-                _LOGGER.debug("matrix sync request returned")
+                _LOGGER.debug(_("matrix sync request returned"))
                 message = await self._parse_sync_response(response)
                 if message:
                     await self.opsdroid.parse(message)
@@ -132,7 +132,7 @@ class ConnectorMatrix(Connector):
                 # We can safely ignore timeout errors. The non-standard error
                 # codes are returned by Cloudflare.
                 if mre.code in [504, 522, 524]:
-                    _LOGGER.info("Matrix Sync Timeout (code: %d)", mre.code)
+                    _LOGGER.info(_("Matrix Sync Timeout (code: %d)", mre.code))
                     continue
 
                 _LOGGER.exception("Matrix Sync Error")
@@ -209,7 +209,7 @@ class ConnectorMatrix(Connector):
                 self._get_formatted_message_body(message.text),
             )
         except aiohttp.client_exceptions.ServerDisconnectedError:
-            _LOGGER.debug("Server had disconnected, retrying send.")
+            _LOGGER.debug(_("Server had disconnected, retrying send."))
             await self.connection.send_message_event(
                 room_id,
                 "m.room.message",

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -82,10 +82,10 @@ class RocketChat(Connector):
         resp = await self.session.get(self.build_url("me"), headers=self.headers)
         if resp.status != 200:
             _LOGGER.error(_("Unable to connect."))
-            _LOGGER.error("Rocket.Chat error %s, %s", resp.status, resp.text)
+            _LOGGER.error(_("Rocket.Chat error %s, %s"), resp.status, resp.text)
         else:
             json = await resp.json()
-            _LOGGER.debug("Connected to Rocket.Chat as %s", json["username"])
+            _LOGGER.debug(_("Connected to Rocket.Chat as %s"), json["username"])
 
     async def _parse_message(self, response):
         """Parse the message received.
@@ -102,7 +102,8 @@ class RocketChat(Connector):
                 self,
             )
             _LOGGER.debug(
-                "Received message from Rocket.Chat %s", response["messages"][0]["msg"]
+                _("Received message from Rocket.Chat %s"),
+                response["messages"][0]["msg"],
             )
 
             await self.opsdroid.parse(message)
@@ -132,7 +133,7 @@ class RocketChat(Connector):
             resp = await self.session.get(url, headers=self.headers)
 
             if resp.status != 200:
-                _LOGGER.error("Rocket.Chat error %s, %s", resp.status, resp.text)
+                _LOGGER.error(_("Rocket.Chat error %s, %s"), resp.status, resp.text)
                 self.listening = False
             else:
                 json = await resp.json()
@@ -178,7 +179,7 @@ class RocketChat(Connector):
             message (object): An instance of Message
 
         """
-        _LOGGER.debug("Responding with: %s", message.text)
+        _LOGGER.debug(_("Responding with: %s"), message.text)
 
         data = {}
         data["channel"] = message.target
@@ -192,7 +193,7 @@ class RocketChat(Connector):
         if resp.status == 200:
             _LOGGER.debug(_("Successfully responded"))
         else:
-            _LOGGER.debug("Error - %s: Unable to respond", resp.status)
+            _LOGGER.debug(_("Error - %s: Unable to respond"), resp.status)
 
     async def disconnect(self):
         """Disconnect from Rocket.Chat.

--- a/opsdroid/connector/rocketchat/__init__.py
+++ b/opsdroid/connector/rocketchat/__init__.py
@@ -45,8 +45,10 @@ class RocketChat(Connector):
             self.headers = {"X-User-Id": self.user_id, "X-Auth-Token": self.token}
         except (KeyError, AttributeError):
             _LOGGER.error(
-                "Unable to login: Access token is missing. "
-                "Rocket.Chat connector will not be available."
+                _(
+                    "Unable to login: Access token is missing. "
+                    "Rocket.Chat connector will not be available."
+                )
             )
 
     def build_url(self, method):
@@ -75,11 +77,11 @@ class RocketChat(Connector):
         information is not used.
 
         """
-        _LOGGER.info("Connecting to Rocket.Chat")
+        _LOGGER.info(_("Connecting to Rocket.Chat"))
         self.session = aiohttp.ClientSession()
         resp = await self.session.get(self.build_url("me"), headers=self.headers)
         if resp.status != 200:
-            _LOGGER.error("Unable to connect.")
+            _LOGGER.error(_("Unable to connect."))
             _LOGGER.error("Rocket.Chat error %s, %s", resp.status, resp.text)
         else:
             json = await resp.json()
@@ -188,7 +190,7 @@ class RocketChat(Connector):
         )
 
         if resp.status == 200:
-            _LOGGER.debug("Successfully responded")
+            _LOGGER.debug(_("Successfully responded"))
         else:
             _LOGGER.debug("Error - %s: Unable to respond", resp.status)
 

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -19,7 +19,7 @@ class ConnectorSlack(Connector):
     def __init__(self, config, opsdroid=None):
         """Create the connector."""
         super().__init__(config, opsdroid=opsdroid)
-        _LOGGER.debug("Starting Slack connector")
+        _LOGGER.debug(_("Starting Slack connector"))
         self.name = "slack"
         self.default_target = config.get("default-room", "#general")
         self.icon_emoji = config.get("icon-emoji", ":robot_face:")
@@ -43,7 +43,7 @@ class ConnectorSlack(Connector):
 
     async def connect(self):
         """Connect to the chat service."""
-        _LOGGER.info("Connecting to Slack")
+        _LOGGER.info(_("Connecting to Slack"))
 
         try:
             # The slack library recommends you call `self.slack_rtm.start()`` here but it
@@ -65,7 +65,7 @@ class ConnectorSlack(Connector):
             _LOGGER.debug("Connected as %s", self.bot_name)
             _LOGGER.debug("Using icon %s", self.icon_emoji)
             _LOGGER.debug("Default room is %s", self.default_target)
-            _LOGGER.info("Connected successfully")
+            _LOGGER.info(_("Connected successfully"))
         except slack.errors.SlackApiError as error:
             _LOGGER.error(
                 "Unable to connect to Slack due to %s - "
@@ -97,14 +97,14 @@ class ConnectorSlack(Connector):
             return
 
         # Lookup username
-        _LOGGER.debug("Looking up sender username")
+        _LOGGER.debug(_("Looking up sender username"))
         try:
             user_info = await self.lookup_username(message["user"])
         except ValueError:
             return
 
         # Replace usernames in the message
-        _LOGGER.debug("Replacing userids in message with usernames")
+        _LOGGER.debug(_("Replacing userids in message with usernames"))
         message["text"] = await self.replace_usernames(message["text"])
 
         await self.opsdroid.parse(

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -62,14 +62,16 @@ class ConnectorSlack(Connector):
             ).data
             self.bot_id = self.user_info["user"]["profile"]["bot_id"]
 
-            _LOGGER.debug("Connected as %s", self.bot_name)
-            _LOGGER.debug("Using icon %s", self.icon_emoji)
-            _LOGGER.debug("Default room is %s", self.default_target)
+            _LOGGER.debug(_("Connected as %s"), self.bot_name)
+            _LOGGER.debug(_("Using icon %s"), self.icon_emoji)
+            _LOGGER.debug(_("Default room is %s"), self.default_target)
             _LOGGER.info(_("Connected successfully"))
         except slack.errors.SlackApiError as error:
             _LOGGER.error(
-                "Unable to connect to Slack due to %s - "
-                "The Slack Connector will not be available.",
+                _(
+                    "Unable to connect to Slack due to %s - "
+                    "The Slack Connector will not be available."
+                ),
                 error,
             )
         except Exception:
@@ -120,7 +122,9 @@ class ConnectorSlack(Connector):
     @register_event(Message)
     async def send_message(self, message):
         """Respond with a message."""
-        _LOGGER.debug("Responding with: '%s' in room  %s", message.text, message.target)
+        _LOGGER.debug(
+            _("Responding with: '%s' in room  %s"), message.text, message.target
+        )
         await self.slack.api_call(
             "chat.postMessage",
             data={
@@ -135,7 +139,9 @@ class ConnectorSlack(Connector):
     @register_event(Blocks)
     async def send_blocks(self, blocks):
         """Respond with structured blocks."""
-        _LOGGER.debug("Responding with interactive blocks in room  %s", blocks.target)
+        _LOGGER.debug(
+            _("Responding with interactive blocks in room  %s"), blocks.target
+        )
         await self.slack.api_call(
             "chat.postMessage",
             data={
@@ -150,7 +156,7 @@ class ConnectorSlack(Connector):
     async def send_reaction(self, reaction):
         """React to a message."""
         emoji = demojize(reaction.emoji).replace(":", "")
-        _LOGGER.debug("Reacting with: %s", emoji)
+        _LOGGER.debug(_("Reacting with: %s"), emoji)
         try:
             await self.slack.api_call(
                 "reactions.add",
@@ -162,7 +168,7 @@ class ConnectorSlack(Connector):
             )
         except slack.errors.SlackApiError as error:
             if "invalid_name" in str(error):
-                _LOGGER.warning("Slack does not support the emoji %s", emoji)
+                _LOGGER.warning(_("Slack does not support the emoji %s"), emoji)
             else:
                 raise
 

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -21,7 +21,7 @@ class ConnectorTelegram(Connector):
                 file config.yaml.
 
         """
-        _LOGGER.debug("Loaded telegram connector")
+        _LOGGER.debug(_("Loaded telegram connector"))
         super().__init__(config, opsdroid=opsdroid)
         self.name = "telegram"
         self.opsdroid = opsdroid
@@ -39,8 +39,10 @@ class ConnectorTelegram(Connector):
             self.token = config["token"]
         except (KeyError, AttributeError):
             _LOGGER.error(
-                "Unable to login: Access token is missing. "
-                "Telegram connector will be unavailable."
+                _(
+                    "Unable to login: Access token is missing. "
+                    "Telegram connector will be unavailable."
+                )
             )
 
     @staticmethod
@@ -105,13 +107,13 @@ class ConnectorTelegram(Connector):
         request possible.
 
         """
-        _LOGGER.debug("Sending deleteWebhook request to Telegram...")
+        _LOGGER.debug(_("Sending deleteWebhook request to Telegram..."))
         resp = await self.session.get(self.build_url("deleteWebhook"))
 
         if resp.status == 200:
-            _LOGGER.debug("Telegram webhook deleted successfully.")
+            _LOGGER.debug(_("Telegram webhook deleted successfully."))
         else:
-            _LOGGER.debug("Unable to delete webhook.")
+            _LOGGER.debug(_("Unable to delete webhook."))
 
     async def connect(self):
         """Connect to Telegram.
@@ -121,12 +123,12 @@ class ConnectorTelegram(Connector):
         call to Telegram and evaluates the status of the call.
 
         """
-        _LOGGER.debug("Connecting to telegram")
+        _LOGGER.debug(_("Connecting to telegram"))
         self.session = aiohttp.ClientSession()
         resp = await self.session.get(self.build_url("getMe"))
 
         if resp.status != 200:
-            _LOGGER.error("Unable to connect")
+            _LOGGER.error(_("Unable to connect"))
             _LOGGER.error("Telegram error %s, %s", resp.status, resp.text)
         else:
             json = await resp.json()
@@ -157,7 +159,7 @@ class ConnectorTelegram(Connector):
                 result["message"] = result.pop("edited_message")
             if "channel" in result["message"]["chat"]["type"]:
                 _LOGGER.debug(
-                    "Channel message parsing not supported " "- Ignoring message"
+                    _("Channel message parsing not supported " "- Ignoring message")
                 )
             elif "message" in result and "text" in result["message"]:
                 user = self.get_user(result)
@@ -180,10 +182,10 @@ class ConnectorTelegram(Connector):
             ):
                 self.latest_update = result["update_id"] + 1
                 _LOGGER.debug(
-                    "Emoji message parsing not supported " "- Ignoring message"
+                    _("Emoji message parsing not supported " "- Ignoring message")
                 )
             else:
-                _LOGGER.error("Unable to parse the message.")
+                _LOGGER.error(_("Unable to parse the message."))
 
     async def _get_messages(self):
         """Connect to the Telegram API.
@@ -207,9 +209,11 @@ class ConnectorTelegram(Connector):
 
         if resp.status == 409:
             _LOGGER.info(
-                "Can't get updates because previous "
-                "webhook is still active. Will try to "
-                "delete webhook."
+                _(
+                    "Can't get updates because previous "
+                    "webhook is still active. Will try to "
+                    "delete webhook."
+                )
             )
             await self.delete_webhook()
 
@@ -266,9 +270,9 @@ class ConnectorTelegram(Connector):
         data["text"] = message.text
         resp = await self.session.post(self.build_url("sendMessage"), data=data)
         if resp.status == 200:
-            _LOGGER.debug("Successfully responded")
+            _LOGGER.debug(_("Successfully responded"))
         else:
-            _LOGGER.error("Unable to respond.")
+            _LOGGER.error(_("Unable to respond."))
 
     @register_event(Image)
     async def send_image(self, file_event):

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -129,11 +129,11 @@ class ConnectorTelegram(Connector):
 
         if resp.status != 200:
             _LOGGER.error(_("Unable to connect"))
-            _LOGGER.error("Telegram error %s, %s", resp.status, resp.text)
+            _LOGGER.error(_("Telegram error %s, %s"), resp.status, resp.text)
         else:
             json = await resp.json()
             _LOGGER.debug(json)
-            _LOGGER.debug("Connected to telegram as %s", json["result"]["username"])
+            _LOGGER.debug(_("Connected to telegram as %s"), json["result"]["username"])
 
     async def _parse_message(self, response):
         """Handle logic to parse a received message.
@@ -218,7 +218,7 @@ class ConnectorTelegram(Connector):
             await self.delete_webhook()
 
         if resp.status != 200:
-            _LOGGER.error("Telegram error %s, %s", resp.status, resp.text)
+            _LOGGER.error(_("Telegram error %s, %s"), resp.status, resp.text)
             self.listening = False
         else:
             json = await resp.json()
@@ -263,7 +263,7 @@ class ConnectorTelegram(Connector):
             message (object): An instance of Message.
 
         """
-        _LOGGER.debug("Responding with: %s", message.text)
+        _LOGGER.debug(_("Responding with: %s"), message.text)
 
         data = dict()
         data["chat_id"] = message.target["id"]
@@ -294,9 +294,9 @@ class ConnectorTelegram(Connector):
 
         resp = await self.session.post(self.build_url("sendPhoto"), data=data)
         if resp.status == 200:
-            _LOGGER.debug("Sent %s image " "successfully", file_event.name)
+            _LOGGER.debug(_("Sent %s image " "successfully"), file_event.name)
         else:
-            _LOGGER.debug("Unable to send image - " "Status Code %s", resp.status)
+            _LOGGER.debug(_("Unable to send image - " "Status Code %s"), resp.status)
 
     async def disconnect(self):
         """Disconnect from Telegram.

--- a/opsdroid/connector/webexteams/__init__.py
+++ b/opsdroid/connector/webexteams/__init__.py
@@ -19,7 +19,7 @@ class ConnectorWebexTeams(Connector):
 
     def __init__(self, config, opsdroid=None):
         """Create a connector."""
-        _LOGGER.debug("Loaded webex teams connector")
+        _LOGGER.debug(_("Loaded webex teams connector"))
         super().__init__(config, opsdroid=opsdroid)
         self.name = "webexteams"
         self.config = config
@@ -35,7 +35,7 @@ class ConnectorWebexTeams(Connector):
         try:
             self.api = WebexTeamsAPI(access_token=self.config["access-token"])
         except KeyError:
-            _LOGGER.error("Must set accesst-token for webex teams connector!")
+            _LOGGER.error(_("Must set accesst-token for webex teams connector!"))
             return
 
         await self.clean_up_webhooks()
@@ -44,7 +44,7 @@ class ConnectorWebexTeams(Connector):
 
     async def webexteams_message_handler(self, request):
         """Handle webhooks from the Webex Teams api."""
-        _LOGGER.debug("Handling message from Webex Teams")
+        _LOGGER.debug(_("Handling message from Webex Teams"))
         req_data = await request.json()
 
         _LOGGER.debug(req_data)
@@ -74,7 +74,7 @@ class ConnectorWebexTeams(Connector):
 
     async def subscribe_to_rooms(self):
         """Create webhooks for all rooms."""
-        _LOGGER.debug("Creating Webex Teams webhook")
+        _LOGGER.debug(_("Creating Webex Teams webhook"))
         webhook_endpoint = "/connector/webexteams"
         self.opsdroid.web_server.web_app.router.add_post(
             webhook_endpoint, self.webexteams_message_handler

--- a/opsdroid/connector/webexteams/__init__.py
+++ b/opsdroid/connector/webexteams/__init__.py
@@ -35,7 +35,7 @@ class ConnectorWebexTeams(Connector):
         try:
             self.api = WebexTeamsAPI(access_token=self.config["access-token"])
         except KeyError:
-            _LOGGER.error(_("Must set accesst-token for webex teams connector!"))
+            _LOGGER.error(_("Must set access-token for webex teams connector!"))
             return
 
         await self.clean_up_webhooks()

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -88,7 +88,7 @@ class ConnectorWebsocket(Connector):
                 text=json.dumps("Socket request timed out"), headers=HEADERS, status=408
             )
         self.available_connections.remove(available[0])
-        _LOGGER.debug("User connected to %s", socket)
+        _LOGGER.debug(_("User connected to %s"), socket)
 
         websocket = aiohttp.web.WebSocketResponse()
         await websocket.prepare(request)
@@ -100,7 +100,7 @@ class ConnectorWebsocket(Connector):
                 await self.opsdroid.parse(message)
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 _LOGGER.error(
-                    "Websocket connection closed with exception %s",
+                    _("Websocket connection closed with exception %s"),
                     websocket.exception(),
                 )
 
@@ -124,8 +124,8 @@ class ConnectorWebsocket(Connector):
             if message.target is None:
                 message.target = next(iter(self.active_connections))
             _LOGGER.debug(
-                "Responding with: '" + message.text + "' in target " + message.target
+                _("Responding with: '" + message.text + "' in target " + message.target)
             )
             await self.active_connections[message.target].send_str(message.text)
         except KeyError:
-            _LOGGER.error("No active socket for target %s", message.target)
+            _LOGGER.error(_("No active socket for target %s"), message.target)

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -124,7 +124,7 @@ class ConnectorWebsocket(Connector):
             if message.target is None:
                 message.target = next(iter(self.active_connections))
             _LOGGER.debug(
-                _("Responding with: '" + message.text + "' in target " + message.target)
+                _("Responding with: '%s' in target %s"), message.text, message.target
             )
             await self.active_connections[message.target].send_str(message.text)
         except KeyError:

--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -22,7 +22,7 @@ class ConnectorWebsocket(Connector):
     def __init__(self, config, opsdroid=None):
         """Create the connector."""
         super().__init__(config, opsdroid=opsdroid)
-        _LOGGER.debug("Starting Websocket connector")
+        _LOGGER.debug(_("Starting Websocket connector"))
         self.name = "websocket"
         self.max_connections = self.config.get("max-connections", 10)
         self.connection_timeout = self.config.get("connection-timeout", 60)
@@ -104,7 +104,7 @@ class ConnectorWebsocket(Connector):
                     websocket.exception(),
                 )
 
-        _LOGGER.info("websocket connection closed")
+        _LOGGER.info(_("websocket connection closed"))
         self.active_connections.pop(socket, None)
 
         return websocket

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -391,7 +391,7 @@ class OpsDroid:
             if len(luisai) == 1 and (
                 "enabled" not in luisai[0] or luisai[0]["enabled"] is not False
             ):
-                _LOGGER.debug("Checking luisai...")
+                _LOGGER.debug(_("Checking luisai..."))
                 ranked_skills += await parse_luisai(self, skills, message, luisai[0])
 
             sapcai = [p for p in parsers if p["name"] == "sapcai"]

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -603,7 +603,7 @@ class Loader:
             )
             return True
 
-        _LOGGER.debug("Couldn't find the file requirements.txt, " "skipping.")
+        _LOGGER.debug(_("Couldn't find the file requirements.txt, " "skipping."))
         return None
 
     def _install_git_module(self, config):

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -22,10 +22,12 @@ class ParsingFilter(logging.Filter):
                 and self.config["filter"]["blacklist"]
             ):
                 _LOGGER.warning(
-                    "Both whitelist and blacklist "
-                    "filters found in configuration. "
-                    "Only one can be used at a time - "
-                    "only the whitelist filter will be used."
+                    _(
+                        "Both whitelist and blacklist "
+                        "filters found in configuration. "
+                        "Only one can be used at a time - "
+                        "only the whitelist filter will be used."
+                    )
                 )
                 self.parse_list = [
                     logging.Filter(name) for name in parse_list[0]["whitelist"]


### PR DESCRIPTION
## Description

I searched for `_LOGGER` in VS Code and it yielded 322 results, out of which about 100 were relevant and not yet translatable. I wrapped all of them in `_(<string>)` and tested after that. Some of the logging calls with more than two arguments caused some tests to fail after that, so I reverted the changes, ultimately changing about ~50 calls. I also ran `black` manually as per @jos3p's [suggestion](https://github.com/opsdroid/opsdroid/issues/1128#issuecomment-538653664) since I had some issues with `pre-commit`.

Fixes #1128


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

I followed the [contributing guide]https://opsdroid.readthedocs.io/en/latest/contributing/l), i.e.:

`pip install -U pre-commit`
`pre-commit install`
`pip install -U tox`
`tox`

As explained in the description, some of the tests failed after changing ALL the logging messages to be wrapped inside `_()`, so I reverted the changes on those to achieve the same testing results as before the changes.


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

