### PR TITLE
Update sapcai parser to allow different language when parsing

### DIFF
--- a/docs/matchers/sapcai.md
+++ b/docs/matchers/sapcai.md
@@ -2,8 +2,10 @@
 
 ## Configuring opsdroid
 
+[SAP Conversational AI](https://cai.tools.sap/) is an NLP API for matching strings to [intents](https://cai.tools.sap/docs/concepts/intent). Intents are created on the SAP Conversational AI website.
+
 In order to enable SAP Conversational AI skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file.
-You can find this `access-token` in the settings of your bot under the name: `'Request access token'`.
+You can find this `access-token` in the settings of your bot. Click on the Tokens tab and use the `'Developer token'` details.
 
 You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
 
@@ -15,11 +17,33 @@ parsers:
     min-score: 0.8
 ```
 
-##
+### Localization
 
-[SAP Conversational AI](https://cai.tools.sap/) is an NLP API for matching strings to [intents](https://cai.tools.sap/docs/concepts/intent). Intents are created on the SAP Conversational AI website.
+If you use opsdroid in a language other than English, this parser will automatically grab the language code that you have set on your configuration.
 
-## [Example 1](#example1)
+If you want to run this parser in a different language you can overwrite the language configuration by adding the `lang` parameter on this parser configuration.
+
+_Note: You need to make sure that your intent has the language that you wish to parse added to it. Click the intent name and choose 'Add Language'._
+
+#### Example
+
+```yaml
+parsers:
+  - name: sapcai
+    access-token: 85769fjoso084jd
+    min-score: 0.8
+    lang: 'pt'
+```
+
+This will make the parser to use the Portuguese language when matching the string to an intent.
+
+## Using the parser with a skill
+
+Let's have a look at how you can use this parser and the `match_sapcai` decorator on a skill. 
+
+The `match_sapcai` decorator takes one parameter (the name of the intent to match), any skill (function or class method) decorated with this matcher, will trigger that skill.
+
+### [Example 1](#example1)
 
 ```python
 from opsdroid.skill import Skill
@@ -36,7 +60,7 @@ class MySkill(Skill):
 
 The above skill would be called on any intent which has a name of `'greetings'`.
 
-## Example 2
+### Example 2
 
 ```python
 from opsdroid.skill import Skill
@@ -57,9 +81,6 @@ You need to [register](https://cai.tools.sap/signup) on SAP Conversational AI an
 
 You can find a quick getting started with the SAP Conversational AI guide [here](https://cai.tools.sap/docs/concepts/create-builder-bot).
 
-If you want to use SAP Conversational AI in a different language other than English, all you need to do is specify the `lang` parameter in opsdroid's configuration.
-
-_Note: "If you do not have any expressions in this language, we will use your default bot language for processing." - [SAP Conversational AI Language page](https://cai.tools.sap/docs/concepts/language)_
 
 ## Message object additional parameters
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -398,7 +398,7 @@ class OpsDroid:
             if len(sapcai) == 1 and (
                 "enabled" not in sapcai[0] or sapcai[0]["enabled"] is not False
             ):
-                _LOGGER.debug(_("Checking Recast.AI..."))
+                _LOGGER.debug(_("Checking SAPCAI..."))
                 ranked_skills += await parse_sapcai(self, skills, message, sapcai[0])
 
             witai = [p for p in parsers if p["name"] == "witai"]

--- a/opsdroid/parsers/sapcai.py
+++ b/opsdroid/parsers/sapcai.py
@@ -31,14 +31,14 @@ async def call_sapcai(message, config, lang=DEFAULT_LANGUAGE):
 async def parse_sapcai(opsdroid, skills, message, config):
     """Parse a message against all SAP Conversational AI intents."""
     matched_skills = []
+    language = config.get("lang") or opsdroid.config.get("lang", DEFAULT_LANGUAGE)
+    _LOGGER.info(language)
     if "access-token" in config:
         try:
-            result = await call_sapcai(
-                message, config, opsdroid.config.get("lang", DEFAULT_LANGUAGE)
-            )
+            result = await call_sapcai(message, config, language)
         except aiohttp.ClientOSError:
             _LOGGER.error(
-                _("No response from SAP Conversational.AI, " "check your network.")
+                _("No response from SAP Conversational.AI, check your network.")
             )
             return matched_skills
 
@@ -60,7 +60,7 @@ async def parse_sapcai(opsdroid, skills, message, config):
         confidence = result["results"]["intents"][0]["confidence"]
 
         if "min-score" in config and confidence < config["min-score"]:
-            _LOGGER.debug(_("SAP Conversational AI score lower " "than min-score"))
+            _LOGGER.debug(_("SAP Conversational AI score lower than min-score"))
             return matched_skills
 
         if result:

--- a/opsdroid/parsers/sapcai.py
+++ b/opsdroid/parsers/sapcai.py
@@ -32,7 +32,7 @@ async def parse_sapcai(opsdroid, skills, message, config):
     """Parse a message against all SAP Conversational AI intents."""
     matched_skills = []
     language = config.get("lang") or opsdroid.config.get("lang", DEFAULT_LANGUAGE)
-    _LOGGER.info(language)
+
     if "access-token" in config:
         try:
             result = await call_sapcai(message, config, language)


### PR DESCRIPTION
# Description

This PR is an effort to tackle #422 and make the sapcai parser to accept a different language when parsing a message.

This has been a pretty trivial change - just choose between the `lang` config either on the parser config or the general opsdroid config.  The documentation has been updated as well to mention localisation and how to set it up with the parser.

There was a few changes done on the whole sapcai website so the section on how to get the access-token was updated.

Finally, while testing the parser with the debug logs I've noticed that we were still using Recastai on the debug log when checking this parser. This log has been changed 👍 

I am going to update my dialogflow PR to accept a language param as well, but since I got a PR open I'll add it there 😄 


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran opsdroid with parser set to Portuguese - parsed the message as expected
- Ran opsdroid with general lang set to Portuguese but parser set to English - parsed as expected


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

