### PR TITLE
Fixed README.md header issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@
 <p align="center">
   <a href="#chatops">ChatOps</a> •
   <a href="#why-use-opsdroid">Why use opsdroid?</a> •
-  <a href="#quick-start">Quick Start</a> •
+  <a href="#quickstart">Quick Start</a> •
   <a href="#installation-guide">Installation Guide</a> •
   <a href="#usage">Usage</a> •
-  <a href="#contributing">Contributing</a> •
+  <a href="#contributors">Contributors</a> •
   <a href="#backers">Backers</a> •
-  <a href="#sponsors">Sponsers</a>
+  <a href="#sponsors">Sponsors</a>
 </p>
 
 ---


### PR DESCRIPTION
# Description

Some hyperlinks (specifically Quick Start & Contributing) in README.md were not re-directing to the desired sub-headings.

## Fixes
- Fixed Quick Start hyperlink which was re-directing to opsdroid/opsdroid repo and not the desired anchor i.e. Quick Start sub-heading in the README.md.

- Changed Contributing to Contributors (#contributing to #contributors for the anchor). Made this change because the sub-heading is"Contributors" in the doc, and not "Contributing". So the #contributing tag wouldn't work either way.

- Typo fix: Sponsers to Sponsors

## Status
**READY**


## Type of change

- Documentation (fix or adds documentation)

# How Has This Been Tested?
Tested hyperlinks (in the header) to check if they re-directed to the correct sub-headings
# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

