### PR TITLE
Add IBM Watson parser 

### DIFF
--- a/docs/extending/events.md
+++ b/docs/extending/events.md
@@ -26,6 +26,8 @@ The base `Event` class has the following attributes and methods:
 
 * `raw_event`: The raw event received by the connector (may be `None`).
 
+* `raw_parses`: The raw response provided by the parser service.
+
 * `responded_to`: A boolean (True/False) flag indicating if this event has already had its `respond` method called.
 
 * `entities`: A dictionary mapping of entities created by parsers. These could be values extracted form sentences like locations, times, people, etc.

--- a/docs/matchers/watson.md
+++ b/docs/matchers/watson.md
@@ -40,8 +40,8 @@ class MySkill(Skill):
     @match_watson('Customer_Care_Appointments')
     async def book_slot(self, message):
         """Book an appointment"""
-        booking_date = message.watson['output']['entities'][0]['value']
-        booking_time = message.watson['output']['entities'][1]['value']
+        booking_date = message.entities['sys-date']['value'][0]
+        booking_time = message.entities['sys-time']['value'][0]
 
         await message.respond("Done! Booked you for {} at {}".format(booking_date, booking_time))
 ```

--- a/docs/matchers/watson.md
+++ b/docs/matchers/watson.md
@@ -4,8 +4,8 @@
 
 ## Configuring opsdroid
 
-In order to enable Watson skills, you must specify an `access-token`, an `assistant-id` and a `gateway` for your bot in the parsers section of the opsdroid configuration file.
-You can find this information inside your Assistant Settings under the `API Details`. Note that depending where your bot is located the gateway will be different, just use this. For example: `gateway-fra`.
+To enable Watson skills, you must specify an `access-token`, an `assistant-id` and a `gateway` for your bot in the parsers section of the opsdroid configuration file.
+You can find this information inside your Assistant Settings under the `API Details`. Note that depending on where your bot is located the gateway will be different, just use this. For example: `gateway-fra`.
 
 You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
 
@@ -21,7 +21,7 @@ parsers:
 
 ### Localization
 
-If you want to use Watson on a different language you will have to create different intents and entities to handle the languages that you wish to support.
+If you want to use Watson in a different language you will have to create different intents and entities to handle the languages that you wish to support.
 
 ## Using the parser with a skill
 
@@ -40,16 +40,11 @@ class MySkill(Skill):
     @match_watson('Customer_Care_Appointments')
     async def book_slot(self, message):
         """Book an appointment"""
-        reply = message.watson['output']['generic'][0]['text']
         booking_date = message.watson['output']['entities'][0]['value']
         booking_time = message.watson['output']['entities'][1]['value']
 
-        _LOGGER.info(reply)
-
         await message.respond("Done! Booked you for {} at {}".format(booking_date, booking_time))
 ```
-
-_Note: In this example we are getting a reply from the bot just to show you how you can get that reply into an opsdroid reply - Watson's reply is actually this: `Let me confirm: You want an appointment for <date> at <time>. Is this correct?`_
 
 The above skill would be called on any intent which has a name of `'Customer_Care_Appointment'`.
 
@@ -90,6 +85,51 @@ This is the JSON response that opsdroid will get from this text:
         "value": "11:00:00", 
         "confidence": 1, 
         "metadata": {"calendar_type": "GREGORIAN", "timezone": "GMT"}}]}}
+```
+
+### [Example 2](#example2)
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_watson
+
+
+class MySkill(Skill):
+    @match_watson('Customer_Care_Appointments')
+    async def book_slot(self, message):
+        """Book an appointment"""
+        reply = message.watson['output']['generic'][0]['text']
+
+
+        await message.respond(reply)
+```
+
+_Note: This example uses the default intent `Customer_Care_Store_Hours` from the `Customer Care Sample Skill` pack to get opening hours of a store._
+
+#### Usage example
+
+> user: What time do you open?
+>
+> opsdroid: Our hours are Monday to Friday 10am to 8pm and Friday and Saturday 11am to 6pm.
+
+This is the JSON response that opsdroid will get from this text:
+
+```json
+{
+  "output": {
+    "generic": [
+      {
+        "response_type": "text", 
+        "text": "Our hours are Monday to Friday 10am to 8pm and Friday and Saturday 11am to 6pm."
+      }
+    ], 
+    "intents": [
+      {
+        "intent": "Customer_Care_Store_Hours", 
+        "confidence": 0.972700834274292
+      }
+    ], 
+    "entities": []}}
 ```
 
 ## Creating a Watson App

--- a/docs/matchers/watson.md
+++ b/docs/matchers/watson.md
@@ -5,7 +5,7 @@
 ## Configuring opsdroid
 
 In order to enable Watson skills, you must specify an `access-token`, an `assistant-id` and a `gateway` for your bot in the parsers section of the opsdroid configuration file.
-You can find these informations inside your Assistant Settings under the `API Details`. Note that depending where your bot is located the gateway will be different, just use this. For example: `gateway-fra`.
+You can find this information inside your Assistant Settings under the `API Details`. Note that depending where your bot is located the gateway will be different, just use this. For example: `gateway-fra`.
 
 You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
 
@@ -13,7 +13,7 @@ You can also set a `min-score` option to tell opsdroid to ignore any matches whi
 
 parsers:
   - name: watson
-    gateway: 'gateway-fr' # Required
+    gateway: 'gateway-fra' # Required
     access-token: XJF475SKGITJ98KHFO # Required
     assistant-id: '74yhfhis9-kfirj1e-jfir34-kfdir345' # Required
     min-score: 0.6

--- a/docs/matchers/watson.md
+++ b/docs/matchers/watson.md
@@ -1,0 +1,129 @@
+# IBM Watson Matcher
+
+## Configuring opsdroid
+
+In order to enable wit.ai skills, you must specify an `access-token` for your bot in the parsers section of the opsdroid configuration file.
+You can find this `access-token` in the settings of your App under the name: `'Server Access Token: '`.
+
+You can also set a `min-score` option to tell opsdroid to ignore any matches which score less than a given number between 0 and 1. The default for this is 0 which will match all messages.
+
+```yaml
+
+parsers:
+  - name: watson
+    gateway: 'gateway-fr' # Required
+    access-token: XJF475SKGITJ98KHFO # Required
+    assistant-id: '74yhfhis9-kfirj1e-jfir34-kfdir345' # Required
+    min-score: 0.6
+```
+
+##
+
+[wit.ai](https://wit.ai) is an NLP API for matching strings to [intents](https://wit.ai/docs/recipes#categorize-the-user-intent). Intents are created on the wit.ai website.
+
+## [Example 1](#example1)
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_witai
+
+class MySkill(Skill):
+    @match_witai('get_weather')
+    async def weather(self, message):
+        """Hard Coded version of weather function"""
+        temp = 10
+        humidity = "80%"
+        city = message.witai['entities']['location'][0]['value']
+        status = "Clouds"
+
+        await message.respond("It's currently {} degrees, {}% humidity in {} and {} is forecasted "
+                              "for today".format(temp, humidity, city, status))
+```
+
+The above skill would be called on any intent which has a name of `'get_weather'`.
+
+#### Usage example
+
+> user: what's the weather like in London
+>
+> opsdroid: It's currently 13.12 degrees, 67% humidity in London and Rain is forecasted for today
+
+## Creating a wit.ai App
+You need to register on wit.ai and create an App in order to use wit.ai with opsdroid.
+
+You can find a quick getting started with the wit.ai guide [here](https://wit.ai/getting-started).
+
+If you want to use wit.ai in a different language other than English, all you need to do is change the language of your app located in the app settings.
+
+## Message object additional parameters
+
+### `message.witai`
+
+An http response object which has been returned by the wit.ai API. This allows you to access any information from the matched intent including other entities, intents, values, etc.
+
+
+## Example Skill
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_witai
+
+import json
+
+class MySkill(Skill):
+    @match_witai('get_weather')
+    async def dumpResponse(self, message):
+        print(json.dumps(message.witai))
+```
+
+### Return Value on "How's the weather?"
+
+The example skill will print the following on the message "how's the weather?".
+
+```json
+{
+  "msg_id": "0zTl3L16kFW4PwtSt",
+  "_text": "how's the weather",
+  "entities": {
+     "intent": [
+       {
+         "confidence": 0.77586417870417,
+         "value": "get_weather"
+       }
+     ]
+  }
+}
+```
+
+## Return Value on "What's the weather like in London?"
+
+The example skill will print the following on the message "What's the weather like in London?".
+
+```json
+{
+   "msg_id": "0zrCQ5LEkWd0MoHYM",
+   "_text": "What's the weather like in London?",
+   "entities": {
+      "location": [
+        {
+          "suggested": true,
+          "confidence": 0.74044071131585,
+          "value": "London",
+          "type": "value"
+        }
+      ],
+      "intent": [
+        {
+          "confidence": 0.99979499373014,
+          "value": "get_weather"
+        }
+      ]
+   }
+}
+
+```
+
+Since Wit.ai can recognise locations, you can use this values on your skills to return different things.
+On our weather skill([example 1](#example1)) we changed the city param to get the temperature related to any city passed on the message.
+
+

--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -39,5 +39,5 @@ WITAI_API_ENDPOINT = "https://api.wit.ai/message?"
 
 SAPCAI_API_ENDPOINT = "https://api.cai.tools.sap/v2/request"
 
-WATSON_API_ENDPOINT = ".watsonplatform.net/assistant/api"
+WATSON_API_ENDPOINT = "https://{gateway}.watsonplatform.net/assistant/api"
 WATSON_API_VERSION = "2019-02-28"

--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -38,3 +38,6 @@ WITAI_DEFAULT_VERSION = "20170307"
 WITAI_API_ENDPOINT = "https://api.wit.ai/message?"
 
 SAPCAI_API_ENDPOINT = "https://api.cai.tools.sap/v2/request"
+
+WATSON_API_ENDPOINT = ".watsonplatform.net/assistant/api"
+WATSON_API_VERSION = "2019-02-28"

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -26,6 +26,7 @@ from opsdroid.parsers.dialogflow import parse_dialogflow
 from opsdroid.parsers.luisai import parse_luisai
 from opsdroid.parsers.sapcai import parse_sapcai
 from opsdroid.parsers.witai import parse_witai
+from opsdroid.parsers.watson import parse_watson
 from opsdroid.parsers.rasanlu import parse_rasanlu, train_rasanlu
 from opsdroid.parsers.crontab import parse_crontab
 
@@ -412,6 +413,13 @@ class OpsDroid:
             ):
                 _LOGGER.debug(_("Checking wit.ai..."))
                 ranked_skills += await parse_witai(self, skills, message, witai[0])
+
+            watson = [p for p in parsers if p["name"] == "watson"]
+            if len(watson) == 1 and (
+                "enabled" not in watson[0] or watson[0]["enabled"] is not False
+            ):
+                _LOGGER.debug(_("Checking IBM Watson..."))
+                ranked_skills += await parse_watson(self, skills, message, watson[0])
 
             rasanlu = [p for p in parsers if p["name"] == "rasanlu"]
             if len(rasanlu) == 1 and (

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -92,6 +92,7 @@ class Event(metaclass=EventMetaClass):
                 was sent.
         connector: Connector object used to interact with given chat service
         raw_event: Raw event provided by chat service
+        raw_parses: Dictionary mapping of the response created by parsers
         responded_to: Boolean initialized as False. True if event has been
             responded to
         entities: Dictionary mapping of entities created by parsers
@@ -115,6 +116,7 @@ class Event(metaclass=EventMetaClass):
         self.created = datetime.now()
         self.event_id = event_id
         self.raw_event = raw_event
+        self.raw_parses = {}
         self.responded_to = False
         self.entities = {}
 
@@ -186,6 +188,7 @@ class Message(Event):
         connector: Connector object used to interact with given chat service
         text: Text of message as string
         raw_event: Raw message provided by chat service
+        raw_parses: Raw response provided by the parser service
         raw_match: A match object for a search against which the message was
             matched. E.g. a regular expression or natural language intent
         responded_to: Boolean initialized as False. True if event has been

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -107,7 +107,7 @@ class Event(metaclass=EventMetaClass):
         target=None,
         connector=None,
         raw_event=None,
-        raw_parser=None,
+        raw_parses=None,
         event_id=None,
         linked_event=None,
     ):  # noqa: D107
@@ -119,19 +119,9 @@ class Event(metaclass=EventMetaClass):
         self.created = datetime.now()
         self.event_id = event_id
         self.raw_event = raw_event
-        self.raw_parser = raw_parser or {}
+        self.raw_parses = raw_parses or {}
         self.responded_to = False
         self.entities = {}
-
-    @property
-    def raw_parses(self):
-        """Helper gets raw_parser."""
-        return self.raw_parser
-
-    @raw_parses.setter
-    def raw_parses(self, val):
-        """Helper sets raw_parser."""
-        self.raw_parser = val
 
     async def respond(self, event):
         """Respond to this event with another event.

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -80,6 +80,8 @@ class Event(metaclass=EventMetaClass):
                                          given chat service
         raw_event (dict, optional): Raw message as provided by chat service.
                                     None by default
+        raw_parses (dict, optional): Raw response as provided by parse service.
+                            None by default
         event_id (object, optional): The unique id for this event as provided
                                      by the connector.
         linked_event (Event, optional): An event to link to this one, i.e. the
@@ -105,6 +107,7 @@ class Event(metaclass=EventMetaClass):
         target=None,
         connector=None,
         raw_event=None,
+        raw_parser=None,
         event_id=None,
         linked_event=None,
     ):  # noqa: D107
@@ -116,9 +119,19 @@ class Event(metaclass=EventMetaClass):
         self.created = datetime.now()
         self.event_id = event_id
         self.raw_event = raw_event
-        self.raw_parses = {}
+        self.raw_parser = raw_parser or {}
         self.responded_to = False
         self.entities = {}
+
+    @property
+    def raw_parses(self):
+        """Helper gets raw_parser."""
+        return self.raw_parser
+
+    @raw_parses.setter
+    def raw_parses(self, val):
+        """Helper sets raw_parser."""
+        self.raw_parser = val
 
     async def respond(self, event):
         """Respond to this event with another event.
@@ -180,6 +193,8 @@ class Message(Event):
                                          given chat service
         raw_event (dict, optional): Raw message as provided by chat service.
                                     None by default
+        raw_parses (dict, optional): Raw response as provided by parse service.
+                    None by default
 
     Attributes:
         created: Local date and time that message object was created

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -183,6 +183,18 @@ def match_sapcai(intent):
     return matcher
 
 
+def match_watson(intent):
+    """Return watson intent match decorator."""
+
+    def matcher(func):
+        """Add decorated function to skills list for watson matching."""
+        func = add_skill_attributes(func)
+        func.matchers.append({"watson_intent": intent})
+        return func
+
+    return matcher
+
+
 def match_witai(intent):
     """Return witai intent match decorator."""
 

--- a/opsdroid/parsers/watson.py
+++ b/opsdroid/parsers/watson.py
@@ -1,0 +1,88 @@
+"""A helper function for parsing and executing IBM watson skills."""
+import logging
+import json
+
+from ibm_watson import AssistantV2
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_watson import ApiException
+
+from opsdroid.const import WATSON_API_ENDPOINT
+from opsdroid.const import WATSON_API_VERSION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def get_session_id(service, config):
+    """Authenticate and get session id from watson."""
+    service.set_service_url(
+        "https://{}{}".format(config["gateway"], WATSON_API_ENDPOINT)
+    )
+    response = service.create_session(assistant_id=config["assistant-id"]).get_result()
+
+    config["session-id"] = response["session_id"]
+
+
+async def call_watson(message, config):
+    """Call the IBM Watson api and return the response."""
+    authenticator = IAMAuthenticator(config["access-token"])
+    service = AssistantV2(version=WATSON_API_VERSION, authenticator=authenticator)
+
+    await get_session_id(service, config)
+
+    response = service.message(
+        assistant_id=config["assistant-id"],
+        session_id=config["session-id"],
+        input={"message_type": "text", "text": message.text},
+    ).get_result()
+
+    _LOGGER.info(_("Watson response - %s"), json.dumps(response))
+
+    return response
+
+
+async def parse_watson(opsdroid, skills, message, config):
+    """Parse a message against all IBM Watson skills."""
+    matched_skills = []
+    try:
+        result = await call_watson(message, config)
+    except KeyError as error:
+        _LOGGER.error(
+            _("Error: %s . You are probably missing some configuration parameter."),
+            error,
+        )
+    except ApiException as ex:
+        _LOGGER.error(_("Watson Api error - %d:%s"), ex.code, ex.message)
+
+    if not result["output"]["intents"]:
+        _LOGGER.error(_("Watson - No intent found. Did you forget to create one?"))
+        return matched_skills
+
+    try:
+        confidence = result["output"]["intents"][0]["confidence"]
+    except KeyError:
+        confidence = 0.0
+
+    if "min-score" in config and confidence < config["min-score"]:
+        _LOGGER.info(_("Watson score lower than min-score"))
+        return matched_skills
+
+    if result:
+        for skill in skills:
+            for matcher in skill.matchers:
+                if "watson_intent" in matcher:
+                    if matcher["watson_intent"] in [
+                        i["value"] for i in result["output"]["intents"][0]["intent"]
+                    ]:
+                        message.watson = result
+                        for key, entity in result["output"]["intents"][0].items():
+                            if key != "intent":
+                                await message.update_entity(key, entity["confidence"])
+                        matched_skills.append(
+                            {
+                                "score": confidence,
+                                "skill": skill,
+                                "config": skill.config,
+                                "message": message,
+                            }
+                        )
+    return matched_skills

--- a/opsdroid/parsers/watson.py
+++ b/opsdroid/parsers/watson.py
@@ -127,7 +127,7 @@ async def parse_watson(opsdroid, skills, message, config):
                             matcher["watson_intent"]
                             in result["output"]["intents"][0]["intent"]
                         ):
-                            message.watson = result
+                            message.raw_parses["watson"] = result
 
                             entities = await get_all_entities(
                                 result["output"]["entities"]

--- a/opsdroid/parsers/watson.py
+++ b/opsdroid/parsers/watson.py
@@ -14,9 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def get_session_id(service, config):
     """Authenticate and get session id from watson."""
-    service.set_service_url(
-        "https://{}{}".format(config["gateway"], WATSON_API_ENDPOINT)
-    )
+    service.set_service_url(WATSON_API_ENDPOINT.format(gateway=config["gateway"]))
     response = service.create_session(assistant_id=config["assistant-id"]).get_result()
 
     config["session-id"] = response["session_id"]
@@ -35,7 +33,7 @@ async def call_watson(message, config):
         input={"message_type": "text", "text": message.text},
     ).get_result()
 
-    _LOGGER.info(_("Watson response - %s"), json.dumps(response))
+    _LOGGER.debug(_("Watson response - %s"), json.dumps(response))
 
     return response
 

--- a/opsdroid/parsers/watson.py
+++ b/opsdroid/parsers/watson.py
@@ -1,6 +1,5 @@
 """A helper function for parsing and executing IBM watson skills."""
 import logging
-import json
 
 from ibm_watson import AssistantV2
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
@@ -32,7 +31,7 @@ async def call_watson(message, config):
         input={"message_type": "text", "text": message.text},
     ).get_result()
 
-    _LOGGER.debug(_("Watson response - %s"), json.dumps(response))
+    _LOGGER.debug(_("Watson response - %s"), response)
 
     return response
 

--- a/opsdroid/parsers/watson.py
+++ b/opsdroid/parsers/watson.py
@@ -67,16 +67,22 @@ async def parse_watson(opsdroid, skills, message, config):
         return matched_skills
 
     if result:
+
         for skill in skills:
             for matcher in skill.matchers:
+
                 if "watson_intent" in matcher:
-                    if matcher["watson_intent"] in [
-                        i["value"] for i in result["output"]["intents"][0]["intent"]
-                    ]:
+                    _LOGGER.info(matcher)
+                    if (
+                        matcher["watson_intent"]
+                        in result["output"]["intents"][0]["intent"]
+                    ):
                         message.watson = result
+
                         for key, entity in result["output"]["intents"][0].items():
                             if key != "intent":
-                                await message.update_entity(key, entity["confidence"])
+                                await message.update_entity(key, entity, None)
+
                         matched_skills.append(
                             {
                                 "score": confidence,
@@ -85,4 +91,5 @@ async def parse_watson(opsdroid, skills, message, config):
                                 "message": message,
                             }
                         )
+
     return matched_skills

--- a/opsdroid/parsers/watson.py
+++ b/opsdroid/parsers/watson.py
@@ -6,8 +6,7 @@ from ibm_watson import AssistantV2
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from ibm_watson import ApiException
 
-from opsdroid.const import WATSON_API_ENDPOINT
-from opsdroid.const import WATSON_API_VERSION
+from opsdroid.const import WATSON_API_ENDPOINT, WATSON_API_VERSION
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pycron==1.0.0
 pyyaml==5.1.2
 setuptools==41.2.0
 slackclient==2.2.1
+ibm-watson==4.0.1
 websockets==8.0.2
 webexteamssdk==1.2
 yamale==2.0.1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,6 +18,7 @@ from opsdroid.matchers import (
     match_luisai_intent,
     match_sapcai,
     match_rasanlu,
+    match_watson,
     match_witai,
 )
 
@@ -365,6 +366,20 @@ class TestCoreAsync(asynctest.TestCase):
             match_sapcai(sapcai_intent)(skill)
             message = Message("Hello", "user", "default", mock_connector)
             with amock.patch("opsdroid.parsers.sapcai.parse_sapcai"):
+                tasks = await opsdroid.parse(message)
+                self.assertEqual(len(tasks), 1)
+                for task in tasks:
+                    await task
+
+    async def test_parse_watson(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [{"name": "watson"}]
+            watson_intent = ""
+            skill = amock.CoroutineMock()
+            mock_connector = Connector({}, opsdroid=opsdroid)
+            match_watson(watson_intent)(skill)
+            message = Message("Hello world", "user", "default", mock_connector)
+            with amock.patch("opsdroid.parsers.watson.parse_watson"):
                 tasks = await opsdroid.parse(message)
                 self.assertEqual(len(tasks), 1)
                 for task in tasks:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,4 @@
 import asyncio
-from unittest import mock
 
 import asynctest
 import asynctest.mock as amock
@@ -35,6 +34,16 @@ class TestEvent(asynctest.TestCase):
 
         self.assertEqual(event.user, "user")
         self.assertEqual(event.target, "default")
+
+    async def test_event_raw_parses(self):
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
+        event = events.Event("user", "default", mock_connector)
+        event.raw_parses["test"] = {"hello": "world"}
+
+        self.assertEqual(event.raw_parses, {"test": {"hello": "world"}})
+        self.assertEqual(event.raw_parses["test"], event.raw_parser["test"])
+        self.assertIn("test", event.raw_parser)
 
     def test_unique_subclasses(self):
         with self.assertRaises(NameError):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -35,16 +35,6 @@ class TestEvent(asynctest.TestCase):
         self.assertEqual(event.user, "user")
         self.assertEqual(event.target, "default")
 
-    async def test_event_raw_parses(self):
-        opsdroid = amock.CoroutineMock()
-        mock_connector = Connector({}, opsdroid=opsdroid)
-        event = events.Event("user", "default", mock_connector)
-        event.raw_parses["test"] = {"hello": "world"}
-
-        self.assertEqual(event.raw_parses, {"test": {"hello": "world"}})
-        self.assertEqual(event.raw_parses["test"], event.raw_parser["test"])
-        self.assertIn("test", event.raw_parser)
-
     def test_unique_subclasses(self):
         with self.assertRaises(NameError):
 

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -67,6 +67,15 @@ class TestMatchers(asynctest.TestCase):
             self.assertEqual(opsdroid.skills[0].matchers[0]["luisai_intent"], intent)
             self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
 
+    async def test_match_watson(self):
+        with OpsDroid() as opsdroid:
+            intent = "myIntent"
+            decorator = matchers.match_watson(intent)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
+            self.assertEqual(len(opsdroid.skills), 1)
+            self.assertEqual(opsdroid.skills[0].matchers[0]["watson_intent"], intent)
+            self.assertTrue(asyncio.iscoroutinefunction(opsdroid.skills[0]))
+
     async def test_match_witai(self):
         with OpsDroid() as opsdroid:
             intent = "myIntent"

--- a/tests/test_parser_watson.py
+++ b/tests/test_parser_watson.py
@@ -32,6 +32,51 @@ class TestParserWatson(asynctest.TestCase):
         mockedskill.config = {}
         return mockedskill
 
+    async def test_get_all_entities(self):
+        entities = [
+            {
+                "entity": "sys-number",
+                "location": [24, 26],
+                "value": "18",
+                "confidence": 1,
+            },
+            {
+                "entity": "sys-date",
+                "location": [24, 32],
+                "value": "2019-10-18",
+                "confidence": 1,
+            },
+            {
+                "entity": "sys-number",
+                "location": [27, 29],
+                "value": "10",
+                "confidence": 1,
+            },
+            {
+                "entity": "sys-number",
+                "location": [30, 32],
+                "value": "19",
+                "confidence": 1,
+            },
+            {
+                "entity": "sys-time",
+                "location": [33, 39],
+                "value": "15:00:00",
+                "confidence": 1,
+            },
+        ]
+
+        entities_dict = await watson.get_all_entities(entities)
+
+        self.assertEqual(
+            entities_dict,
+            {
+                "sys-number": ["18", "10", "19"],
+                "sys-date": ["2019-10-18"],
+                "sys-time": ["15:00:00"],
+            },
+        )
+
     async def test_get_session_id(self):
         config = {
             "name": "watson",

--- a/tests/test_parser_watson.py
+++ b/tests/test_parser_watson.py
@@ -1,0 +1,289 @@
+import asynctest
+import asynctest.mock as amock
+import unittest.mock as mock
+
+from opsdroid.cli.start import configure_lang
+from opsdroid.core import OpsDroid
+from opsdroid.matchers import match_watson
+from opsdroid.events import Message
+from opsdroid.parsers import watson
+from opsdroid.connector import Connector
+
+from ibm_watson import ApiException
+
+
+class TestParserWatson(asynctest.TestCase):
+    """Test the opsdroid watson parser."""
+
+    async def setup(self):
+        configure_lang({})
+
+    async def getMockSkill(self):
+        async def mockedskill(opsdroid, config, message):
+            pass
+
+        mockedskill.config = {}
+        return mockedskill
+
+    async def getRaisingMockSkill(self):
+        async def mockedskill(opsdroid, config, message):
+            raise Exception()
+
+        mockedskill.config = {}
+        return mockedskill
+
+    async def test_get_session_id(self):
+        config = {
+            "name": "watson",
+            "access-token": "test",
+            "gateway": "gateway",
+            "min-score": 0.3,
+            "assistant-id": "test",
+        }
+        result = mock.Mock()
+        service = mock.MagicMock()
+
+        result.return_value = {"session_id": "test123"}
+
+        service.create_session.return_value.set_result(result)
+
+        await watson.get_session_id(service, config)
+
+        self.assertIn("session-id", config)
+
+    async def test_call_watson(self):
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
+        message = Message("Hello", "user", "default", mock_connector)
+        config = {
+            "name": "watson",
+            "access-token": "test",
+            "gateway": "gateway",
+            "min-score": 0.3,
+            "assistant-id": "test",
+            "session-id": "12ndior2kld",
+        }
+        result = amock.Mock()
+        result.json = amock.CoroutineMock()
+        result.json.return_value = {
+            "output": {
+                "generic": [{"response_type": "text", "text": "Hey hows it going?"}],
+                "intents": [{"intent": "hello", "confidence": 1}],
+                "entities": [
+                    {
+                        "entity": "greetings",
+                        "location": [0, 2],
+                        "value": "hello",
+                        "confidence": 1,
+                    },
+                    {
+                        "entity": "greetings",
+                        "location": [0, 2],
+                        "value": "hi",
+                        "confidence": 1,
+                    },
+                ],
+            }
+        }
+        with mock.patch(
+            "ibm_cloud_sdk_core.authenticators.IAMAuthenticator"
+        ), amock.patch.object(watson, "get_session_id"), mock.patch(
+            "ibm_watson.assistant_v2.AssistantV2.message"
+        ) as mocked_service:
+
+            mocked_service.get_result.return_value.set_result(result)
+
+            await watson.call_watson(message, config)
+
+            self.assertTrue(mocked_service.called)
+            self.assertLogs("_LOGGER", "debug")
+
+    async def test_parse_watson(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [
+                {
+                    "name": "watson",
+                    "access-token": "test",
+                    "gateway": "gateway",
+                    "min-score": 0.3,
+                    "assistant-id": "test",
+                    "session-id": "12ndior2kld",
+                }
+            ]
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(match_watson("hello")(mock_skill))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("hi", "user", "default", mock_connector)
+
+            with amock.patch.object(watson, "call_watson") as mocked_call_watson:
+                mocked_call_watson.return_value = {
+                    "output": {
+                        "generic": [
+                            {"response_type": "text", "text": "Hey hows it going?"}
+                        ],
+                        "intents": [{"intent": "hello", "confidence": 1}],
+                        "entities": [
+                            {
+                                "entity": "greetings",
+                                "location": [0, 2],
+                                "value": "hello",
+                                "confidence": 1,
+                            },
+                            {
+                                "entity": "greetings",
+                                "location": [0, 2],
+                                "value": "hi",
+                                "confidence": 1,
+                            },
+                        ],
+                    }
+                }
+                skills = await watson.parse_watson(
+                    opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
+                )
+                self.assertEqual(mock_skill, skills[0]["skill"])
+
+    async def test_parse_watson_no_intent(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [
+                {
+                    "name": "watson",
+                    "access-token": "test",
+                    "gateway": "gateway",
+                    "min-score": 0.3,
+                    "assistant-id": "test",
+                    "session-id": "12ndior2kld",
+                }
+            ]
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(match_watson("hello")(mock_skill))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message(
+                "how's the weather outside", "user", "default", mock_connector
+            )
+
+            with amock.patch.object(watson, "call_watson") as mocked_call_watson:
+                mocked_call_watson.return_value = {
+                    "output": {
+                        "generic": [
+                            {"response_type": "text", "text": "Hey hows it going?"}
+                        ],
+                        "intents": [],
+                        "entities": [],
+                    }
+                }
+                skills = await watson.parse_watson(
+                    opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
+                )
+                self.assertEqual([], skills)
+                self.assertLogs("_LOGGER", "error")
+
+    async def test_parse_watson_no_confidence(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [
+                {
+                    "name": "watson",
+                    "access-token": "test",
+                    "gateway": "gateway",
+                    "assistant-id": "test",
+                    "session-id": "12ndior2kld",
+                }
+            ]
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(match_watson("hello")(mock_skill))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("hi", "user", "default", mock_connector)
+
+            with amock.patch.object(watson, "call_watson") as mocked_call_watson:
+                mocked_call_watson.return_value = {
+                    "output": {
+                        "generic": [
+                            {"response_type": "text", "text": "Hey hows it going?"}
+                        ],
+                        "intents": [{"intent": "hello"}],
+                        "entities": [],
+                    }
+                }
+                skills = await watson.parse_watson(
+                    opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
+                )
+                self.assertEqual(0.0, skills[0]["score"])
+
+    async def test_parse_watson_low_score(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [
+                {
+                    "name": "watson",
+                    "access-token": "test",
+                    "gateway": "gateway",
+                    "min-score": 0.5,
+                    "assistant-id": "test",
+                    "session-id": "12ndior2kld",
+                }
+            ]
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(match_watson("hello")(mock_skill))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("hi", "user", "default", mock_connector)
+
+            with amock.patch.object(watson, "call_watson") as mocked_call_watson:
+                mocked_call_watson.return_value = {
+                    "output": {
+                        "generic": [
+                            {"response_type": "text", "text": "Hey hows it going?"}
+                        ],
+                        "intents": [{"intent": "hello", "confidence": 0.3}],
+                        "entities": [
+                            {
+                                "entity": "greetings",
+                                "location": [0, 2],
+                                "value": "hello",
+                                "confidence": 1,
+                            },
+                            {
+                                "entity": "greetings",
+                                "location": [0, 2],
+                                "value": "hi",
+                                "confidence": 1,
+                            },
+                        ],
+                    }
+                }
+                skills = await watson.parse_watson(
+                    opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
+                )
+                self.assertEqual([], skills)
+                self.assertLogs("_LOGGER", "info")
+
+    async def test_parse_watson_APIException(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.config["parsers"] = [
+                {
+                    "name": "watson",
+                    "access-token": "test",
+                    "gateway": "gateway",
+                    "min-score": 0.3,
+                    "assistant-id": "test",
+                    "session-id": "12ndior2kld",
+                }
+            ]
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(match_watson("hello")(mock_skill))
+
+            mock_connector = amock.CoroutineMock()
+            message = Message("hi", "user", "default", mock_connector)
+
+            with amock.patch.object(watson, "call_watson") as mocked_call_watson:
+                mocked_call_watson.side_effect = ApiException(
+                    code=404, message="Not Found."
+                )
+
+                skills = await watson.parse_watson(
+                    opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
+                )
+                self.assertEqual([], skills)
+                self.assertLogs("_LOGGER", "error")


### PR DESCRIPTION
# Description

Decided to work on something new and added IBM Watson assistant to opsdroid. Tested the parser and works alright. Watson allows you to have a conversation with the assistant and it follows a logic.

I'm not sure if Watson uses the session id to keep track of the conversation. Initially I was using the session id but when I tried to talk to opsdroid it would crash because Watson api would give an error due to the session id (this is the reason why I'm getting a new session with every parse).

I still need to add the tests to this PR as well.


Fixes #<issue>


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

_Please delete options that are not relevant._

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Ran opsdroid with Watson and dummy hello skill - all working ok
- Ran opsdroid with Watson and default customer entity - all working ok
- Tox - all green

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

