### PR TITLE
chores(webhook): rest-api as baseurl of matechers/webhook link

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -42,7 +42,7 @@ This method returns runtime statistics which could be useful in monitoring.
 
 ### `/skill/{skillname}/{webhookname}` _[POST]_
 
-This method family will call skills which have been decorated with the [webhook matcher](../matchers/webhook). The URI format includes the name of the skill from the `configuration.yaml` and the name of the webhook set in the decorator.
+This method family will call skills which have been decorated with the [webhook matcher](matchers/webhook.md). The URI format includes the name of the skill from the `configuration.yaml` and the name of the webhook set in the decorator.
 
 The response includes information on whether a skill was successfully triggered or not.
 


### PR DESCRIPTION
fix is to remove starting '../' and replace 'webhook', by 'webhook.md'
so mkdocs will generate correct reference to the file.

# Description

One of the urls was left in style of previous errors (not referenced as markdown file), so it keep generating error.

Fixes opsdroid/opsdroid#1120

## Status
**READY**

## Type of change
- Documentation (fix or adds documentation)

# How Has This Been Tested?

with `deadlinks`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)

