### PR TITLE
refactor: Reduce Dockerfile steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ WORKDIR /usr/src/app
 
 # Copy source
 COPY opsdroid opsdroid
-COPY setup.cfg setup.cfg
-COPY README.md README.md
-COPY MANIFEST.in MANIFEST.in
-COPY requirements.txt requirements.txt
 COPY setup.py setup.py
 COPY versioneer.py versioneer.py
+COPY setup.cfg setup.cfg
+COPY requirements.txt requirements.txt
+COPY README.md README.md
+COPY MANIFEST.in MANIFEST.in
 
 RUN apk update \
 && apk add --no-cache gcc musl-dev git openssh-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,19 @@ LABEL maintainer="Jacob Tomlinson <jacob@tom.linson.uk>"
 RUN apk update && apk add --no-cache gcc musl-dev git openssh-client
 
 WORKDIR /usr/src/app
-COPY requirements.txt requirements.txt
-RUN pip3 install --upgrade pip && pip3 install --no-cache-dir --no-use-pep517 .
 
 # Copy source
 COPY opsdroid opsdroid
-COPY setup.py setup.py
-COPY versioneer.py versioneer.py
 COPY setup.cfg setup.cfg
 COPY README.md README.md
 COPY MANIFEST.in MANIFEST.in
- 
-RUN apk del gcc musl-dev
+COPY requirements.txt requirements.txt
+COPY setup.py setup.py
+COPY versioneer.py versioneer.py
+
+RUN pip3 install --upgrade pip \
+&& pip3 install --no-cache-dir --no-use-pep517 . \
+&& apk del gcc musl-dev
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:3.7-alpine
 LABEL maintainer="Jacob Tomlinson <jacob@tom.linson.uk>"
 
-RUN apk update && apk add --no-cache gcc musl-dev git openssh-client
-
 WORKDIR /usr/src/app
 
 # Copy source
@@ -14,7 +12,9 @@ COPY requirements.txt requirements.txt
 COPY setup.py setup.py
 COPY versioneer.py versioneer.py
 
-RUN pip3 install --upgrade pip \
+RUN apk update \
+&& apk add --no-cache gcc musl-dev git openssh-client \
+&& pip3 install --upgrade pip \
 && pip3 install --no-cache-dir --no-use-pep517 . \
 && apk del gcc musl-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
 FROM python:3.7-alpine
 LABEL maintainer="Jacob Tomlinson <jacob@tom.linson.uk>"
 
-RUN apk add --no-cache gcc musl-dev
-RUN mkdir -p /usr/src/app
+RUN apk update && apk add --no-cache gcc musl-dev git openssh-client
+
 WORKDIR /usr/src/app
+COPY requirements.txt requirements.txt
+RUN pip3 install --upgrade pip && pip3 install --no-cache-dir --no-use-pep517 .
 
 # Copy source
 COPY opsdroid opsdroid
 COPY setup.py setup.py
 COPY versioneer.py versioneer.py
 COPY setup.cfg setup.cfg
-COPY requirements.txt requirements.txt
 COPY README.md README.md
 COPY MANIFEST.in MANIFEST.in
-
-RUN apk update && apk add --no-cache git openssh-client
-RUN pip3 install --upgrade pip
-RUN pip3 install --no-cache-dir --no-use-pep517 .
+ 
 RUN apk del gcc musl-dev
 
 EXPOSE 8080


### PR DESCRIPTION
# Reduced Dockerfile steps by removing redundant steps, and chaining commands

Removed some redundant lines in the Dockerfile. `WORKDIR` will create a directory if it doesn't exist, meaning the `RUN` line above is unneeded.

Also chained together some of the `RUN` commands together to reduce the total number of layers in the Dockerfile. Docker will create a new layer per command line, which increases build time. By chaining these commands together you can reduce build time + cache some dependencies so that don't have to rebuild the dependencies on a code change.

Happy Hacktoberfest 🎃 

## Status
**READY** 


## Type of change

_Please delete options that are not relevant._
- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- `docker build -t <name> .`
- `docker run -t <name>`


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

