### PR TITLE
Fixes schema.yaml and matrix connector to allow connections to selfho…

### DIFF
--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -1,6 +1,6 @@
 # opsdroid connector Matrix
 
-A connector for [opsdroid](https://github.com/opsdroid/opsdroid) to receive and respond to messages in [Matrix](https://matrix.org/) rooms.
+A connector for [opsdroid](https://github.com/opsdroid/opsdroid) to receive and respond to messages in [Matrix](https://matrix.org/) rooms. 
 
 Maintained by [@SolarDrew](https://github.com/SolarDrew).
 
@@ -16,11 +16,13 @@ connectors:
     # Required
     mxid: "@username:matrix.org"
     password: "mypassword"
-    # a dictionary of rooms to connect to, at least one is needed
-    # # a dictionary of multiple rooms
+    # Name of a single room to connect to
+    room: "#matrix:matrix.org"
+    # Alternatively, a dictionary of multiple rooms
+    # One of these should be named 'main'
     rooms:
-      - '#matrix:matrix.org'
-      - '#riot:matrix.org'
+      'main': '#matrix:matrix.org'
+      'other': '#riot:matrix.org'
     # Optional
     homeserver: "https://matrix.org"
     nick: "Botty McBotface"  # The nick will be set on startup

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -16,10 +16,8 @@ connectors:
     # Required
     mxid: "@username:matrix.org"
     password: "mypassword"
-    # Name of a single room to connect to
-    room: "#matrix:matrix.org"
-    # Alternatively, a dictionary of multiple rooms
-    # One of these should be named 'main'
+    # A dictionary of rooms to connect to
+    # One of these have to be named 'main'
     rooms:
       'main': '#matrix:matrix.org'
       'other': '#riot:matrix.org'

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -1,6 +1,6 @@
 # opsdroid connector Matrix
 
-A connector for [opsdroid](https://github.com/opsdroid/opsdroid) to receive and respond to messages in [Matrix](https://matrix.org/) rooms. 
+A connector for [opsdroid](https://github.com/opsdroid/opsdroid) to receive and respond to messages in [Matrix](https://matrix.org/) rooms.
 
 Maintained by [@SolarDrew](https://github.com/SolarDrew).
 
@@ -16,13 +16,11 @@ connectors:
     # Required
     mxid: "@username:matrix.org"
     password: "mypassword"
-    # Name of a single room to connect to
-    room: "#matrix:matrix.org"
-    # Alternatively, a dictionary of multiple rooms
-    # One of these should be named 'main'
+    # a dictionary of rooms to connect to, at least one is needed
+    # # a dictionary of multiple rooms
     rooms:
-      'main': '#matrix:matrix.org'
-      'other': '#riot:matrix.org'
+      - '#matrix:matrix.org'
+      - '#riot:matrix.org'
     # Optional
     homeserver: "https://matrix.org"
     nick: "Botty McBotface"  # The nick will be set on startup

--- a/opsdroid/configuration/schema.yaml
+++ b/opsdroid/configuration/schema.yaml
@@ -68,18 +68,13 @@ github:
 ---
 matrix:
   name: regex('^(?i)matrix$')
-  mxid: regex('^\@[a-zA-Z]*:matrix.org$')
+  mxid: str()
   password: str()
-  room: str()
-  rooms: (include('room1'))
-  homeserver: regex('^https://matrix.org$')
+  rooms: list(str(), required=True)
+  homeserver: str()
   nick: str(required=False)
   room_specific_nicks: bool(required=False)
   send_m_notice: bool(required=False)
----
-room1:
-  'main': regex('^#matrix:matrix.org')
-  'other': regex('^#riot:matrix.org$')
 ---
 slack:
   name: regex('^(?i)slack$')

--- a/opsdroid/configuration/schema.yaml
+++ b/opsdroid/configuration/schema.yaml
@@ -70,7 +70,6 @@ matrix:
   name: regex('^(?i)matrix$')
   mxid: str()
   password: str()
-  room: str(required=False)
   rooms: (include('room1'))
   homeserver: str()
   nick: str(required=False)

--- a/opsdroid/configuration/schema.yaml
+++ b/opsdroid/configuration/schema.yaml
@@ -79,7 +79,6 @@ matrix:
 ---
 room1:
   'main': str()
-  'other': str()
 ---
 slack:
   name: regex('^(?i)slack$')

--- a/opsdroid/configuration/schema.yaml
+++ b/opsdroid/configuration/schema.yaml
@@ -70,11 +70,16 @@ matrix:
   name: regex('^(?i)matrix$')
   mxid: str()
   password: str()
-  rooms: list(str(), required=True)
+  room: str(required=False)
+  rooms: (include('room1'))
   homeserver: str()
   nick: str(required=False)
   room_specific_nicks: bool(required=False)
   send_m_notice: bool(required=False)
+---
+room1:
+  'main': str()
+  'other': str()
 ---
 slack:
   name: regex('^(?i)slack$')

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -31,8 +31,6 @@ class ConnectorMatrix(Connector):
 
         self.name = "ConnectorMatrix"  # The name of your connector
         self.rooms = config.get("rooms", None)
-        if not self.rooms:
-            self.rooms = {"main": config["room"]}
         self.room_ids = {}
         self.default_target = self.rooms["main"]
         self.mxid = config["mxid"]

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -30,7 +30,7 @@ class ConnectorMatrix(Connector):
         super().__init__(config, opsdroid=opsdroid)
 
         self.name = "ConnectorMatrix"  # The name of your connector
-        self.rooms = config.get("rooms", None)
+        self.rooms = config["rooms"]
         self.room_ids = {}
         self.default_target = self.rooms["main"]
         self.mxid = config["mxid"]

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -31,10 +31,8 @@ class ConnectorMatrix(Connector):
 
         self.name = "ConnectorMatrix"  # The name of your connector
         self.rooms = config.get("rooms", None)
-        if not self.rooms:
-            self.rooms = {"main": config["room"]}
         self.room_ids = {}
-        self.default_target = self.rooms["main"]
+        self.default_target = self.rooms[0]
         self.mxid = config["mxid"]
         self.nick = config.get("nick", None)
         self.homeserver = config.get("homeserver", "https://matrix.org")
@@ -84,9 +82,9 @@ class ConnectorMatrix(Connector):
         mapi.token = login_response["access_token"]
         mapi.sync_token = None
 
-        for roomname, room in self.rooms.items():
+        for room in self.rooms:
             response = await mapi.join_room(room)
-            self.room_ids[roomname] = response["room_id"]
+            self.room_ids[room] = response["room_id"]
         self.connection = mapi
 
         # Create a filter now, saves time on each later sync

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -31,8 +31,10 @@ class ConnectorMatrix(Connector):
 
         self.name = "ConnectorMatrix"  # The name of your connector
         self.rooms = config.get("rooms", None)
+        if not self.rooms:
+            self.rooms = {"main": config["room"]}
         self.room_ids = {}
-        self.default_target = self.rooms[0]
+        self.default_target = self.rooms["main"]
         self.mxid = config["mxid"]
         self.nick = config.get("nick", None)
         self.homeserver = config.get("homeserver", "https://matrix.org")
@@ -82,9 +84,9 @@ class ConnectorMatrix(Connector):
         mapi.token = login_response["access_token"]
         mapi.sync_token = None
 
-        for room in self.rooms:
+        for roomname, room in self.rooms.items():
             response = await mapi.join_room(room)
-            self.room_ids[room] = response["room_id"]
+            self.room_ids[roomname] = response["room_id"]
         self.connection = mapi
 
         # Create a filter now, saves time on each later sync

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -21,7 +21,7 @@ def setup_connector():
     """Initiate a basic connector setup for testing on"""
     connector = ConnectorMatrix(
         {
-            "room": "#test:localhost",
+            "rooms": {"main": "#test:localhost"},
             "mxid": "@opsdroid:localhost",
             "password": "hello",
             "homeserver": "http://localhost:8008",

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -21,7 +21,7 @@ def setup_connector():
     """Initiate a basic connector setup for testing on"""
     connector = ConnectorMatrix(
         {
-            "rooms": ["#test:localhost"],
+            "room": "#test:localhost",
             "mxid": "@opsdroid:localhost",
             "password": "hello",
             "homeserver": "http://localhost:8008",
@@ -273,7 +273,7 @@ class TestConnectorMatrixAsync(asynctest.TestCase):
             patched_room_id.return_value = asyncio.Future()
             patched_room_id.return_value.set_result(message.target)
 
-            message.target = "#test:localhost"
+            message.target = "main"
             await self.connector.send(message)
 
             message_obj = self.connector._get_formatted_message_body(message.text)

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -21,7 +21,7 @@ def setup_connector():
     """Initiate a basic connector setup for testing on"""
     connector = ConnectorMatrix(
         {
-            "room": "#test:localhost",
+            "rooms": ["#test:localhost"],
             "mxid": "@opsdroid:localhost",
             "password": "hello",
             "homeserver": "http://localhost:8008",
@@ -273,7 +273,7 @@ class TestConnectorMatrixAsync(asynctest.TestCase):
             patched_room_id.return_value = asyncio.Future()
             patched_room_id.return_value.set_result(message.target)
 
-            message.target = "main"
+            message.target = "#test:localhost"
             await self.connector.send(message)
 
             message_obj = self.connector._get_formatted_message_body(message.text)


### PR DESCRIPTION
…sted matrix homeserver

# Description

Changes parsing of matrix connector config to allow self-hosted matrix homeservers

Fixes #1159


## Status
**READY**

## Type of change

- Bug fix


# How Has This Been Tested?

Tested with the following configuration that connected to my own matrix homeserver:

```
## Set the logging level
logging:
  level: info
  path: opsdroid.log
  console: true

## Show welcome message
welcome-message: true

## Connector modules
connectors:

  ## Matrix (core)
  - name: matrix
    # Required
    mxid: "@xxx:example.com"
    password: "xxx"
    # a dictionary of multiple rooms, at least one is needed
    rooms:
      - '#xxx:example.com'
      - '#xxx2:example.com'
    homeserver: "https://example.com"
    nick: "xxx"  # The nick will be set on startup
    room_specific_nicks: False  # Look up room specific nicknames of senders (expensive in large rooms)

## Skill modules
skills:
  ## Hello (https://github.com/opsdroid/skill-hello)
  - name: hello
```


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

