### PR TITLE
Increase loader coverage

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -321,9 +321,9 @@ class Loader:
         """
 
         try:
-            yaml_loader = yaml.CSafeLoader
+            cls.yaml_loader = yaml.CSafeLoader
         except AttributeError:
-            yaml_loader = yaml.SafeLoader
+            cls.yaml_loader = yaml.SafeLoader
 
         config_path = ""
         for possible_path in config_paths:

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -43,11 +43,6 @@ _LOGGER = logging.getLogger(__name__)
 class Loader:
     """Class to load in config and modules."""
 
-    try:
-        yaml_loader = yaml.CSafeLoader
-    except AttributeError:
-        yaml_loader = yaml.SafeLoader
-
     def __init__(self, opsdroid):
         """Create object with opsdroid instance."""
         self.opsdroid = opsdroid
@@ -324,6 +319,12 @@ class Loader:
             dict: Dict containing config fields
 
         """
+
+        try:
+            yaml_loader = yaml.CSafeLoader
+        except AttributeError:
+            yaml_loader = yaml.SafeLoader
+
         config_path = ""
         for possible_path in config_paths:
             if not os.path.isfile(possible_path):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -33,6 +33,22 @@ class TestLoader(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self._tmp_dir, onerror=del_rw)
 
+    def test_yaml_loader_exception(self):
+        ld2 = ld
+
+        with contextlib.suppress(AttributeError):
+            csafeloader = ld2.yaml.CSafeLoader
+            safeloader = ld2.yaml.SafeLoader
+            del ld2.yaml.CSafeLoader
+
+            ld2.Loader.load_config_file([os.path.abspath("tests/configs/minimal.yaml")])
+            self.assertEqual(ld2.Loader.yaml_loader, safeloader)
+            del ld2
+
+            ld.yaml.CSafeLoader = csafeloader
+            ld.Loader.load_config_file([os.path.abspath("tests/configs/minimal.yaml")])
+            self.assertEqual(ld.Loader.yaml_loader, csafeloader)
+
     def test_load_config_file(self):
         opsdroid, loader = self.setup()
         config = loader.load_config_file(


### PR DESCRIPTION
# Description

I moved the yaml_loader setting to the only method using it and added a test that simply deletes the CSafeLoader attribute to force the AttributeError which gets us the missing 2 lines of coverage


## Status
**READY**

## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- tox


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

