### PR TITLE
Adding steps to work on Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ $ sudo pip3 install opsdroid
 $ opsdroid start
 ```
 
+### Windows 10
+
+```powershell
+# Install Python from https://www.python.org/downloads/
+# Launch powershell command prompt
+
+# Install opsdroid
+C:\Users\myaccount> pip install opsdroid
+
+# Create a starting configuration to work with
+C:\Users\myaccount> opsdroid config gen | out-file "configuration.yaml" -encoding utf8
+
+# Start opsdroid
+C:\Users\myaccount> opsdroid start
+```
+
+
 ## Usage
 
 When running the `opsdroid` command with no arguments the bot framework will start using the configuration in `~/.opsdroid/configuration.yaml`. Beginners should check out the [introduction tutorial](http://opsdroid.readthedocs.io/en/stable/tutorials/introduction/) for information on how to configure opsdroid.


### PR DESCRIPTION
# Description

In order to start using this on Windows their is a unique step due to how windows saves files when doing a redirection by default into UTF-16LE.   This is not readable by opsdroid when starting.   A clarification of how to do it for those wanting to use Windows would be helpful.   

## Status
**READY**


## Type of change

- Documentation (fix or adds documentation)


# How Has This Been Tested?

Ran this a couple times in my environment to confirm this creates a good starting version tied with issue #1189 fix in place.  

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

