### PR TITLE
Add examples section

### DIFF
--- a/docs/examples/introduction.md
+++ b/docs/examples/introduction.md
@@ -1,0 +1,5 @@
+# Example skills
+
+This section contains examples of the many things you can do with skills in opsdroid. Select an example from the menu to see the full source and instructions.
+
+For introductory tutorials, see our [tutorials section](../tutorials./introduction.md). You can also find detailed information on how skills are structured in the [extending opsdroid documentation](../extending/skills.md).

--- a/docs/examples/weather.md
+++ b/docs/examples/weather.md
@@ -1,37 +1,47 @@
 # Creating a Weather Skill
-We will create a skill, that will make opsdroid tell us the current weather in a town. This skill will be quite similar to the [official weather](https://github.com/opsdroid/skill-weather) skill that can be found in the opsdroid repo.
+
+We will create a skill, that will make opsdroid tell us the current weather in a town.
 
 This tutorial will use the  [OpenWeatherMap](https://openweathermap.org) API to get the weather information from a city. We will only need the free version of the API, so register and get your key from the [API](https://openweathermap.org/price) menu.
 
 *If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
 
 ## Setting Up
+
 In the tutorial, you can choose the city that you want the weather information about and which system to use (metric or imperial). These settings will be specified in our opsdroid `configuration.yaml` file.
 
 Our `__init__.py` init file will contain two functions, one that interacts with the OpenWeatherMap API and one that opsdroid will use to tell us the weather in our city.
 
-
 ## Building the Skill
+
 We are ready to start working on our skills. First, you need to create a folder for the weather skill. Choose a location and name it weather-skill.
+
+```bash
+mkdir /path/to/my/weather-skill
+```
+
+### Configuration
 
 Now, let's open opsdroid `configuration.yaml` file and add our weather skill to the skills section.
 
 ```yaml
 skills:
   - name: weather
-    city: < Your city, your country >     # For accuracy use {city},{country code}
-    units: < metric/imperial >       # Choose metric/imperial
-    api-key: < Your Api Key >
+    city: <Your city, your country>     # For accuracy use {city},{country code}
+    units: <metric/imperial>       # Choose metric/imperial
+    api-key: <Your Api Key>
     # Developing the skill
-    path: < full path of your weather-skill folder >
+    path: /path/to/my/weather-skill
     no-cache: true
 ```
+
 _Note: We will need to set `no-cache` to true, in order to tell opsdroid to install the skill on every opsdroid run._
 
 #### Weather Skill
-Now that our skill has all the configuration details set up in the `configuration.yaml` file, let's create the `__init__.py` inside our weather-skill folder and start working on the skill.
 
-The first thing we need to do, is to import the skill class and the regex_matcher from opsdroid and the aiohttp module. Your `__init__.py` file should look like this:
+Now that our skill has all the configuration details set up in the `configuration.yaml` file, let's create the `__init__.py` inside our `weather-skill` folder and start working on the skill.
+
+The first thing we need to do is to import the `Skill` class and the `regex_matcher` from opsdroid and the `aiohttp` module. Your `__init__.py` file should look like this:
 
 ```python
 from opsdroid.skill import Skill
@@ -41,6 +51,7 @@ import aiohttp
 ```
 
 #### Get Weather Data
+
 Now we need to get the weather data from OpenWeatherMap. Let's create an asynchronous function to get the weather data.
 
 If you read the [current weather data](https://openweathermap.org/current) documentation from OpenWeatherMap, you will see that the API endpoint that we need to use is `http://api.openweathermap.org/data/2.5/weather?q=`
@@ -59,11 +70,12 @@ async def get_weather(config):
 ```
 
 We will need to pass the following things to OpenWeatherMap:
+
 - City
 - Units
 - API-key
 
-Since these details are already in our opsdroid `configuration.yaml` we can simply get them from the config.
+Since these details are already in our opsdroid `configuration.yaml` we can get them from the config.
 
 Make your function look like this:
 
@@ -73,7 +85,8 @@ async def get_weather(config):
     parameters = "{}&units={}&appid={}".format(
         config['city'], config['units'], config['api-key'])
 ```
-If we join `api_url` and `parameters`  we get the full URL that we need to get our weather data. We will now use aiohttp to start a session and get the data from OpenWeatherMap.
+
+If we join `api_url` and `parameters`  we get the full URL that we need to get our weather data. We will now use `aiohttp` to start a session and get the data from OpenWeatherMap.
 
 Your function should look like this now:
 
@@ -87,7 +100,7 @@ async def get_weather(config):
         response = await session.get(api_url + parameters)
 ```
 
-Our `get_weather` function is starting to look good. What's left to do is returning our response in a JSON format. Luckily aiohttp makes that quite easy for us, all we need to do is add `.json()` to our response.
+Our `get_weather` function is starting to look good. What's left to do is returning our response in a JSON format. Luckily `aiohttp` makes that quite easy for us, all we need to do is add `.json()` to our response.
 
 Make our function to look like this:
 
@@ -101,7 +114,8 @@ async def get_weather(config):
         response = await session.get(api_url + parameters)
     return await response.json()
 ```
-Now when we call our `get_weather` function, aiohttp will get all the data from the OpenWeatherMap API and return it to us in a json format.
+
+Now when we call our `get_weather` function, `aiohttp` will get all the data from the OpenWeatherMap API and return it to us as a Python dictionary.
 
 `response.json()` will give us something that looks like this:
 
@@ -156,11 +170,11 @@ Now when we call our `get_weather` function, aiohttp will get all the data from 
  }
 ```
 
-
-That's all we need to do. Now if we call our function we will be able to get our weather data. The next step is to make opsdroid tell us the current weather.
+Now if we call our function we will be able to get our weather data. The next step is to make opsdroid tell us the current weather.
 
 #### Tell the Weather
-This skill is quite easy to understand and it will simply call our `get_weather` function and then get the details from our weather data.
+
+This skill will call our `get_weather` function and then get the details from our weather data.
 
 We also need to decorate the skill with our chosen matcher (regex in this case).
 
@@ -190,7 +204,7 @@ class WeatherSkill(Skill):
         pass
 ```
 
-We need to chose what should trigger opsdroid to tell us the weather. Let's make opsdroid trigger when we type `How's the weather`.
+We need to chose what should trigger opsdroid to tell us the weather. Let's make opsdroid trigger when we type `How's the weather?`.
 
 ```python
 class WeatherSkill(Skill):
@@ -263,6 +277,3 @@ class WeatherSkill(Skill):
 
         await message.respond("It's {} and {}% humidity in {}.".format(temp, humidity, city))
 ```
-
-Hopefully this tutorial was helpful to you.
-

--- a/docs/extending/skills.md
+++ b/docs/extending/skills.md
@@ -135,9 +135,6 @@ This means that if you decorate a skill with both the `regex` and `dialogflow` m
 
 ## Example modules
 
-See the following official modules for examples:
-
- * [hello](https://github.com/opsdroid/skill-hello) - A simple hello world skill.
- * [seen](https://github.com/opsdroid/skill-seen) - Makes use of opsdroid memory.
+For examples of the kind of skill you can build in opsdroid see the [examples section](../examples/introduction.md).
 
 *If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*

--- a/docs/tutorials/basic-skill.md
+++ b/docs/tutorials/basic-skill.md
@@ -100,3 +100,5 @@ skills:
 ```
 
 As mentioned in the [introduction](introduction.md), the indentation and the use of spaces instead of tabs is very important. If you have any issues when running opsdroid check both of these things; it might be a problem with space.
+
+For more examples of skills you can build with opsdroid checkout our [examples section](../examples/introduction.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ pages:
               - "Create a Basic Skill": "tutorials/basic-skill.md"
               - "Introduction to Vim": "tutorials/introduction-vim.md"
       - "Example Skills":
+              - "Introduction": "examples/introduction.md"
               - "Weather": "examples/weather.md"
       - "Extending opsdroid":
               - "Introduction": "extending/intro.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,54 +3,55 @@ repo_url: https://github.com/opsdroid/opsdroid
 theme: readthedocs
 
 pages:
-    - "Home": "index.md"
-    - "Configuration Reference": "configuration-reference.md"
-    - "REST API": "rest-api.md"
-    - "Tutorial":
-          - "Introduction": "tutorials/introduction.md"
-          - "Create a Basic Skill": "tutorials/basic-skill.md"
-          - "Create a Weather Skill": "tutorials/create-weather-skill.md"
-          - "Introduction to Vim": "tutorials/introduction-vim.md"
-    - "Extending opsdroid":
-          - "Introduction": "extending/intro.md"
-          - "Adding skills": "extending/skills.md"
-          - "Adding connectors": "extending/connectors.md"
-          - "Adding databases": "extending/databases.md"
-          - "Using Events": "extending/events.md"
-          - "Extension packaging": "extending/packaging.md"
-    - "Connectors":
-          - "Facebook": "connectors/facebook.md"
-          - "GitHub": "connectors/github.md"
-          - "Gitter": "connectors/gitter.md"
-          - "Matrix": "connectors/matrix.md"
-          - "Rocket.Chat": "connectors/rocketchat.md"
-          - "Shell": "connectors/shell.md"
-          - "Slack": "connectors/slack.md"
-          - "Telegram": "connectors/telegram.md"
-          - "Webex Teams": "connectors/webexteams.md"
-          - "Websocket": "connectors/websocket.md"
-    - "Databases":
-          - "MongoDB": "databases/mongo.md"
-          - "Redis": "databases/redis.md"
-          - "SQLite": "databases/sqlite.md"
-    - "Matchers":
-          - "Simple":
-                - "Parse Format": "matchers/parse_format.md"
-                - "Regular Expressions": "matchers/regex.md"
-          - "Third party NLU":
-                - "Dialogflow (Api.ai)": "matchers/dialogflow.md"
-                - "LUIS.AI": "matchers/luis.ai.md"
-                - "Rasa NLU (local)": "matchers/rasanlu.md"
-                - "Recast.AI (SAPCAI)": "matchers/sapcai.md"
-                - "wit.ai": "matchers/wit.ai.md"
-          - "Misc":
-                - "Always": "matchers/always.md"
-                - "Crontab": "matchers/crontab.md"
-                - "Event": "matchers/event.md"
-                - "Webhook": "matchers/webhook.md"
-    - "Constraints": "constraints.md"
-    - "Contributing": "contributing.md"
-    - "Project":
-          - "Supported Python Versions": "project/supported-python-versions.md"
-          - "Releasing": "project/making-a-release.md"
-          - "Maintainers Guide": "maintainers.md"
+      - "Home": "index.md"
+      - "Configuration Reference": "configuration-reference.md"
+      - "REST API": "rest-api.md"
+      - "Tutorial":
+              - "Introduction": "tutorials/introduction.md"
+              - "Create a Basic Skill": "tutorials/basic-skill.md"
+              - "Introduction to Vim": "tutorials/introduction-vim.md"
+      - "Example Skills":
+              - "Weather": "examples/weather.md"
+      - "Extending opsdroid":
+              - "Introduction": "extending/intro.md"
+              - "Adding skills": "extending/skills.md"
+              - "Adding connectors": "extending/connectors.md"
+              - "Adding databases": "extending/databases.md"
+              - "Using Events": "extending/events.md"
+              - "Extension packaging": "extending/packaging.md"
+      - "Connectors":
+              - "Facebook": "connectors/facebook.md"
+              - "GitHub": "connectors/github.md"
+              - "Gitter": "connectors/gitter.md"
+              - "Matrix": "connectors/matrix.md"
+              - "Rocket.Chat": "connectors/rocketchat.md"
+              - "Shell": "connectors/shell.md"
+              - "Slack": "connectors/slack.md"
+              - "Telegram": "connectors/telegram.md"
+              - "Webex Teams": "connectors/webexteams.md"
+              - "Websocket": "connectors/websocket.md"
+      - "Databases":
+              - "MongoDB": "databases/mongo.md"
+              - "Redis": "databases/redis.md"
+              - "SQLite": "databases/sqlite.md"
+      - "Matchers":
+              - "Simple":
+                      - "Parse Format": "matchers/parse_format.md"
+                      - "Regular Expressions": "matchers/regex.md"
+              - "Third party NLU":
+                      - "Dialogflow (Api.ai)": "matchers/dialogflow.md"
+                      - "LUIS.AI": "matchers/luis.ai.md"
+                      - "Rasa NLU (local)": "matchers/rasanlu.md"
+                      - "Recast.AI (SAPCAI)": "matchers/sapcai.md"
+                      - "wit.ai": "matchers/wit.ai.md"
+              - "Misc":
+                      - "Always": "matchers/always.md"
+                      - "Crontab": "matchers/crontab.md"
+                      - "Event": "matchers/event.md"
+                      - "Webhook": "matchers/webhook.md"
+      - "Constraints": "constraints.md"
+      - "Contributing": "contributing.md"
+      - "Project":
+              - "Supported Python Versions": "project/supported-python-versions.md"
+              - "Releasing": "project/making-a-release.md"
+              - "Maintainers Guide": "maintainers.md"


### PR DESCRIPTION
I've added a new section to the documentation for skill examples. I've also moved the weather example from the tutorials section to be the first example. I gave it a little tidy up while I was at it.

My plan is to encourage folks to write up all the existing skills as examples (that was the point in them in the first place). 

My general feeling is that most opsdroid users will be writing their own skills and are not so interested in a set of "official skills". The clone stats on the skills back up this assumption.

Therefore I think it would be more useful for people to have a set of examples that they can copy/pasta from when writing their own things. Once this is in I'll raise some issues to get people writing more examples.