### PR TITLE
Format for reading configuration.yaml needs to be ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ $ opsdroid start
 C:\Users\myaccount> pip install opsdroid
 
 # Create a starting configuration to work with
-C:\Users\myaccount> opsdroid config gen | out-file "configuration.yaml" -encoding utf8
+C:\Users\myaccount> opsdroid config gen | out-file "configuration.yaml" -encoding ascii
 
 # Start opsdroid
 C:\Users\myaccount> opsdroid start


### PR DESCRIPTION
# Description

Format for reading configuration.yaml needs to be ascii instead of utf8 today.   Development environment was corrupted in testing.  


## Status
**READY**


## Type of change

- Documentation (fix or adds documentation)


# How Has This Been Tested?

Tested again locally.   Could use some 3rd party validations.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

