### PR TITLE
Slack connector ignore message edits

### DIFF
--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -90,6 +90,10 @@ class ConnectorSlack(Connector):
         """Process a raw message and pass it to the parser."""
         message = payload["data"]
 
+        # Ignore message edits
+        if "subtype" in message and message["subtype"] == "message_changed":
+            return
+
         # Ignore own messages
         if (
             "subtype" in message


### PR DESCRIPTION
# Description

Since switching to the new Slack library it seems that the parse message code matches more events. Notably here it also matched the `message_changed` event which is triggered when a user edits a message. For now I've added some code here to ignore edits as it could be confusing in a conversation flow if a user repeatedly edits their message.

In future we may want to trigger a message edited event instead, but that needs more thinking about.

Fixes #1217


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Run opsdroid locally with dance skill enabled. When you say dance the bot responds with a link to a gif. Slack automatically replaces the link with the actual gif and this is treated as an edit event. Before this change opsdroid would crash at this stage but now it is fine and ignores the edit.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

