### PR TITLE
Remove await from Slack disconnect

### DIFF
--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -87,7 +87,7 @@ class ConnectorSlack(Connector):
 
     async def disconnect(self):
         """Disconnect from Slack."""
-        await self.slack_rtm.stop()
+        self.slack_rtm.stop()
         self.listening = False
 
     async def listen(self):


### PR DESCRIPTION
`slack.RTMClient.stop` is not an async function but instead dispatches to the event loop asyncronously. Therefore it doesn't need to be awaited. By awaiting it we actually end up awaiting the return of the function which is `None` and therefore raises an error as you can't await `None`.

I've tested this locally and everything seems ok.

Fixes #1239 