### PR TITLE
Fix webhook class skills and update docs

### DIFF
--- a/docs/matchers/webhook.md
+++ b/docs/matchers/webhook.md
@@ -1,19 +1,20 @@
 # Webhook Matcher
 
-**Config**
+The webhook matcher allows you to trigger the skill by calling a specific URL endpoint.
+
+**Example Config**
 
 ```yaml
 skills:
   - name: "exampleskill"
+    path: "/path/to/my/exampleskill"
 ```
-
-The above skill would be called if you send a POST to `http://localhost:8080/skill/exampleskill/examplewebhook`. As the skill is being triggered by a webhook the `message` argument being passed in will be set to the [aiohttp Request](http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.BaseRequest), this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_target` properties to get some sensible defaults.
-
-Similar to the [crontab](crontab.md) matcher this matcher doesn't take a message as an input, it takes a webhook instead. It allows you to trigger the skill by calling a specific URL endpoint.
 
 ## Example
 
 ```python
+# /path/to/my/exampleskill/__init__.py
+
 from aiohttp.web import Request
 
 from opsdroid.skill import Skill
@@ -22,17 +23,15 @@ from opsdroid.events import Message
 
 class MySkill(Skill):
     @match_webhook('examplewebhook')
-    async def mywebhookskill(self, message):
+    async def mywebhookskill(self, event: Request):
+        # Capture the post data
+        data = await event.json()
 
-        if type(message) is not Message and type(message) is Request:
-          # Capture the request POST data and set message to a default message
-          request = await message.post()
-          message = Message("", None, self.opsdroid.connector.default_target,
-                            self.opsdroid.default_connector)
-
-        # Respond
-        await message.respond('Hey')
+        # Respond with the data in the default room on the default connector
+        await self.opsdroid.send(Message(str(data)))
 ```
+
+The above skill would be called if you send a POST to `http://localhost:8080/skill/exampleskill/examplewebhook`. The skill is being triggered by a webhook and so the `event` argument being passed in will be set to the [aiohttp Request](http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.BaseRequest) object. You may also want to trigger actions to happen in a chat connector, for this you can use `opsdroid.send` to send a message to the default target in the default connector. You could also explore the `opsdroid.connectors` list and call `connector.send` on a specific connector.
 
 ## Custom Responses
 
@@ -47,15 +46,13 @@ from opsdroid.events import Message
 
 class MySkill(Skill):
     @match_webhook('examplewebhook')
-    async def mywebhookskill(self, message):
+    async def mywebhookskill(self, event: Request):
+        # Capture the post data
+        data = await event.json()
 
-        if type(message) is not Message and type(message) is Request:
-          # Capture the request POST data and set message to a default message
-          request = await message.post()
-          message = Message("", None, self.opsdroid.connector.default_target,
-                            self.opsdroid.default_connector)
+        # Respond with the data in the default room on the default connector
+        await self.opsdroid.send(Message(str(data)))
 
-        # Respond
-        await message.respond('Hey')
+        # Send a custom aiohttp.web.Response object back to the webhook
         return Response(body='my custom response', status=201)
 ```

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -390,9 +390,9 @@ class OpsDroid:
         # give a response to the user, so an error response should be given.
         try:
             if len(inspect.signature(skill).parameters.keys()) > 1:
-                await skill(self, config, event)
+                return await skill(self, config, event)
             else:
-                await skill(event)
+                return await skill(event)
         except Exception:
             _LOGGER.exception(
                 _("Exception when running skill '%s' "), str(config["name"])

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -130,7 +130,7 @@ class Web:
             """Wrap up the aiohttp handler."""
             _LOGGER.info(_("Running skill %s via webhook"), webhook)
             opsdroid.stats["webhooks_called"] = opsdroid.stats["webhooks_called"] + 1
-            resp = await skill(opsdroid, config, req)
+            resp = await opsdroid.run_skill(skill, config, req)
             if isinstance(resp, web.Response):
                 return resp
             return Web.build_response(200, {"called_skill": webhook})


### PR DESCRIPTION
Made some tweaks to the webhook functionality to call `opsdroid.run_skill` instead of running the skill itself. This allows for class skills to follow the `skill(self, event)` interface instead of the `skill(self, opsdroid, config, event)` interface.

I've also updated the docs with a much simpler example that makes use of `opsdroid.send`.