### PR TITLE
Make no-cache the default for local skills

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -247,7 +247,7 @@ logging:
   level: info
   path: ~/.opsdroid/output.log
   console: true
-  filter: 
+  filter:
     whitelist:
       - "opsdroid.core"
       - "opsdroid.logging"
@@ -269,7 +269,7 @@ logging:
   level: info
   path: ~/.opsdroid/output.log
   console: true
-  filter: 
+  filter:
     blacklist:
       - "opsdroid.loader"
       - "aiosqlite"
@@ -305,7 +305,7 @@ INFO opsdroid.web: Started web server on http://0.0.0.0:8080
 _Note: You can also use the extended mode to filter out logs - this should allow you to have even more flexibility while dealing with your logs._
 
 ##### Using both whitelist and blacklist filter
-You are only able to filter either with the whitelist filter or the blacklist filter. If you add both in your configuration file, you will get a warning 
+You are only able to filter either with the whitelist filter or the blacklist filter. If you add both in your configuration file, you will get a warning
 and only the whitelist filter will be used. This behavior was done because setting two filters causes an RuntimeError exception to be raised(_maximum recursion depth exceeded_).
 
 ```yaml
@@ -313,7 +313,7 @@ logging:
   level: info
   path: ~/.opsdroid/output.log
   console: true
-  filter: 
+  filter:
     whitelist:
       - "opsdroid.core"
       - "opsdroid.logging"
@@ -496,7 +496,8 @@ skills:
 
 ### Disable Caching
 
-Set `no-cache` to true to do a fresh git clone of the module whenever you start opsdroid.
+Set `no-cache` to true to do a fresh git clone of the module whenever you start opsdroid. This will
+default to `true` for modules configured with a local `path`.
 
 ```yaml
 databases:

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -114,8 +114,8 @@ class Loader:
         _LOGGER.error(_("Failed to load %s: %s"), config["type"], config["module_path"])
         return None
 
-    @staticmethod
-    def check_cache(config):
+    @classmethod
+    def check_cache(cls, config):
         """Remove module if 'no-cache' set in config.
 
         Args:
@@ -124,10 +124,29 @@ class Loader:
         """
         if "no-cache" in config and config["no-cache"]:
             _LOGGER.debug(_("'no-cache' set, removing %s"), config["install_path"])
-            if os.path.isdir(config["install_path"]):
-                shutil.rmtree(config["install_path"])
-            if os.path.isfile(config["install_path"] + ".py"):
-                os.remove(config["install_path"] + ".py")
+            cls.remove_cache(config)
+
+        if "no-cache" not in config and cls._is_local_module(config):
+            _LOGGER.debug(
+                _(
+                    "Removing cache for local module %s, set 'no-cache: false' to disable this."
+                ),
+                config["install_path"],
+            )
+            cls.remove_cache(config)
+
+    @staticmethod
+    def remove_cache(config):
+        """Remove module cache.
+
+        Args:
+            config: dict of config information related to the module
+
+        """
+        if os.path.isdir(config["install_path"]):
+            shutil.rmtree(config["install_path"])
+        if os.path.isfile(config["install_path"] + ".py"):
+            os.remove(config["install_path"] + ".py")
 
     @staticmethod
     def is_builtin_module(config):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -298,6 +298,28 @@ class TestLoader(unittest.TestCase):
         self.assertEqual(intent_contents, loaded_intents)
         shutil.rmtree(config["install_path"], onerror=del_rw)
 
+    def test_check_cache_clears_local_by_default(self):
+        config = {}
+        config["path"] = "abc"
+        config["install_path"] = os.path.join(
+            self._tmp_dir, os.path.normpath("test/module")
+        )
+        os.makedirs(config["install_path"], mode=0o777)
+        ld.Loader.check_cache(config)
+        self.assertFalse(os.path.isdir(config["install_path"]))
+
+    def test_check_cache_clear_local_by_default_disabled(self):
+        config = {}
+        config["no-cache"] = False
+        config["path"] = "abc"
+        config["install_path"] = os.path.join(
+            self._tmp_dir, os.path.normpath("test/module")
+        )
+        os.makedirs(config["install_path"], mode=0o777)
+        ld.Loader.check_cache(config)
+        self.assertTrue(os.path.isdir(config["install_path"]))
+        shutil.rmtree(config["install_path"], onerror=del_rw)
+
     def test_loading_intents_failed(self):
         config = {}
         config["no-cache"] = True


### PR DESCRIPTION
# Description

Change the loader so that if a module is installed from a `path` rather than a `repo` or `gist` it will be assumed to have `no-cache: true`.

Fixes #654


## Status
**READY**


## Type of change

- Config defaults change


# How Has This Been Tested?

Added unit tests


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

