### PR TITLE
Chat as slack bot user

### DIFF
--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -23,7 +23,7 @@ connectors:
     default-room: "#random" # default "#general"
     icon-emoji: ":smile:" # default ":robot_face:"
     connect-timeout: 10 # default 10 seconds
-    chat-as-user: true # default False
+    chat-as-user: true # default false
 ```
 
 ## Usage

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -23,6 +23,7 @@ connectors:
     default-room: "#random" # default "#general"
     icon-emoji: ":smile:" # default ":robot_face:"
     connect-timeout: 10 # default 10 seconds
+    chat-as-user: true # default False
 ```
 
 ## Usage

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -165,6 +165,7 @@ connectors:
 #    default-room: "#random" # default "#general"
 #    icon-emoji: ":smile:" # default ":robot_face:"
 #    connect-timeout: 10 # default 10 seconds
+#    chat-as-user: true # default False
 #
 #  ## Rocketchat (core)
 #  - name: rocketchat

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -165,7 +165,7 @@ connectors:
 #    default-room: "#random" # default "#general"
 #    icon-emoji: ":smile:" # default ":robot_face:"
 #    connect-timeout: 10 # default 10 seconds
-#    chat-as-user: true # default False
+#    chat-as-user: true # default false
 #
 #  ## Rocketchat (core)
 #  - name: rocketchat

--- a/opsdroid/configuration/schema.yaml
+++ b/opsdroid/configuration/schema.yaml
@@ -86,6 +86,7 @@ slack:
   default-room: str(required=False)
   icon-emoji: str(required=False)
   connect-timeout: int(required=False)
+  chat-as-user: bool(required=False)
 ---
 telegram:
   name: regex('^(?i)telegram$')

--- a/opsdroid/configuration/schema.yaml
+++ b/opsdroid/configuration/schema.yaml
@@ -86,7 +86,7 @@ slack:
   default-room: str(required=False)
   icon-emoji: str(required=False)
   connect-timeout: int(required=False)
-  chat-as-user: bool(required=false)
+  chat-as-user: bool(required=False)
 ---
 telegram:
   name: regex('^(?i)telegram$')

--- a/opsdroid/configuration/schema.yaml
+++ b/opsdroid/configuration/schema.yaml
@@ -86,7 +86,7 @@ slack:
   default-room: str(required=False)
   icon-emoji: str(required=False)
   connect-timeout: int(required=False)
-  chat-as-user: bool(required=False)
+  chat-as-user: bool(required=false)
 ---
 telegram:
   name: regex('^(?i)telegram$')

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -28,8 +28,12 @@ class ConnectorSlack(Connector):
         self.token = config["api-token"]
         self.timeout = config.get("connect-timeout", 10)
         self.ssl_context = ssl.create_default_context(cafile=certifi.where())
-        self.slack = slack.WebClient(token=self.token, run_async=True, ssl=self.ssl_context)
-        self.slack_rtm = slack.RTMClient(token=self.token, run_async=True, ssl=self.ssl_context)
+        self.slack = slack.WebClient(
+            token=self.token, run_async=True, ssl=self.ssl_context
+        )
+        self.slack_rtm = slack.RTMClient(
+            token=self.token, run_async=True, ssl=self.ssl_context
+        )
         self.websocket = None
         self.bot_name = config.get("bot-name", "opsdroid")
         self.auth_info = None

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -1,6 +1,7 @@
 """A connector for Slack."""
 import logging
 import re
+import ssl
 
 import slack
 from emoji import demojize

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import ssl
+import certifi
 
 import slack
 from emoji import demojize
@@ -26,9 +27,9 @@ class ConnectorSlack(Connector):
         self.icon_emoji = config.get("icon-emoji", ":robot_face:")
         self.token = config["api-token"]
         self.timeout = config.get("connect-timeout", 10)
-        ssl_context = ssl.create_default_context()
-        self.slack = slack.WebClient(token=self.token, run_async=True, ssl=ssl_context)
-        self.slack_rtm = slack.RTMClient(token=self.token, run_async=True, ssl=ssl_context)
+        self.ssl_context = ssl.create_default_context(cafile=certifi.where())
+        self.slack = slack.WebClient(token=self.token, run_async=True, ssl=self.ssl_context)
+        self.slack_rtm = slack.RTMClient(token=self.token, run_async=True, ssl=self.ssl_context)
         self.websocket = None
         self.bot_name = config.get("bot-name", "opsdroid")
         self.auth_info = None

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -27,8 +27,6 @@ class ConnectorSlack(Connector):
         self.token = config["api-token"]
         self.timeout = config.get("connect-timeout", 10)
         ssl_context = ssl.create_default_context()
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
         self.slack = slack.WebClient(token=self.token, run_async=True, ssl=ssl_context)
         self.slack_rtm = slack.RTMClient(token=self.token, run_async=True, ssl=ssl_context)
         self.websocket = None

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -25,8 +25,11 @@ class ConnectorSlack(Connector):
         self.icon_emoji = config.get("icon-emoji", ":robot_face:")
         self.token = config["api-token"]
         self.timeout = config.get("connect-timeout", 10)
-        self.slack = slack.WebClient(token=self.token, run_async=True)
-        self.slack_rtm = slack.RTMClient(token=self.token, run_async=True)
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+        self.slack = slack.WebClient(token=self.token, run_async=True, ssl=ssl_context)
+        self.slack_rtm = slack.RTMClient(token=self.token, run_async=True, ssl=ssl_context)
         self.websocket = None
         self.bot_name = config.get("bot-name", "opsdroid")
         self.auth_info = None

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -27,6 +27,7 @@ class ConnectorSlack(Connector):
         self.icon_emoji = config.get("icon-emoji", ":robot_face:")
         self.token = config["api-token"]
         self.timeout = config.get("connect-timeout", 10)
+        self.chat_as_user = config.get("chat-as-user", False)
         self.ssl_context = ssl.create_default_context(cafile=certifi.where())
         self.slack = slack.WebClient(
             token=self.token, run_async=True, ssl=self.ssl_context
@@ -141,7 +142,7 @@ class ConnectorSlack(Connector):
             data={
                 "channel": message.target,
                 "text": message.text,
-                "as_user": False,
+                "as_user": self.chat_as_user,
                 "username": self.bot_name,
                 "icon_emoji": self.icon_emoji,
             },
@@ -157,6 +158,7 @@ class ConnectorSlack(Connector):
             "chat.postMessage",
             data={
                 "channel": blocks.target,
+                "as_user": self.chat_as_user,
                 "username": self.bot_name,
                 "blocks": blocks.blocks,
                 "icon_emoji": self.icon_emoji,

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ ibm-watson==4.0.1
 websockets==8.1
 webexteamssdk==1.2
 yamale==2.0.1
+certifi==2019.9.11


### PR DESCRIPTION
# Description

Added a new boolean property for Slack Connector `chat-as-user`. If set to true, the message is sent as the authenticated bot user whose API token is configured. This ignores the `bot-name` and `icon-emoji` properties. If set to false, the message is sent using the `bot-name` and `icon-emoji` properties.

Fixes #1246 


## Status
**READY**

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

- Tested using the existing test cases in opsdroid.
- Tested with an opsdroid skill that sends a message to a slack user.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

