### PR TITLE
Fix issue when dict doesn't update

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=too-many-branches
 
+import contextlib
 import importlib
 import importlib.util
 import json
@@ -482,6 +483,11 @@ class Loader:
         is just a string rather than a mapping object so we do a check and
         update the config as appropriate.
 
+        We also need to update the config file with the rest of the config params.
+        Since modules can be Key: { key: value } or key: None, we suppress the
+        TypeError exception which is given when we try to use .get() on a None type,
+        .
+
         Args:
             module (dict): Module to be configured
             modules_type (str): Type of module being loaded
@@ -499,6 +505,8 @@ class Loader:
         else:
             config["name"] = module["name"]
             config["module"] = module.get("module", "")
+
+        with contextlib.suppress(TypeError, AttributeError):
             config.update(modules.get(module))
 
         config["type"] = modules_type


### PR DESCRIPTION
# Description

@daniccan reported a bug with the new layout config where the config params inside the dictionary of a module weren't being passed on.

This was my own mistake when trying to refactor and added the `config.update` on the wrong place.

This is a quick fix for the issue but I'm not sure if we should be just using the suppress when dealing with exceptions.  


Fixes #<issue>


## Status
**READY** 


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Tox - all green
- Ran opsdroid with slack connector - all ok


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

