### PR TITLE
Token based authentication for Webhook Matcher

### DIFF
--- a/docs/matchers/webhook.md
+++ b/docs/matchers/webhook.md
@@ -67,8 +67,8 @@ web:
   webhook-token: "aabbccddee"
 ```
 
-**Example POST Request Header**
+**Example POST Request using Curl**
 
 ```
-Authorization: Bearer aabbccddee
+curl -X POST -H "Authorization: Bearer aabbccddee" http://localhost:8080/skill/exampleskill/examplewebhook
 ```

--- a/docs/matchers/webhook.md
+++ b/docs/matchers/webhook.md
@@ -56,3 +56,19 @@ class MySkill(Skill):
         # Send a custom aiohttp.web.Response object back to the webhook
         return Response(body='my custom response', status=201)
 ```
+## Securing Webhooks
+
+You can also secure the webhooks by adding an optional `webhook-token` value to the `web` configuration. This enables a token-based authentication where the `POST` request is required to have an `Authorization` header with the bearer token as its value.
+
+**Example Config**
+
+```yaml
+web:
+  webhook-token: "aabbccddee"
+```
+
+**Example POST Request Header**
+
+```
+Authorization: Bearer aabbccddee
+```

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -32,6 +32,7 @@ welcome-message: true
 #   ssl:
 #     cert: /path/to/cert.pem
 #     key: /path/to/key.pem
+#   webhook-token: "aabbccddee"
 
 ## Parsers
 # parsers:

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -130,7 +130,7 @@ class Web:
             """Wrap up the aiohttp handler."""
             webhook_token = self.config.get("webhook-token", None)
             authorization_header = []
-            if req.headers is not None:
+            if req is not None:
                 authorization_header = req.headers.get("Authorization", "").split()
 
             if webhook_token is not None:

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -128,6 +128,20 @@ class Web:
 
         async def wrapper(req, opsdroid=opsdroid, config=skill.config):
             """Wrap up the aiohttp handler."""
+            webhook_token = self.config.get("webhook-token", None)
+            authorization_header = req.headers.get("Authorization", "").split()
+
+            if webhook_token is not None:
+                if not (
+                    len(authorization_header) == 2
+                    and authorization_header[0] == "Bearer"
+                    and authorization_header[1] == webhook_token
+                ):
+                    _LOGGER.error(
+                        _("Unauthorized to run skill %s via webhook"), webhook
+                    )
+                    return Web.build_response(403, {"called_skill": webhook})
+
             _LOGGER.info(_("Running skill %s via webhook"), webhook)
             opsdroid.stats["webhooks_called"] = opsdroid.stats["webhooks_called"] + 1
             resp = await opsdroid.run_skill(skill, config, req)

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -129,7 +129,9 @@ class Web:
         async def wrapper(req, opsdroid=opsdroid, config=skill.config):
             """Wrap up the aiohttp handler."""
             webhook_token = self.config.get("webhook-token", None)
-            authorization_header = req.headers.get("Authorization", "").split()
+            authorization_header = []
+            if req.headers is not None:
+                authorization_header = req.headers.get("Authorization", "").split()
 
             if webhook_token is not None:
                 if not (

--- a/scripts/update_example_config/configuration.j2
+++ b/scripts/update_example_config/configuration.j2
@@ -32,6 +32,7 @@ welcome-message: true
 #   ssl:
 #     cert: /path/to/cert.pem
 #     key: /path/to/key.pem
+#   webhook-token: "aabbccddee"
 
 ## Parsers
 # parsers:

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -4,6 +4,8 @@ import asynctest.mock as mock
 import asyncio
 import aiohttp.web
 
+from aiohttp.test_utils import make_mocked_request
+
 from opsdroid.cli.start import configure_lang
 from opsdroid.core import OpsDroid
 from opsdroid.web import Web
@@ -141,6 +143,26 @@ class TestMatchers(asynctest.TestCase):
             postcalls, _ = opsdroid.web_server.web_app.router.add_post.call_args_list[0]
             wrapperfunc = postcalls[1]
             webhookresponse = await wrapperfunc(None)
+            self.assertEqual(type(webhookresponse), aiohttp.web.Response)
+
+    async def test_match_webhook_response_with_authorization_failure(self):
+        with OpsDroid() as opsdroid:
+            opsdroid.loader.current_import_config = {"name": "testhook"}
+            opsdroid.config["web"] = {"webhook-token": "aabbccddeeff"}
+            opsdroid.web_server = Web(opsdroid)
+            opsdroid.web_server.web_app = mock.Mock()
+            webhook = "test"
+            decorator = matchers.match_webhook(webhook)
+            opsdroid.skills.append(decorator(await self.getMockSkill()))
+            opsdroid.skills[0].config = {"name": "mockedskill"}
+            opsdroid.web_server.setup_webhooks(opsdroid.skills)
+            postcalls, _ = opsdroid.web_server.web_app.router.add_post.call_args_list[0]
+            wrapperfunc = postcalls[1]
+            webhookresponse = await wrapperfunc(
+                make_mocked_request(
+                    "POST", postcalls[0], headers={"Authorization": "Bearer wwxxyyzz"}
+                )
+            )
             self.assertEqual(type(webhookresponse), aiohttp.web.Response)
 
     async def test_match_webhook_custom_response(self):


### PR DESCRIPTION
# Description

Added `webhook-token` parameter to `web` config to secure webhooks.

Fixes #1259 


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

- Existing test cases
- Create skill with `webhook matcher` with the following configuration in the `configuration.yaml`

```
web:
  webhook-token: "abcdef"
```

Trigger the skill using a POST request to the webhook. Add `Authorization` header to the request as follows:

```
Authorization: Bearer abcdef
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

