### PR TITLE
Fail sphinx on warnings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,3 +13,4 @@ python:
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 basepython = python3
 ignore_errors = True
 commands =
-     sphinx-build -b html docs/ docs/_build/
+     sphinx-build -W -b html docs/ docs/_build/
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
# Description

Sphinx should fail on warnings. That way we can be sure the docs are building correctly.