### PR TITLE
Always run matched events

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -419,7 +419,6 @@ class OpsDroid:
         if isinstance(message, events.Message):
             ranked_skills += await parse_regex(self, skills, message)
             ranked_skills += await parse_format(self, skills, message)
-        ranked_skills += await parse_event_type(self, message)
 
         if "parsers" in self.config:
             _LOGGER.debug(_("Processing parsers..."))
@@ -491,8 +490,8 @@ class OpsDroid:
         tasks = []
         if isinstance(event, events.Message):
             _LOGGER.debug(_("Parsing input: %s."), event)
-
             tasks.append(self.eventloop.create_task(parse_always(self, event)))
+            tasks.append(self.eventloop.create_task(parse_event_type(self, event)))
 
             unconstrained_skills = await self._constrain_skills(self.skills, event)
             ranked_skills = await self.get_ranked_skills(unconstrained_skills, event)
@@ -506,6 +505,8 @@ class OpsDroid:
                         )
                     )
                 )
+
+        await asyncio.gather(*tasks)
 
         return tasks
 

--- a/opsdroid/parsers/event_type.py
+++ b/opsdroid/parsers/event_type.py
@@ -10,32 +10,22 @@ _LOGGER = logging.getLogger(__name__)
 
 async def parse_event_type(opsdroid, event):
     """Parse an event if it's of a certain type."""
-    matched_skills = []
     for skill in opsdroid.skills:
         for matcher in skill.matchers:
             event_type = matcher.get("event_type", {}).get("type", None)
             if event_type:
                 # The event type can be specified with a string
                 if isinstance(event_type, str):
-                    # pylint: disable=invalid-name
-                    et = Event.event_registry.get(event_type, None)
-                    if et is None:
+                    matcher_event_type = Event.event_registry.get(event_type, None)
+                    if matcher_event_type is None:
                         raise ValueError(
                             "{event_type} is not a valid opsdroid"
                             " event representation.".format(event_type=event_type)
                         )
-                    event_type = et
+                    event_type = matcher_event_type
 
                 # TODO: Add option to match all subclasses as well
                 # if isinstance(event, event_type):
                 # pylint: disable=unidiomatic-typecheck
                 if type(event) is event_type:
-                    matched_skills.append(
-                        {
-                            "score": 1,
-                            "skill": skill,
-                            "config": skill.config,
-                            "message": event,
-                        }
-                    )
-    return matched_skills
+                    await opsdroid.run_skill(skill, skill.config, event)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -23,7 +23,6 @@ class TestConstraints(asynctest.TestCase):
 
     async def test_constrain_rooms_constrains(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_rooms(["#general"])(skill)
@@ -32,11 +31,10 @@ class TestConstraints(asynctest.TestCase):
             tasks = await opsdroid.parse(
                 Message(text="Hello", user="user", target="#random", connector=None)
             )
-            self.assertEqual(len(tasks), 1)  # Just match_always
+            self.assertEqual(len(tasks), 2)  # Just match_always and match_event
 
     async def test_constrain_rooms_skips(self):
         with OpsDroid() as opsdroid, mock.patch("opsdroid.parsers.always.parse_always"):
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_rooms(["#general"])(skill)
@@ -45,11 +43,10 @@ class TestConstraints(asynctest.TestCase):
             tasks = await opsdroid.parse(
                 Message(text="Hello", user="user", target="#general", connector=None)
             )
-            self.assertEqual(len(tasks), 2)  # match_always and the skill
+            self.assertEqual(len(tasks), 3)  # match_always, match_event and the skill
 
     async def test_constrain_rooms_inverted(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_rooms(["#general"], invert=True)(skill)
@@ -58,11 +55,10 @@ class TestConstraints(asynctest.TestCase):
             tasks = await opsdroid.parse(
                 Message(text="Hello", user="user", target="#general", connector=None)
             )
-            self.assertEqual(len(tasks), 1)  # match_always only
+            self.assertEqual(len(tasks), 2)  # Just match_always and match_event
 
     async def test_constrain_users_constrains(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_users(["user"])(skill)
@@ -73,11 +69,10 @@ class TestConstraints(asynctest.TestCase):
                     text="Hello", user="otheruser", target="#general", connector=None
                 )
             )
-            self.assertEqual(len(tasks), 1)  # Just match_always
+            self.assertEqual(len(tasks), 2)  # Just match_always and match_event
 
     async def test_constrain_users_skips(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_users(["user"])(skill)
@@ -86,11 +81,10 @@ class TestConstraints(asynctest.TestCase):
             tasks = await opsdroid.parse(
                 Message(text="Hello", user="user", target="#general", connector=None)
             )
-            self.assertEqual(len(tasks), 2)  # match_always and the skill
+            self.assertEqual(len(tasks), 3)  # match_always, match_event and the skill
 
     async def test_constrain_users_inverted(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_users(["user"], invert=True)(skill)
@@ -99,11 +93,10 @@ class TestConstraints(asynctest.TestCase):
             tasks = await opsdroid.parse(
                 Message(text="Hello", user="user", target="#general", connector=None)
             )
-            self.assertEqual(len(tasks), 1)  # match_always only
+            self.assertEqual(len(tasks), 2)  # Just match_always and match_event
 
     async def test_constrain_connectors_constrains(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_connectors(["slack"])(skill)
@@ -116,11 +109,10 @@ class TestConstraints(asynctest.TestCase):
                     text="Hello", user="user", target="#random", connector=connector
                 )
             )
-            self.assertEqual(len(tasks), 1)  # Just match_always
+            self.assertEqual(len(tasks), 2)  # Just match_always and match_event
 
     async def test_constrain_connectors_skips(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_connectors(["slack"])(skill)
@@ -133,11 +125,10 @@ class TestConstraints(asynctest.TestCase):
                     text="Hello", user="user", target="#general", connector=connector
                 )
             )
-            self.assertEqual(len(tasks), 2)  # match_always and the skill
+            self.assertEqual(len(tasks), 3)  # match_always, match_event and the skill
 
     async def test_constrain_connectors_inverted(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_connectors(["slack"], invert=True)(skill)
@@ -150,11 +141,10 @@ class TestConstraints(asynctest.TestCase):
                     text="Hello", user="user", target="#general", connector=connector
                 )
             )
-            self.assertEqual(len(tasks), 1)  # match_always only
+            self.assertEqual(len(tasks), 2)  # Just match_always and match_event
 
     async def test_constraint_can_be_called_after_skip(self):
         with OpsDroid() as opsdroid:
-            opsdroid.eventloop = mock.CoroutineMock()
             skill = await self.getMockSkill()
             skill = match_regex(r".*")(skill)
             skill = constraints.constrain_users(["user"])(skill)
@@ -163,16 +153,16 @@ class TestConstraints(asynctest.TestCase):
             tasks = await opsdroid.parse(
                 Message(text="Hello", user="user", target="#general", connector=None)
             )
-            self.assertEqual(len(tasks), 2)  # match_always and the skill
+            self.assertEqual(len(tasks), 3)  # match_always, match_event and the skill
 
             tasks = await opsdroid.parse(
                 Message(
                     text="Hello", user="otheruser", target="#general", connector=None
                 )
             )
-            self.assertEqual(len(tasks), 1)  # Just match_always
+            self.assertEqual(len(tasks), 2)  # Just match_always and match_event
 
             tasks = await opsdroid.parse(
                 Message(text="Hello", user="user", target="#general", connector=None)
             )
-            self.assertEqual(len(tasks), 2)  # match_always and the skill
+            self.assertEqual(len(tasks), 3)  # match_always, match_event and the skill

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -281,9 +281,7 @@ class TestCoreAsync(asynctest.TestCase):
                 target="default",
                 connector=mock_connector,
             )
-            tasks = await opsdroid.parse(message)
-            for task in tasks:
-                await task
+            await opsdroid.parse(message)
             self.assertTrue(mock_connector.send.called)
 
     async def test_parse_regex_method_skill(self):
@@ -299,9 +297,7 @@ class TestCoreAsync(asynctest.TestCase):
                 target="default",
                 connector=mock_connector,
             )
-            tasks = await opsdroid.parse(message)
-            for task in tasks:
-                await task
+            await opsdroid.parse(message)
             self.assertTrue(mock_connector.send.called)
 
     async def test_parse_regex_insensitive(self):
@@ -317,9 +313,7 @@ class TestCoreAsync(asynctest.TestCase):
                 target="default",
                 connector=mock_connector,
             )
-            tasks = await opsdroid.parse(message)
-            for task in tasks:
-                await task
+            await opsdroid.parse(message)
             self.assertTrue(mock_connector.send.called)
 
     async def test_parse_dialogflow(self):
@@ -342,14 +336,10 @@ class TestCoreAsync(asynctest.TestCase):
                 "opsdroid.parsers.dialogflow.parse_dialogflow"
             ), amock.patch("opsdroid.parsers.dialogflow.call_dialogflow"):
                 tasks = await opsdroid.parse(message)
-                self.assertEqual(len(tasks), 1)
+                self.assertEqual(len(tasks), 2)
 
                 tasks = await opsdroid.parse(message)
                 self.assertLogs("_LOGGER", "warning")
-
-                # But leave this bit
-                for task in tasks:
-                    await task
 
     async def test_parse_luisai(self):
         with OpsDroid() as opsdroid:
@@ -366,9 +356,7 @@ class TestCoreAsync(asynctest.TestCase):
             )
             with amock.patch("opsdroid.parsers.luisai.parse_luisai"):
                 tasks = await opsdroid.parse(message)
-                self.assertEqual(len(tasks), 1)
-                for task in tasks:
-                    await task
+                self.assertEqual(len(tasks), 2)
 
     async def test_parse_rasanlu(self):
         with OpsDroid() as opsdroid:
@@ -382,9 +370,7 @@ class TestCoreAsync(asynctest.TestCase):
             )
             with amock.patch("opsdroid.parsers.rasanlu.parse_rasanlu"):
                 tasks = await opsdroid.parse(message)
-                self.assertEqual(len(tasks), 1)
-                for task in tasks:
-                    await task
+                self.assertEqual(len(tasks), 2)
 
     async def test_parse_sapcai(self):
         with OpsDroid() as opsdroid:
@@ -398,9 +384,7 @@ class TestCoreAsync(asynctest.TestCase):
             )
             with amock.patch("opsdroid.parsers.sapcai.parse_sapcai"):
                 tasks = await opsdroid.parse(message)
-                self.assertEqual(len(tasks), 1)
-                for task in tasks:
-                    await task
+                self.assertEqual(len(tasks), 2)
 
     async def test_parse_watson(self):
         with OpsDroid() as opsdroid:
@@ -412,9 +396,7 @@ class TestCoreAsync(asynctest.TestCase):
             message = Message("Hello world", "user", "default", mock_connector)
             with amock.patch("opsdroid.parsers.watson.parse_watson"):
                 tasks = await opsdroid.parse(message)
-                self.assertEqual(len(tasks), 1)
-                for task in tasks:
-                    await task
+                self.assertEqual(len(tasks), 2)
 
     async def test_parse_witai(self):
         with OpsDroid() as opsdroid:
@@ -431,9 +413,7 @@ class TestCoreAsync(asynctest.TestCase):
             )
             with amock.patch("opsdroid.parsers.witai.parse_witai"):
                 tasks = await opsdroid.parse(message)
-                self.assertEqual(len(tasks), 1)
-                for task in tasks:
-                    await task
+                self.assertEqual(len(tasks), 2)
 
     async def test_send_default_one(self):
         with OpsDroid() as opsdroid, amock.patch(


### PR DESCRIPTION
# Description

The `match_event` matcher should not be part of the NLU ranking pipeline. If a event matches a skill it should be run regardless.