### PR TITLE
Add build subcommand to load config without running bot

### DIFF
--- a/opsdroid/cli/config.py
+++ b/opsdroid/cli/config.py
@@ -3,11 +3,12 @@
 import click
 
 from opsdroid.cli.utils import (
+    build_config,
     edit_files,
-    warn_deprecated_cli_option,
-    validate_config,
     list_all_modules,
     path_option,
+    validate_config,
+    warn_deprecated_cli_option,
 )
 from opsdroid.const import EXAMPLE_CONFIG_FILE
 
@@ -125,3 +126,31 @@ def list_modules(ctx):
 
     """
     list_all_modules(ctx, ctx.obj, "config")
+
+
+@config.command()
+@click.pass_context
+@click.option(
+    "-d",
+    "verbose",
+    is_flag=True,
+    help="Turns logging level to debug to see all logging messages.",
+)
+def build(ctx, verbose):
+    """Load configuration, load modules and install dependencies.
+
+    This function loads the configuration and install all necessary
+    dependencies defined on a `requirements.txt` file inside the module.
+    If the flag `-d` is passed the logging level will be set as debug and
+    all logs will be shown to the user.
+
+
+    Args:
+        ctx (:obj:`click.Context`): The current click cli context.
+        verbose (bool): set the logging level to debug.
+
+    Returns:
+        int: the exit code. Always returns 0 in this case.
+
+    """
+    build_config(ctx, {"path": ctx.obj, "verbose": verbose}, "config")

--- a/opsdroid/cli/config.py
+++ b/opsdroid/cli/config.py
@@ -131,7 +131,7 @@ def list_modules(ctx):
 @config.command()
 @click.pass_context
 @click.option(
-    "-d",
+    "--verbose",
     "verbose",
     is_flag=True,
     help="Turns logging level to debug to see all logging messages.",
@@ -141,7 +141,7 @@ def build(ctx, verbose):
 
     This function loads the configuration and install all necessary
     dependencies defined on a `requirements.txt` file inside the module.
-    If the flag `-d` is passed the logging level will be set as debug and
+    If the flag `--verbose` is passed the logging level will be set as debug and
     all logs will be shown to the user.
 
 

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -1,6 +1,7 @@
 """Utilities for the opsdroid CLI commands."""
 
 import click
+import contextlib
 import gettext
 import os
 import logging
@@ -253,17 +254,19 @@ def build_config(ctx, params, value):
     """
     click.echo("Opsdroid will build modules from config.")
     path = params.get("path")
-    check_dependencies()
 
-    config = load_config_file([path] if path else DEFAULT_CONFIG_LOCATIONS)
+    with contextlib.suppress(Exception):
+        check_dependencies()
 
-    if params["verbose"]:
-        config["logging"] = {"level": "debug"}
-        configure_logging(config)
+        config = load_config_file([path] if path else DEFAULT_CONFIG_LOCATIONS)
 
-    with OpsDroid(config=config) as opsdroid:
-        opsdroid.loader.load_modules_from_config(config)
+        if params["verbose"]:
+            config["logging"] = {"level": "debug"}
+            configure_logging(config)
 
-        click.echo("Opsdroid modules successfully built from config.")
+        with OpsDroid(config=config) as opsdroid:
 
-        opsdroid.exit()
+            opsdroid.loader.load_modules_from_config(config)
+
+            click.echo(click.style("SUCCESS:", bg="green", bold=True), nl=False)
+            click.echo(" Opsdroid modules successfully built from config.")

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -235,7 +235,7 @@ def build_config(ctx, params, value):
 
     This function loads the configuration and install all necessary
     dependencies defined on a `requirements.txt` file inside the module.
-    If the flag `-d` is passed the logging level will be set as debug and
+    If the flag `--verbose` is passed the logging level will be set as debug and
     all logs will be shown to the user.
 
 
@@ -251,6 +251,7 @@ def build_config(ctx, params, value):
         int: the exit code. Always returns 0 in this case.
 
     """
+    click.echo("Opsdroid will build modules from config.")
     path = params.get("path")
     check_dependencies()
 
@@ -261,8 +262,8 @@ def build_config(ctx, params, value):
         configure_logging(config)
 
     with OpsDroid(config=config) as opsdroid:
-        opsdroid.sync_load()
-        opsdroid.exit()
+        opsdroid.loader.load_modules_from_config(config)
 
         click.echo("Opsdroid modules successfully built from config.")
-        ctx.exit(0)
+
+        opsdroid.exit()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,3 +266,30 @@ class TestCLI(unittest.TestCase):
             self.assertTrue(click_echo.called)
             self.assertFalse(opsdroid_load.called)
             self.assertEqual(result.exit_code, 0)
+
+    def test_config_build_from_path(self):
+        with mock.patch.object(click, "echo") as click_echo, mock.patch(
+            "opsdroid.configuration.load_config_file"
+        ) as opsdroid_load:
+            runner = CliRunner()
+            from opsdroid.cli import config
+
+            result = runner.invoke(
+                config,
+                ["-f", os.path.abspath("tests/configs/full_valid.yaml"), "build", "-d"],
+            )
+            self.assertTrue(click_echo.called)
+            self.assertFalse(opsdroid_load.called)
+            self.assertEqual(result.exit_code, 0)
+
+    def test_config_build(self):
+        with mock.patch.object(click, "echo") as click_echo, mock.patch(
+            "opsdroid.configuration.load_config_file"
+        ) as opsdroid_load:
+            runner = CliRunner()
+            from opsdroid.cli.config import build
+
+            result = runner.invoke(build, [])
+            self.assertTrue(click_echo.called)
+            self.assertFalse(opsdroid_load.called)
+            self.assertEqual(result.exit_code, 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,7 +276,12 @@ class TestCLI(unittest.TestCase):
 
             result = runner.invoke(
                 config,
-                ["-f", os.path.abspath("tests/configs/full_valid.yaml"), "build", "-d"],
+                [
+                    "-f",
+                    os.path.abspath("tests/configs/full_valid.yaml"),
+                    "build",
+                    "--verbose",
+                ],
             )
             self.assertTrue(click_echo.called)
             self.assertFalse(opsdroid_load.called)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,3 +298,16 @@ class TestCLI(unittest.TestCase):
             self.assertTrue(click_echo.called)
             self.assertFalse(opsdroid_load.called)
             self.assertEqual(result.exit_code, 0)
+
+    def test_config_build_exception(self):
+        with mock.patch.object(click, "echo") as click_echo, mock.patch(
+            "opsdroid.configuration.load_config_file"
+        ), mock.patch("opsdroid.loader") as mock_load:
+
+            mock_load.load_modules_from_config.side_effect = Exception()
+            runner = CliRunner()
+            from opsdroid.cli.config import build
+
+            result = runner.invoke(build, [])
+            self.assertTrue(click_echo.called)
+            self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
# Description

This is the initial work on the build subcommand. I was able to add a skill that contains a `requirement.txt` and the subcommand installed all the necessary things.

I've also added a `-d` flag to set the logging level to debug - not sure if this should always be active but it might be good to have the logs showing when running the subcommand so the user knows what's happening.

When I run the command an exception is raised:

```shell
py opsdroid config build
No databases in configuration. This will cause skills which store things in memory to lose data when opsdroid is restarted.
ERROR: Unhandled exception in opsdroid, exiting...
ERROR: Unhandled exception in opsdroid, exiting...
sys:1: RuntimeWarning: coroutine 'BaseEventLoop._create_server_getaddrinfo' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

After running the command in debug mode I can see that the logging message saying that the web server started just after exiting.  I'm not sure how to deal with the issue since this is an synchronous function.

Perhaps we should just run the Loader on the config? 🤔 

Fixes #244


## Status
~~**READY**~~ | **UNDER DEVELOPMENT** | ~~**ON HOLD**~~


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Ran the command `opsdroid config build` 
- Ran the command `opsdroid config build -d`
- Ran the command  `opsdroid config -f <path> build`
- Tox - green


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
