### PR TITLE
Fix logs command - open logs if given different name than default

### DIFF
--- a/opsdroid/cli/logs.py
+++ b/opsdroid/cli/logs.py
@@ -3,18 +3,12 @@
 
 import click
 
-from opsdroid.cli.utils import edit_files, clear_logs
+from opsdroid.cli.utils import edit_files
 
 
-@click.group()
+@click.command()
 @click.pass_context
 def logs(ctx):
-    """Subcommands related to opsdroid logs."""
-
-
-@logs.command()
-@click.pass_context
-def view(ctx):
     """Open the log file with your favourite editor.
 
     By default this command will open the configuration file with
@@ -33,19 +27,3 @@ def view(ctx):
 
     """
     edit_files(ctx, None, "log")
-
-
-@logs.command()
-@click.pass_context
-def clear(ctx):
-    """Clear all logs.
-
-    Asks for the user confirmation if the logs should be cleared or not. If user chooses
-    yes then all logs will be clear otherwise the action will be aborted.
-
-
-    Args:
-        ctx (:obj:`click.Context`): The current click cli context.
-
-    """
-    clear_logs(ctx, None, "log")

--- a/opsdroid/cli/logs.py
+++ b/opsdroid/cli/logs.py
@@ -3,12 +3,18 @@
 
 import click
 
-from opsdroid.cli.utils import edit_files
+from opsdroid.cli.utils import edit_files, clear_logs
 
 
-@click.command()
+@click.group()
 @click.pass_context
 def logs(ctx):
+    """Subcommands related to opsdroid logs."""
+
+
+@logs.command()
+@click.pass_context
+def view(ctx):
     """Open the log file with your favourite editor.
 
     By default this command will open the configuration file with
@@ -27,3 +33,19 @@ def logs(ctx):
 
     """
     edit_files(ctx, None, "log")
+
+
+@logs.command()
+@click.pass_context
+def clear(ctx):
+    """Clear all logs.
+
+    Asks for the user confirmation if the logs should be cleared or not. If user chooses
+    yes then all logs will be clear otherwise the action will be aborted.
+
+
+    Args:
+        ctx (:obj:`click.Context`): The current click cli context.
+
+    """
+    clear_logs(ctx, None, "log")

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -10,14 +10,16 @@ import sys
 import time
 import warnings
 
+from appdirs import user_log_dir
 from opsdroid.core import OpsDroid
 from opsdroid.configuration import load_config_file
 from opsdroid.const import (
     DEFAULT_LOG_FILENAME,
-    LOCALE_DIR,
     DEFAULT_LANGUAGE,
     DEFAULT_CONFIG_PATH,
     DEFAULT_CONFIG_LOCATIONS,
+    LOCALE_DIR,
+    NAME,
 )
 from opsdroid.helper import get_config_option
 from opsdroid.loader import Loader
@@ -59,6 +61,11 @@ def edit_files(ctx, param, value):
             )
     elif value == "log":
         file = DEFAULT_LOG_FILENAME
+        logs = load_config_file(DEFAULT_CONFIG_LOCATIONS).get("logging")
+
+        if logs and logs.get("path"):
+            file = os.path.join(user_log_dir(NAME, appauthor=False), logs.get("path"))
+
         if ctx.command.name == "cli":
             warn_deprecated_cli_option(
                 "The flag -l/--view-log has been deprecated. "
@@ -270,31 +277,3 @@ def build_config(ctx, params, value):
 
             click.echo(click.style("SUCCESS:", bg="green", bold=True), nl=False)
             click.echo(" Opsdroid modules successfully built from config.")
-
-
-def clear_logs(ctx, params, value):
-    """Clear all logs.
-
-    Asks for the user confirmation if the logs should be cleared or not. If user chooses
-    yes then all logs will be clear otherwise the action will be aborted.
-
-
-    Args:
-        ctx (:obj:`click.Context`): The current click cli context.
-        params (dict): a dictionary of all parameters pass to the click
-            context when invoking this function as a callback.
-        value (string): the value of this parameter after invocation.
-            It is either "config" or "log" depending on the program
-            calling this function.
-
-    """
-    click.echo(click.style("WARNING:", bg="yellow", bold=True), nl=False)
-    click.confirm(
-        " Are you sure you wish to clear all your logs? This action cannot be undone.",
-        abort=True,
-    )
-
-    open(DEFAULT_LOG_FILENAME, "w").close()
-
-    click.echo(click.style("SUCCESS:", bg="green", bold=True), nl=False)
-    click.echo(" All logs cleared.")

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -270,3 +270,31 @@ def build_config(ctx, params, value):
 
             click.echo(click.style("SUCCESS:", bg="green", bold=True), nl=False)
             click.echo(" Opsdroid modules successfully built from config.")
+
+
+def clear_logs(ctx, params, value):
+    """Clear all logs.
+
+    Asks for the user confirmation if the logs should be cleared or not. If user chooses
+    yes then all logs will be clear otherwise the action will be aborted.
+
+
+    Args:
+        ctx (:obj:`click.Context`): The current click cli context.
+        params (dict): a dictionary of all parameters pass to the click
+            context when invoking this function as a callback.
+        value (string): the value of this parameter after invocation.
+            It is either "config" or "log" depending on the program
+            calling this function.
+
+    """
+    click.echo(click.style("WARNING:", bg="yellow", bold=True), nl=False)
+    click.confirm(
+        " Are you sure you wish to clear all your logs? This action cannot be undone.",
+        abort=True,
+    )
+
+    open(DEFAULT_LOG_FILENAME, "w").close()
+
+    click.echo(click.style("SUCCESS:", bg="green", bold=True), nl=False)
+    click.echo(" All logs cleared.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,7 +200,7 @@ class TestCLI(unittest.TestCase):
             runner = CliRunner()
             from opsdroid.cli.logs import logs
 
-            result = runner.invoke(logs, ["view"])
+            result = runner.invoke(logs, [])
             self.assertTrue(click_echo.called)
             self.assertTrue(editor.called)
             self.assertEqual(result.exit_code, 0)
@@ -212,6 +212,22 @@ class TestCLI(unittest.TestCase):
             runner = CliRunner()
             with pytest.warns(DeprecationWarning, match=".*opsdroid logs.*"):
                 result = runner.invoke(opsdroid.cli.cli, ["--view-log"])
+            self.assertTrue(click_echo.called)
+            self.assertTrue(editor.called)
+            self.assertEqual(result.exit_code, 0)
+
+    def test_edit_logs_with_name(self):
+        with mock.patch.object(click, "echo") as click_echo, mock.patch(
+            "subprocess.run"
+        ) as editor, mock.patch(
+            "opsdroid.configuration.load_config_file"
+        ) as mock_config:
+            runner = CliRunner()
+            from opsdroid.cli.logs import logs
+
+            mock_config.return_value = {"logging": {"path": "test.yaml"}}
+
+            result = runner.invoke(logs, [])
             self.assertTrue(click_echo.called)
             self.assertTrue(editor.called)
             self.assertEqual(result.exit_code, 0)
@@ -310,16 +326,4 @@ class TestCLI(unittest.TestCase):
 
             result = runner.invoke(build, [])
             self.assertTrue(click_echo.called)
-            self.assertEqual(result.exit_code, 0)
-
-    def test_clear_logs(self):
-        with mock.patch.object(click, "echo") as click_echo, mock.patch.object(
-            click, "confirm"
-        ) as click_confirms, mock.patch("builtins.open"):
-            runner = CliRunner()
-            from opsdroid.cli.logs import logs
-
-            result = runner.invoke(logs, ["clear"])
-            self.assertTrue(click_echo.called)
-            self.assertTrue(click_confirms.called)
             self.assertEqual(result.exit_code, 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,7 +200,7 @@ class TestCLI(unittest.TestCase):
             runner = CliRunner()
             from opsdroid.cli.logs import logs
 
-            result = runner.invoke(logs, [])
+            result = runner.invoke(logs, ["view"])
             self.assertTrue(click_echo.called)
             self.assertTrue(editor.called)
             self.assertEqual(result.exit_code, 0)
@@ -310,4 +310,16 @@ class TestCLI(unittest.TestCase):
 
             result = runner.invoke(build, [])
             self.assertTrue(click_echo.called)
+            self.assertEqual(result.exit_code, 0)
+
+    def test_clear_logs(self):
+        with mock.patch.object(click, "echo") as click_echo, mock.patch.object(
+            click, "confirm"
+        ) as click_confirms, mock.patch("builtins.open"):
+            runner = CliRunner()
+            from opsdroid.cli.logs import logs
+
+            result = runner.invoke(logs, ["clear"])
+            self.assertTrue(click_echo.called)
+            self.assertTrue(click_confirms.called)
             self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
# Description

As we talked in matrix, it could be good to have a command to clear all the logs collected from opsdroid. Since click allows you to ask for confirmation I thought it could be a good idea to include it in this subcommand. 

I've also had to split the logs into `view` since I was unable to use the command `logs clear`. 


## Status
~~**READY**~~ | **UNDER DEVELOPMENT** | ~~**ON HOLD**~~


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tox - all green coverage 100%
- Ran opsdroid logs view - opens logs with vim
- Ran opsdroid logs clear - selected no - aborted message and logs untouched.
- Ran opsdroid logs clear - selected yes - success message and logs cleared.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable) - docstring
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
