### PR TITLE
Remove deprecated flags and add -f flag to logs

### DIFF
--- a/opsdroid/cli/__init__.py
+++ b/opsdroid/cli/__init__.py
@@ -2,66 +2,20 @@
 
 import click
 
-from opsdroid.cli.config import config, print_example_config
+from opsdroid.cli.config import config
 from opsdroid.cli.logs import logs
 from opsdroid.cli.start import start
-from opsdroid.cli.version import version, print_version
-from opsdroid.cli.utils import edit_files, warn_deprecated_cli_option
+from opsdroid.cli.version import version
 
 
-@click.group(invoke_without_command=True)
+@click.group()
 @click.pass_context
-@click.option(
-    "--gen-config",
-    is_flag=True,
-    callback=print_example_config,
-    expose_value=False,
-    default=False,
-    help="[Deprecated] Print an example config and exit.",
-)
-@click.option(
-    "--version",
-    "-v",
-    is_flag=True,
-    callback=print_version,
-    expose_value=False,
-    default=False,
-    is_eager=True,
-    help="[Deprecated] Print the version and exit.",
-)
-@click.option(
-    "--edit-config",
-    "-e",
-    is_flag=True,
-    callback=edit_files,
-    default=False,
-    flag_value="config",
-    expose_value=False,
-    help="[Deprecated] Open configuration.yaml with your favorite editor and exits.",
-)
-@click.option(
-    "--view-log",
-    "-l",
-    is_flag=True,
-    callback=edit_files,
-    default=False,
-    flag_value="log",
-    expose_value=False,
-    help="[Deprecated] Open opsdroid logs with your favorite editor and exits.",
-)
 def cli(ctx):
     """Opsdroid is a chat bot framework written in Python.
 
     It is designed to be extendable, scalable and simple.
     See https://opsdroid.github.io/ for more information.
     """
-    if ctx.invoked_subcommand is None:
-        warn_deprecated_cli_option(
-            "Running `opsdroid` without a subcommand is now deprecated. "
-            "Please run `opsdroid start` instead. "
-            "You can also run `opsdroid --help` to learn about the other subcommands."
-        )
-        ctx.invoke(start)
 
 
 cli.add_command(config)

--- a/opsdroid/cli/config.py
+++ b/opsdroid/cli/config.py
@@ -4,7 +4,7 @@ import click
 
 from opsdroid.cli.utils import (
     build_config,
-    edit_files,
+    edit_config,
     list_all_modules,
     path_option,
     validate_config,
@@ -59,7 +59,7 @@ def edit(ctx):
         int: the exit code. Always returns 0 in this case.
 
     """
-    edit_files(ctx, ctx.obj)
+    edit_config(ctx, ctx.obj)
 
 
 @config.command()

--- a/opsdroid/cli/config.py
+++ b/opsdroid/cli/config.py
@@ -8,35 +8,8 @@ from opsdroid.cli.utils import (
     list_all_modules,
     path_option,
     validate_config,
-    warn_deprecated_cli_option,
 )
 from opsdroid.const import EXAMPLE_CONFIG_FILE
-
-
-def print_example_config(ctx, param, value):
-    """[Deprecated] Print out the example config.
-
-    Args:
-        ctx (:obj:`click.Context`): The current click cli context.
-        param (dict): a dictionary of all parameters pass to the click
-            context when invoking this function as a callback.
-        value (bool): the value of this parameter after invocation.
-            Defaults to False, set to True when this flag is called.
-
-    Returns:
-        int: the exit code. Always returns 0 in this case.
-
-    """
-    if not value or ctx.resilient_parsing:
-        return
-    if ctx.command.name == "cli":
-        warn_deprecated_cli_option(
-            "The flag --gen-config has been deprecated. "
-            "Please run `opsdroid config gen` instead."
-        )
-    with open(EXAMPLE_CONFIG_FILE, "r") as conf:
-        click.echo(conf.read())
-    ctx.exit(0)
 
 
 @click.group()
@@ -52,10 +25,10 @@ def config(ctx, path):
 def gen(ctx):
     """Print out the example config.
 
-    This is a pretty basic function that will simply open your opsdroid
-    configuration file and prints the whole thing into the terminal.
-    You can also use the -f flag to generate a config from a path instead
-    of using the default config location.
+    Open the example configuration file and print it into the terminal.
+    If the -f flag was used with the config command, then this path will be
+    set on `ctx.obj` and will be passed into this subcommand and the contents
+    of the file set in the path will be print into the terminal instead.
 
     Args:
         ctx (:obj:`click.Context`): The current click cli context.
@@ -64,7 +37,10 @@ def gen(ctx):
         int: the exit code. Always returns 0 in this case.
 
     """
-    print_example_config(ctx, ctx.obj, True)
+    path = ctx.obj or EXAMPLE_CONFIG_FILE
+    with open(path, "r") as conf:
+        click.echo(conf.read())
+    ctx.exit(0)
 
 
 @config.command()
@@ -83,7 +59,7 @@ def edit(ctx):
         int: the exit code. Always returns 0 in this case.
 
     """
-    edit_files(ctx, None, "config")
+    edit_files(ctx, ctx.obj)
 
 
 @config.command()
@@ -106,7 +82,7 @@ def lint(ctx):
         int: the exit code. Always returns 0 in this case.
 
     """
-    validate_config(ctx, ctx.obj, "config")
+    validate_config(ctx, ctx.obj)
 
 
 @config.command()
@@ -125,7 +101,7 @@ def list_modules(ctx):
         int: the exit code. Always returns 0 in this case.
 
     """
-    list_all_modules(ctx, ctx.obj, "config")
+    list_all_modules(ctx, ctx.obj)
 
 
 @config.command()
@@ -153,4 +129,4 @@ def build(ctx, verbose):
         int: the exit code. Always returns 0 in this case.
 
     """
-    build_config(ctx, {"path": ctx.obj, "verbose": verbose}, "config")
+    build_config(ctx, {"path": ctx.obj, "verbose": verbose})

--- a/opsdroid/cli/logs.py
+++ b/opsdroid/cli/logs.py
@@ -1,21 +1,20 @@
 """The logs subcommand for opsdroid cli."""
 
-
 import click
+import tailer
+from opsdroid.const import DEFAULT_LOG_FILENAME
+
+lines_argument = click.argument("lines", type=click.INT, required=False, default=20)
 
 
-@click.command()
+@click.group(invoke_without_command=True)
 @click.pass_context
 def logs(ctx):
-    """Open the log file with your favourite editor.
+    """Print the content of the log file into the terminal.
 
-    By default this command will open the configuration file with
-    vi/vim. If you have a different editor that you would like to sure,
-    you need to change the environment variable - `EDITOR`.
-
-    This file will be updated if you are using the configuration option
-    `logging.path`. Notice that depending on your `logging.level` and how
-    long you run opsdroid, this file will grow quite quickly.
+    Open opsdroid logs and prints the contents of the file into the terminal.
+    Since the logs can grow quite quickly, expect a large amount of lines being
+    printed into your terminal.
 
     Args:
         ctx (:obj:`click.Context`): The current click cli context.
@@ -24,4 +23,65 @@ def logs(ctx):
         int: the exit code. Always returns 0 in this case.
 
     """
-    edit_files(ctx, None)
+    if not ctx.invoked_subcommand:
+        with open(DEFAULT_LOG_FILENAME, "r") as log:
+            click.echo(log.read())
+        ctx.exit(0)
+
+
+@logs.command()
+@click.pass_context
+@lines_argument
+@click.option("-f", "follow", is_flag=True, help="Print the logs in real time")
+def tail(ctx, lines, follow):
+    """Print the last lines of the logs.
+
+    By default this subcommand will print the last 5 lines of the logs, but this can be
+    changed if you pass an integer after calling the subcommand like such `opsdroid logs tail 10`
+    this will print the last 10 lines instead of the default 20.
+
+    Alternatively you can also add the `-f` flag to the subcommand to follow the logs in real time.
+    If this flag is passed no logs will be shown unless they are received from the bot.
+
+    Args:
+        ctx (:obj:`click.Context`): The current click cli context.
+        lines(int): Number of lines that should be shown from the end up.
+        follow(bool): Flag that sets the subcommand to print the logs in real time.
+
+    Returns:
+        int: the exit code. Always returns 0 in this case.
+
+    """
+    with open(DEFAULT_LOG_FILENAME) as file:
+        if follow:
+            click.echo("Now following logs in real time, press CTRL+C to stop.")
+            for line in tailer.follow(file):
+                click.echo(line)
+
+        for line in tailer.tail(file, lines):
+            click.echo(line)
+            ctx.exit(0)
+
+
+@logs.command()
+@click.pass_context
+@lines_argument
+def head(ctx, lines):
+    """Print the first lines of the logs.
+
+    This subcommand by default will print the first 5 lines from the logs. But you can change
+    the default number by passing an int to the subcommand like such: `opsdroid logs head 50`.
+
+    Args:
+        ctx (:obj:`click.Context`): The current click cli context.
+        lines(int): Number of lines that should be shown from the end up.
+
+    Returns:
+        int: the exit code. Always returns 0 in this case.
+
+    """
+    with open(DEFAULT_LOG_FILENAME) as file:
+        for line in tailer.head(file, lines):
+            click.echo(line)
+
+    ctx.exit(0)

--- a/opsdroid/cli/logs.py
+++ b/opsdroid/cli/logs.py
@@ -3,8 +3,6 @@
 
 import click
 
-from opsdroid.cli.utils import edit_files
-
 
 @click.command()
 @click.pass_context

--- a/opsdroid/cli/logs.py
+++ b/opsdroid/cli/logs.py
@@ -26,4 +26,4 @@ def logs(ctx):
         int: the exit code. Always returns 0 in this case.
 
     """
-    edit_files(ctx, None, "log")
+    edit_files(ctx, None)

--- a/opsdroid/cli/logs.py
+++ b/opsdroid/cli/logs.py
@@ -4,84 +4,30 @@ import click
 import tailer
 from opsdroid.const import DEFAULT_LOG_FILENAME
 
-lines_argument = click.argument("lines", type=click.INT, required=False, default=20)
-
 
 @click.group(invoke_without_command=True)
+@click.option("-f", "follow", is_flag=True, help="Print the logs in real time")
 @click.pass_context
-def logs(ctx):
+def logs(ctx, follow):
     """Print the content of the log file into the terminal.
 
     Open opsdroid logs and prints the contents of the file into the terminal.
-    Since the logs can grow quite quickly, expect a large amount of lines being
-    printed into your terminal.
+    If you wish to follow the logs in real time you can use the `-f` flag which
+    will allow you to do this.
 
     Args:
         ctx (:obj:`click.Context`): The current click cli context.
+        follow(bool): Set by the `-f` flag to trigger the print of the logs in real time.
 
     Returns:
         int: the exit code. Always returns 0 in this case.
 
     """
-    if not ctx.invoked_subcommand:
-        with open(DEFAULT_LOG_FILENAME, "r") as log:
-            click.echo(log.read())
-        ctx.exit(0)
-
-
-@logs.command()
-@click.pass_context
-@lines_argument
-@click.option("-f", "follow", is_flag=True, help="Print the logs in real time")
-def tail(ctx, lines, follow):
-    """Print the last lines of the logs.
-
-    By default this subcommand will print the last 5 lines of the logs, but this can be
-    changed if you pass an integer after calling the subcommand like such `opsdroid logs tail 10`
-    this will print the last 10 lines instead of the default 20.
-
-    Alternatively you can also add the `-f` flag to the subcommand to follow the logs in real time.
-    If this flag is passed no logs will be shown unless they are received from the bot.
-
-    Args:
-        ctx (:obj:`click.Context`): The current click cli context.
-        lines(int): Number of lines that should be shown from the end up.
-        follow(bool): Flag that sets the subcommand to print the logs in real time.
-
-    Returns:
-        int: the exit code. Always returns 0 in this case.
-
-    """
-    with open(DEFAULT_LOG_FILENAME) as file:
+    with open(DEFAULT_LOG_FILENAME, "r") as log:
         if follow:
             click.echo("Now following logs in real time, press CTRL+C to stop.")
-            for line in tailer.follow(file):
+            for line in tailer.follow(log):
                 click.echo(line)
 
-        for line in tailer.tail(file, lines):
-            click.echo(line)
-            ctx.exit(0)
-
-
-@logs.command()
-@click.pass_context
-@lines_argument
-def head(ctx, lines):
-    """Print the first lines of the logs.
-
-    This subcommand by default will print the first 5 lines from the logs. But you can change
-    the default number by passing an int to the subcommand like such: `opsdroid logs head 50`.
-
-    Args:
-        ctx (:obj:`click.Context`): The current click cli context.
-        lines(int): Number of lines that should be shown from the end up.
-
-    Returns:
-        int: the exit code. Always returns 0 in this case.
-
-    """
-    with open(DEFAULT_LOG_FILENAME) as file:
-        for line in tailer.head(file, lines):
-            click.echo(line)
-
+        click.echo(log.read())
     ctx.exit(0)

--- a/opsdroid/cli/start.py
+++ b/opsdroid/cli/start.py
@@ -23,7 +23,13 @@ _LOGGER = logging.getLogger("opsdroid")
 @click.command()
 @path_option
 def start(path):
-    """Start the opsdroid bot."""
+    """Start the opsdroid bot.
+
+    If the `-f` flag is used with this command, opsdroid will load the
+    configuration specified on that path otherwise it will use the default
+    configuration.
+
+    """
     check_dependencies()
 
     config = load_config_file([path] if path else DEFAULT_CONFIG_LOCATIONS)

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -32,7 +32,7 @@ path_option = click.option(
 )
 
 
-def edit_files(ctx, path):
+def edit_config(ctx, path):
     """Open config/log file with favourite editor.
 
     Args:

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -8,12 +8,10 @@ import logging
 import subprocess
 import sys
 import time
-import warnings
 
 from opsdroid.core import OpsDroid
 from opsdroid.configuration import load_config_file
 from opsdroid.const import (
-    DEFAULT_LOG_FILENAME,
     LOCALE_DIR,
     DEFAULT_LANGUAGE,
     DEFAULT_CONFIG_PATH,
@@ -34,52 +32,33 @@ path_option = click.option(
 )
 
 
-def edit_files(ctx, param, value):
+def edit_files(ctx, path):
     """Open config/log file with favourite editor.
 
     Args:
         ctx (:obj:`click.Context`): The current click cli context.
-        param (dict): a dictionary of all parameters pass to the click
-            context when invoking this function as a callback.
+        path (str or None): the path passed to the config option.
         value (string): the value of this parameter after invocation.
-            It is either "config" or "log" depending on the program
-            calling this function.
 
     Returns:
         int: the exit code. Always returns 0 in this case.
 
     """
-
-    if value == "config":
-        file = DEFAULT_CONFIG_PATH
-        if ctx.command.name == "cli":
-            warn_deprecated_cli_option(
-                "The flag -e/--edit-files has been deprecated. "
-                "Please run `opsdroid config edit` instead."
-            )
-    elif value == "log":
-        file = DEFAULT_LOG_FILENAME
-        if ctx.command.name == "cli":
-            warn_deprecated_cli_option(
-                "The flag -l/--view-log has been deprecated. "
-                "Please run `opsdroid logs` instead."
-            )
-    else:
-        return
-
+    file = path or DEFAULT_CONFIG_PATH
     editor = os.environ.get("EDITOR", "vi")
+
     if editor == "vi":
         click.echo(
             "You are about to edit a file in vim. \n"
             "Read the tutorial on vim at: https://bit.ly/2HRvvrB"
         )
-        time.sleep(3)
+        time.sleep(1.5)
 
     subprocess.run([editor, file])
     ctx.exit(0)
 
 
-def validate_config(ctx, path, value):
+def validate_config(ctx, path):
     """Validate opsdroid configuration.
 
     We load the configuration and modules from it to run the validation on them.
@@ -111,12 +90,6 @@ def validate_config(ctx, path, value):
         click.echo("Configuration validated - No errors founds!")
 
         ctx.exit(0)
-
-
-def warn_deprecated_cli_option(text):
-    """Warn users that the cli option they have used is deprecated."""
-    print(f"Warning: {text}")
-    warnings.warn(text, DeprecationWarning)
 
 
 def configure_lang(config):
@@ -182,7 +155,7 @@ def welcome_message(config):
         )
 
 
-def list_all_modules(ctx, path, value):
+def list_all_modules(ctx, path):
     """List the active modules from config.
 
     This function will try to get information from the modules that are active in the
@@ -192,9 +165,6 @@ def list_all_modules(ctx, path, value):
     Args:
         ctx (:obj:`click.Context`): The current click cli context.
         path (str): a str that contains a path passed.
-        value (string): the value of this parameter after invocation.
-            It is either "config" or "log" depending on the program
-            calling this function.
 
     Returns:
         int: the exit code. Always returns 0 in this case.
@@ -231,7 +201,7 @@ def list_all_modules(ctx, path, value):
     ctx.exit(0)
 
 
-def build_config(ctx, params, value):
+def build_config(ctx, params):
     """Load configuration, load modules and install dependencies.
 
     This function loads the configuration and install all necessary
@@ -244,9 +214,6 @@ def build_config(ctx, params, value):
         ctx (:obj:`click.Context`): The current click cli context.
         params (dict): a dictionary of all parameters pass to the click
             context when invoking this function as a callback.
-        value (string): the value of this parameter after invocation.
-            It is either "config" or "log" depending on the program
-            calling this function.
 
     Returns:
         int: the exit code. Always returns 0 in this case.

--- a/opsdroid/cli/version.py
+++ b/opsdroid/cli/version.py
@@ -1,39 +1,21 @@
 """The version subcommand for opsdroid cli."""
 
-
 import click
 
 from opsdroid import __version__
-from opsdroid.cli.utils import warn_deprecated_cli_option
-
-
-def print_version(ctx, param, value):
-    """[Deprecated] Print out the version of opsdroid that is installed.
-
-    Args:
-        ctx (:obj:`click.Context`): The current click cli context.
-        param (dict): a dictionary of all parameters pass to the click
-            context when invoking this function as a callback.
-        value (bool): the value of this parameter after invocation.
-            Defaults to False, set to true when this flag is called.
-
-    Returns:
-        int: the exit code. Always returns 0 in this case.
-
-    """
-    if not value or ctx.resilient_parsing:
-        return
-    if ctx.command.name == "cli":
-        warn_deprecated_cli_option(
-            "The flag --version has been deprecated. "
-            "Please run `opsdroid version` instead."
-        )
-    click.echo("opsdroid {version}".format(version=__version__))
-    ctx.exit(0)
 
 
 @click.command()
 @click.pass_context
 def version(ctx):
-    """Print the version and exit."""
-    print_version(ctx, None, True)
+    """Print out the version of opsdroid that is installed and exits.
+
+    Args:
+        ctx (:obj:`click.Context`): The current click cli context.
+
+    Returns:
+        int: the exit code. Always returns 0 in this case.
+
+    """
+    click.echo("opsdroid {version}".format(version=__version__))
+    ctx.exit(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pycron==1.0.0
 pyyaml==5.2
 setuptools==42.0.2
 slackclient==2.4.0
+tailer==0.4.1
 ibm-watson==4.0.1
 websockets==8.1
 webexteamssdk==1.2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import unittest
 import unittest.mock as mock
-import pytest
 import os
 import sys
 import shutil
@@ -134,17 +133,6 @@ class TestCLI(unittest.TestCase):
             self.assertFalse(opsdroid_load.called)
             self.assertEqual(result.exit_code, 0)
 
-    def test_deprecated_gen_config(self):
-        with mock.patch.object(click, "echo") as click_echo, mock.patch(
-            "opsdroid.core.OpsDroid.load"
-        ) as opsdroid_load:
-            runner = CliRunner()
-            with pytest.warns(DeprecationWarning, match=".*opsdroid config gen.*"):
-                result = runner.invoke(opsdroid.cli.cli, ["--gen-config"])
-            self.assertTrue(click_echo.called)
-            self.assertFalse(opsdroid_load.called)
-            self.assertEqual(result.exit_code, 0)
-
     def test_print_version(self):
         with mock.patch.object(click, "echo") as click_echo, mock.patch(
             "opsdroid.core.OpsDroid.load"
@@ -153,18 +141,6 @@ class TestCLI(unittest.TestCase):
             from opsdroid.cli.version import version
 
             result = runner.invoke(version, [])
-            self.assertTrue(click_echo.called)
-            self.assertFalse(opsdroid_load.called)
-            self.assertTrue(__version__ in click_echo.call_args[0][0])
-            self.assertEqual(result.exit_code, 0)
-
-    def test_deprecated_print_version(self):
-        with mock.patch.object(click, "echo") as click_echo, mock.patch(
-            "opsdroid.core.OpsDroid.load"
-        ) as opsdroid_load:
-            runner = CliRunner()
-            with pytest.warns(DeprecationWarning, match=".*opsdroid version.*"):
-                result = runner.invoke(opsdroid.cli.cli, ["--version"])
             self.assertTrue(click_echo.called)
             self.assertFalse(opsdroid_load.called)
             self.assertTrue(__version__ in click_echo.call_args[0][0])
@@ -182,46 +158,62 @@ class TestCLI(unittest.TestCase):
             self.assertTrue(editor.called)
             self.assertEqual(result.exit_code, 0)
 
-    def test_deprecated_edit_files_config(self):
-        with mock.patch.object(click, "echo") as click_echo, mock.patch(
-            "subprocess.run"
-        ) as editor:
-            runner = CliRunner()
-            with pytest.warns(DeprecationWarning, match=".*opsdroid config edit.*"):
-                result = runner.invoke(opsdroid.cli.cli, ["--edit-config"], input="y")
-            self.assertTrue(click_echo.called)
-            self.assertTrue(editor.called)
-            self.assertEqual(result.exit_code, 0)
-
-    def test_edit_files_log(self):
-        with mock.patch.object(click, "echo") as click_echo, mock.patch(
-            "subprocess.run"
-        ) as editor:
+    def test_print_files_log(self):
+        with mock.patch.object(click, "echo") as click_echo:
             runner = CliRunner()
             from opsdroid.cli.logs import logs
 
             result = runner.invoke(logs, [])
             self.assertTrue(click_echo.called)
-            self.assertTrue(editor.called)
             self.assertEqual(result.exit_code, 0)
 
-    def test_deprecated_edit_files_log(self):
+    def test_print_files_log_head(self):
         with mock.patch.object(click, "echo") as click_echo, mock.patch(
-            "subprocess.run"
-        ) as editor:
+            "tailer.head"
+        ) as tailer_head, mock.patch("builtins.open"):
             runner = CliRunner()
-            with pytest.warns(DeprecationWarning, match=".*opsdroid logs.*"):
-                result = runner.invoke(opsdroid.cli.cli, ["--view-log"])
+            from opsdroid.cli.logs import logs
+
+            tailer_head.return_value = ["line 1", "line 2"]
+
+            result = runner.invoke(logs, ["head"])
+            self.assertTrue(tailer_head.called)
             self.assertTrue(click_echo.called)
-            self.assertTrue(editor.called)
             self.assertEqual(result.exit_code, 0)
+
+    def test_print_files_log_tail(self):
+        with mock.patch.object(click, "echo") as click_echo, mock.patch(
+            "tailer.tail"
+        ) as tailer_tail, mock.patch("builtins.open"):
+            runner = CliRunner()
+            from opsdroid.cli.logs import logs
+
+            tailer_tail.return_value = ["line 1", "line 2"]
+
+            result = runner.invoke(logs, ["tail"])
+            self.assertTrue(tailer_tail.called)
+            self.assertTrue(click_echo.called)
+            self.assertEqual(result.exit_code, 0)
+
+    def test_print_files_log_tail_follow(self):
+        with mock.patch.object(click, "echo") as click_echo, mock.patch(
+            "tailer.follow"
+        ) as tailer_follow, mock.patch("builtins.open"):
+            runner = CliRunner()
+            from opsdroid.cli.logs import logs
+
+            tailer_follow.return_value = ["line 1", "line 2"]
+
+            runner.invoke(logs, ["tail", "-f"])
+            self.assertTrue(tailer_follow.called)
+            self.assertTrue(click_echo.called)
 
     def test_main(self):
-        with pytest.warns(DeprecationWarning, match=".*opsdroid start.*"):
-            runner = CliRunner()
-            with mock.patch.object(OpsDroid, "run") as mock_run:
-                runner.invoke(opsdroid.cli.cli, [])
-                assert mock_run.called
+        runner = CliRunner()
+
+        with mock.patch.object(OpsDroid, "run") as mock_run:
+            runner.invoke(opsdroid.cli.start, [])
+            assert mock_run.called
 
     def test_config_validate(self):
         with mock.patch.object(click, "echo") as click_echo, mock.patch(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,35 +167,7 @@ class TestCLI(unittest.TestCase):
             self.assertTrue(click_echo.called)
             self.assertEqual(result.exit_code, 0)
 
-    def test_print_files_log_head(self):
-        with mock.patch.object(click, "echo") as click_echo, mock.patch(
-            "tailer.head"
-        ) as tailer_head, mock.patch("builtins.open"):
-            runner = CliRunner()
-            from opsdroid.cli.logs import logs
-
-            tailer_head.return_value = ["line 1", "line 2"]
-
-            result = runner.invoke(logs, ["head"])
-            self.assertTrue(tailer_head.called)
-            self.assertTrue(click_echo.called)
-            self.assertEqual(result.exit_code, 0)
-
-    def test_print_files_log_tail(self):
-        with mock.patch.object(click, "echo") as click_echo, mock.patch(
-            "tailer.tail"
-        ) as tailer_tail, mock.patch("builtins.open"):
-            runner = CliRunner()
-            from opsdroid.cli.logs import logs
-
-            tailer_tail.return_value = ["line 1", "line 2"]
-
-            result = runner.invoke(logs, ["tail"])
-            self.assertTrue(tailer_tail.called)
-            self.assertTrue(click_echo.called)
-            self.assertEqual(result.exit_code, 0)
-
-    def test_print_files_log_tail_follow(self):
+    def test_print_files_log_follow(self):
         with mock.patch.object(click, "echo") as click_echo, mock.patch(
             "tailer.follow"
         ) as tailer_follow, mock.patch("builtins.open"):
@@ -204,7 +176,7 @@ class TestCLI(unittest.TestCase):
 
             tailer_follow.return_value = ["line 1", "line 2"]
 
-            runner.invoke(logs, ["tail", "-f"])
+            runner.invoke(logs, ["-f"])
             self.assertTrue(tailer_follow.called)
             self.assertTrue(click_echo.called)
 


### PR DESCRIPTION
# Description

This PR removes the deprecated flags from the cli, it also adds two new subcommands to the logs command - head and tail.

The head command will print the first 20 lines - this can be changed if passed like `opsdroid logs head 100`

The tail will print the last 20 ones. I've also added the `-f` flag to the tail subcommand to follow the logs in realtime.

I've used the tailer dependency since it seem a good way to deal with it.

I know that we talked in matrix about settings just the -f flag on the logs but perhaps it could be useful to get either the first or last lines of the logs instead of getting them in real time only.


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation (fix or adds documentation) - docstrings


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tox - green and coverage ok
- Ran opsdroid logs - print all the logs
- Ran opsdroid logs head - shows either 20 lines or more if int is passed
- Ran opsdroid logs tail - shows either 20 lines or more if int is passed
- Ran opsdroid and opsdroid logs tail -f - got logs in real time.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
