### PR TITLE
Update pydocstyle and fix linting

### DIFF
--- a/opsdroid/connector/__init__.py
+++ b/opsdroid/connector/__init__.py
@@ -94,6 +94,7 @@ class Connector:
         Args:
             config (dict): The config for this connector specified in the
                            `configuration.yaml` file.
+            opsdroid (OpsDroid): An instance of opsdroid.core.
 
         """
         self.name = ""

--- a/opsdroid/connector/shell/__init__.py
+++ b/opsdroid/connector/shell/__init__.py
@@ -35,12 +35,12 @@ class ConnectorShell(Connector):
 
     @property
     def is_listening(self):
-        """Helper, gets listening."""
+        """Get listening status."""
         return self.listening
 
     @is_listening.setter
     def is_listening(self, val):
-        """Helper, sets listening."""
+        """Set listening status."""
         self.listening = val
 
     async def read_stdin(self):

--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -26,6 +26,7 @@ class ConnectorTelegram(Connector):
         Args:
             config (dict): configuration settings from the
                 file config.yaml.
+            opsdroid (OpsDroid): An instance of opsdroid.core.
 
         """
         _LOGGER.debug(_("Loaded Telegram Connector"))

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -127,7 +127,7 @@ class OpsDroid:
         self.exit()
 
     @staticmethod
-    def handle_async_exception(loop, context):
+    def handle_async_exception(context):
         """Handle exceptions from async coroutines.
 
         Args:

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -127,10 +127,11 @@ class OpsDroid:
         self.exit()
 
     @staticmethod
-    def handle_async_exception(context):
+    def handle_async_exception(loop, context):
         """Handle exceptions from async coroutines.
 
         Args:
+            loop (asyncio.loop): Running loop that raised the exception.
             context (String): Describes the exception encountered.
 
         """

--- a/opsdroid/database/__init__.py
+++ b/opsdroid/database/__init__.py
@@ -19,6 +19,7 @@ class Database:
         Args:
             config (dict): The config for this database specified in the
                            `configuration.yaml` file.
+            opsdroid (OpsDroid): An instance of opsdroid.core.
 
         """
         self.name = ""

--- a/opsdroid/database/mongo/__init__.py
+++ b/opsdroid/database/mongo/__init__.py
@@ -19,9 +19,10 @@ class DatabaseMongo(Database):
         Set some basic properties from the database config such as the name
         of this database.
 
-        Attributes:
+        Args:
             config (dict): The config for this database specified in the
                            `configuration.yaml` file.
+             opsdroid (OpsDroid): An instance of opsdroid.core.
 
         """
         super().__init__(config, opsdroid=opsdroid)

--- a/opsdroid/database/redis/__init__.py
+++ b/opsdroid/database/redis/__init__.py
@@ -26,6 +26,7 @@ class RedisDatabase(Database):
             config (dict): The configuration of the database which consists
                            of `file` and `table` name of the sqlite database
                            specified in `configuration.yaml` file.
+            opsdroid (OpsDroid): An instance of opsdroid.core.
 
         """
         super().__init__(config, opsdroid=opsdroid)

--- a/opsdroid/database/sqlite/__init__.py
+++ b/opsdroid/database/sqlite/__init__.py
@@ -32,6 +32,7 @@ class DatabaseSqlite(Database):
             config (dict): The configuration of the database which consists
                            of `file` and `table` name of the sqlite database
                            specified in `configuration.yaml` file.
+            opsdroid (OpsDroid): An instance of opsdroid.core.
 
         """
         super().__init__(config, opsdroid=opsdroid)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ astroid==2.3.3
 pytest==5.3.1
 pytest-cov==2.7.1
 pytest-timeout==1.3.3
-pydocstyle==4.0.1
+pydocstyle==5.0.1
 asynctest==0.13.0
 mypy-lang==0.5.0
 sphinx==2.2.2


### PR DESCRIPTION
# Description

With the latest pydocstyle update travis was failing due to linting issues. This PR fixes those issues and bumps pydocstyle dependency up to 5.0.1.

Fixes #1297 failured


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tox - All green
- Lint - all green


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
