### PR TITLE
fix(logging): UnboundLocalError when config['logging']['extended'] is…

### DIFF
--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -80,13 +80,14 @@ def configure_logging(config):
 
     rootlogger.setLevel(log_level)
 
+    formatter = logging.Formatter("%(levelname)s %(name)s: %(message)s")
     try:
         if config["logging"]["extended"]:
             formatter = logging.Formatter(
                 "%(levelname)s %(name)s.%(funcName)s(): %(message)s"
             )
     except KeyError:
-        formatter = logging.Formatter("%(levelname)s %(name)s: %(message)s")
+        pass        
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)


### PR DESCRIPTION
# Description

If config['logging']['extended'] == False, we were getting an UnboundLocalError

Set formatter before attempting to get the value from the configuration, on KeyError just ignore.

Fixes #<issue>


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test, set extended to True/False, also removed it from the config file.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
