### PR TITLE
Fix Typos

### DIFF
--- a/opsdroid/connector/gitter/__init__.py
+++ b/opsdroid/connector/gitter/__init__.py
@@ -94,7 +94,7 @@ class ConnectorGitter(Connector):
 
     @register_event(Message)
     async def send_message(self, message):
-        """Recived parsed message and send it back to gitter room."""
+        """Received parsed message and send it back to gitter room."""
         # Send message.text back to the chat service
         url = self.build_url(GITTER_MESSAGE_BASE_API, message.target, "chatMessages")
         headers = {

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -648,7 +648,7 @@ class Loader:
 
         # We only support one skill file in a gist for now.
         #
-        # TODO: Add support for mutliple files. Could be particularly
+        # TODO: Add support for multiple files. Could be particularly
         # useful for including a requirements.txt file.
         skill_content = python_files[0]["content"]
         extension = os.path.splitext(python_files[0]["filename"])[1]


### PR DESCRIPTION
```
opsdroid/opsdroid/connector/gitter/__init__.py:97:11: "Recived" is a misspelling of "Received"
opsdroid/opsdroid/loader.py:651:32: "mutliple" is a misspelling of "multiple"
```