### PR TITLE
Allow mxc URLs in matrix messages

### DIFF
--- a/opsdroid/connector/matrix/html_cleaner.py
+++ b/opsdroid/connector/matrix/html_cleaner.py
@@ -66,7 +66,12 @@ def clean(html, **kwargs):
     A version of `bleach.clean` but with Riot's allowed tags and ``strip=True``
     by default.
     """
-    defaults = {"strip": True, "tags": ALLOWED_TAGS, "attributes": ALLOWED_ATTRIBUTES}
+    defaults = {
+        "strip": True,
+        "tags": ALLOWED_TAGS,
+        "attributes": ALLOWED_ATTRIBUTES,
+        "protocols": ["https", "http", "mxc"],
+    }
     defaults.update(kwargs)
 
     return bleach.clean(html, **defaults)


### PR DESCRIPTION
This is a quick bugfix which allows you to embed images in html messages when using matrix. I think this is a new feature of bleach.