### PR TITLE
Add logs rotation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,15 +191,15 @@ skills:
 You can pass optional arguments to the logging configuration to extend the opsdroid logging.
 
 ##### Logs rotation
-To keep the logs under control the file will grow to 50kb before being rotated back. You can change the default value by passing the `file-size` argument.
+To keep the logs under control the file will grow to 50MB before being rotated back. You can change the default value by passing the `file-size` argument.
 
 ```yaml
 logging:
   level: info
-  file-size: 100
+  file-size: 100e6
 ```
 
-This will change the size of the file to 100kb before being rotated back to zero.
+This will change the size of the file to 100MB before being rotated back to zero.
 
 ##### extended mode
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,7 @@ The default locations for the logs are:
 - Linux: `/home/<User>/.cache/opsdroid/log`
 - Windows: `C:\Users\<User>\AppData\Local\opsdroid\Logs\`
 
-If you are using one of the default paths for your log you can run the command `opsdroid logs` to open the logs with your favorite editor (taken from the environment variable `EDITOR`) or the default editor vim.
+If you are using one of the default paths for your log you can run the command `opsdroid logs` to print the logs into the terminal. 
 
 ```yaml
 logging:
@@ -189,6 +189,17 @@ skills:
 #### Optional logging arguments
 
 You can pass optional arguments to the logging configuration to extend the opsdroid logging.
+
+##### Logs rotation
+To keep the logs under control the file will grow to 50kb before being rotated back. You can change the default value by passing the `file-size` argument.
+
+```yaml
+logging:
+  level: info
+  file-size: 100
+```
+
+This will change the size of the file to 100kb before being rotated back to zero.
 
 ##### extended mode
 

--- a/opsdroid/configuration/validation.py
+++ b/opsdroid/configuration/validation.py
@@ -9,6 +9,7 @@ logging = {
     Optional("level"): str,
     Optional("console"): bool,
     Optional("extended"): bool,
+    Optional("file-size"): int,
     Optional("filter"): {Optional("whitelist"): list, Optional("blacklist"): list},
 }
 

--- a/opsdroid/configuration/validation.py
+++ b/opsdroid/configuration/validation.py
@@ -9,7 +9,6 @@ logging = {
     Optional("level"): str,
     Optional("console"): bool,
     Optional("extended"): bool,
-    Optional("file-size"): int,
     Optional("filter"): {Optional("whitelist"): list, Optional("blacklist"): list},
 }
 

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -4,6 +4,7 @@ import os
 import logging
 import contextlib
 
+from logging.handlers import RotatingFileHandler
 from opsdroid.const import DEFAULT_LOG_FILENAME, __version__
 
 _LOGGER = logging.getLogger(__name__)
@@ -112,6 +113,8 @@ def configure_logging(config):
         with contextlib.suppress(KeyError):
             file_handler.addFilter(ParsingFilter(config, config["logging"]["filter"]))
 
+        rotation_handler = RotatingFileHandler(logfile_path, maxBytes=config["logging"].get('file-size', 50))
+        rootlogger.addHandler(rotation_handler)
         rootlogger.addHandler(file_handler)
     _LOGGER.info("=" * 40)
     _LOGGER.info(_("Started opsdroid %s."), __version__)

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -113,8 +113,8 @@ def configure_logging(config):
         with contextlib.suppress(KeyError):
             file_handler.addFilter(ParsingFilter(config, config["logging"]["filter"]))
 
-        rotation_handler = RotatingFileHandler(logfile_path, maxBytes=config["logging"].get('file-size', 50))
-        rootlogger.addHandler(rotation_handler)
+            rotation_handler = RotatingFileHandler(logfile_path, maxBytes=config["logging"].get('file-size', 50e6))
+            rootlogger.addHandler(rotation_handler)
         rootlogger.addHandler(file_handler)
     _LOGGER.info("=" * 40)
     _LOGGER.info(_("Started opsdroid %s."), __version__)

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -113,7 +113,7 @@ def configure_logging(config):
         with contextlib.suppress(KeyError):
             file_handler.addFilter(ParsingFilter(config, config["logging"]["filter"]))
 
-            rotation_handler = RotatingFileHandler(logfile_path, maxBytes=config["logging"].get('file-size', 50e6))
+            rotation_handler = RotatingFileHandler(logfile_path, maxBytes=config["logging"].get("file-size", 50e6))
             rootlogger.addHandler(rotation_handler)
         rootlogger.addHandler(file_handler)
     _LOGGER.info("=" * 40)

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -63,6 +63,8 @@ class ParsingFilter(logging.Filter):
 def configure_logging(config):
     """Configure the root logger based on user config."""
     rootlogger = logging.getLogger()
+    logging_config = config or {}
+
     while rootlogger.handlers:
         rootlogger.handlers.pop()
 
@@ -107,13 +109,14 @@ def configure_logging(config):
         if not os.path.isdir(logdir):
             os.makedirs(logdir)
 
-        with contextlib.suppress(KeyError):
-            file_handler = RotatingFileHandler(
-                logfile_path, maxBytes=config["logging"].get("file-size", 50e6)
-            )
+        file_handler = RotatingFileHandler(
+            logfile_path, maxBytes=logging_config.get("file-size", 50e6)
+        )
 
-            file_handler.setLevel(log_level)
-            file_handler.setFormatter(formatter)
+        file_handler.setLevel(log_level)
+        file_handler.setFormatter(formatter)
+
+        with contextlib.suppress(KeyError):
             file_handler.addFilter(ParsingFilter(config, config["logging"]["filter"]))
 
         rootlogger.addHandler(file_handler)

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -113,8 +113,10 @@ def configure_logging(config):
         with contextlib.suppress(KeyError):
             file_handler.addFilter(ParsingFilter(config, config["logging"]["filter"]))
 
-            rotation_handler = RotatingFileHandler(logfile_path, maxBytes=config["logging"].get("file-size", 50e6))
-            rootlogger.addHandler(rotation_handler)
+            file_handler = RotatingFileHandler(
+                logfile_path, maxBytes=config["logging"].get("file-size", 50e6)
+            )
+
         rootlogger.addHandler(file_handler)
     _LOGGER.info("=" * 40)
     _LOGGER.info(_("Started opsdroid %s."), __version__)

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -106,16 +106,15 @@ def configure_logging(config):
         logdir = os.path.dirname(os.path.realpath(logfile_path))
         if not os.path.isdir(logdir):
             os.makedirs(logdir)
-        file_handler = logging.FileHandler(logfile_path)
-        file_handler.setLevel(log_level)
-        file_handler.setFormatter(formatter)
 
         with contextlib.suppress(KeyError):
-            file_handler.addFilter(ParsingFilter(config, config["logging"]["filter"]))
-
             file_handler = RotatingFileHandler(
                 logfile_path, maxBytes=config["logging"].get("file-size", 50e6)
             )
+
+            file_handler.setLevel(log_level)
+            file_handler.setFormatter(formatter)
+            file_handler.addFilter(ParsingFilter(config, config["logging"]["filter"]))
 
         rootlogger.addHandler(file_handler)
     _LOGGER.info("=" * 40)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -59,13 +59,12 @@ class TestLogging(unittest.TestCase):
         }
         opsdroid.configure_logging(config)
         rootlogger = logging.getLogger()
-        self.assertEqual(len(rootlogger.handlers), 3)
+        self.assertEqual(len(rootlogger.handlers), 2)
         self.assertEqual(logging.StreamHandler, type(rootlogger.handlers[0]))
         self.assertEqual(rootlogger.handlers[0].level, logging.CRITICAL)
         self.assertEqual(
             logging.handlers.RotatingFileHandler, type(rootlogger.handlers[1])
         )
-        self.assertEqual(rootlogger.handlers[1].level, logging.INFO)
         self.assertLogs("_LOGGER", None)
 
     def test_configure_file_logging_directory_not_exists(self):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -62,7 +62,9 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(rootlogger.handlers), 3)
         self.assertEqual(logging.StreamHandler, type(rootlogger.handlers[0]))
         self.assertEqual(rootlogger.handlers[0].level, logging.CRITICAL)
-        self.assertEqual(logging.FileHandler, type(rootlogger.handlers[1]))
+        self.assertEqual(
+            logging.handlers.RotatingFileHandler, type(rootlogger.handlers[1])
+        )
         self.assertEqual(rootlogger.handlers[1].level, logging.INFO)
         self.assertLogs("_LOGGER", None)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -46,7 +46,9 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(rootlogger.handlers), 2)
         self.assertEqual(logging.StreamHandler, type(rootlogger.handlers[0]))
         self.assertEqual(rootlogger.handlers[0].level, logging.CRITICAL)
-        self.assertEqual(logging.FileHandler, type(rootlogger.handlers[1]))
+        self.assertEqual(
+            logging.handlers.RotatingFileHandler, type(rootlogger.handlers[1])
+        )
         self.assertEqual(rootlogger.handlers[1].level, logging.INFO)
 
     def test_configure_file_blacklist(self):
@@ -103,7 +105,7 @@ class TestLogging(unittest.TestCase):
         rootlogger = logging.getLogger()
         self.assertEqual(len(rootlogger.handlers), 1)
         self.assertEqual(logging.StreamHandler, type(rootlogger.handlers[0]))
-        self.assertEqual(rootlogger.handlers[1].level, logging.ERROR)
+        self.assertEqual(rootlogger.handlers[0].level, logging.ERROR)
         self.assertLogs("_LOGGER", None)
 
     def test_configure_console_whitelist(self):
@@ -142,7 +144,9 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(rootlogger.handlers), 2)
         self.assertEqual(logging.StreamHandler, type(rootlogger.handlers[0]))
         self.assertEqual(rootlogger.handlers[0].level, logging.INFO)
-        self.assertEqual(logging.FileHandler, type(rootlogger.handlers[1]))
+        self.assertEqual(
+            logging.handlers.RotatingFileHandler, type(rootlogger.handlers[1])
+        )
         self.assertEqual(rootlogger.handlers[1].level, logging.INFO)
         self.assertLogs("_LOGGER", "info")
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -103,6 +103,7 @@ class TestLogging(unittest.TestCase):
         rootlogger = logging.getLogger()
         self.assertEqual(len(rootlogger.handlers), 1)
         self.assertEqual(logging.StreamHandler, type(rootlogger.handlers[0]))
+        self.assertEqual(rootlogger.handlers[1].level, logging.ERROR)
         self.assertLogs("_LOGGER", None)
 
     def test_configure_console_whitelist(self):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -59,7 +59,7 @@ class TestLogging(unittest.TestCase):
         }
         opsdroid.configure_logging(config)
         rootlogger = logging.getLogger()
-        self.assertEqual(len(rootlogger.handlers), 2)
+        self.assertEqual(len(rootlogger.handlers), 3)
         self.assertEqual(logging.StreamHandler, type(rootlogger.handlers[0]))
         self.assertEqual(rootlogger.handlers[0].level, logging.CRITICAL)
         self.assertEqual(logging.FileHandler, type(rootlogger.handlers[1]))


### PR DESCRIPTION
# Description

I've been meant to add rotation to logs for a while now, finally I've sat down and got working on it. This is a pretty simple change but works as expected. 

I've decided on 50kb size +/- mostly because it should be the size of 1000 lines. I'd be happy to change this if you prefer something else 😄 

We could add a timed rotation as well but I'm not sure if that should be added or not what do you think?

Fixes #<issue>


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tox - all green
- Ran opsdroid and watch logs being rotated


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
