### PR TITLE
Change entities to be sync and add helper for getting entity

### DIFF
--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -277,7 +277,7 @@ class ConnectorSlack(Connector):
                         action_value = [v["value"] for v in action["selected_options"]]
 
                     if action_value:
-                        await block_action.update_entity("value", action_value)
+                        block_action.update_entity("value", action_value)
                     await self.opsdroid.parse(block_action)
             elif payload["type"] == "message_action":
                 await self.opsdroid.parse(

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -154,18 +154,30 @@ class Event(metaclass=EventMetaClass):
 
         return result
 
-    async def update_entity(self, name, value, confidence=None):
+    def update_entity(self, name, value, confidence=None):
         """Add or update an entitiy.
 
         Adds or updates an entitiy entry for an event.
 
         Args:
-            name (string): String name of entity
-            value (string): String value of entity
+            name (string): Name of entity
+            value (string): Value of entity
             confidence (float, optional): Confidence that entity is correct
 
         """
         self.entities[name] = {"value": value, "confidence": confidence}
+
+    def get_entity(self, name):
+        """Get the value of an entity by name.
+
+        Args:
+            name (string): Name of entity
+
+        Returns:
+            The value of the entity. Returns ``None`` if no such entity.
+
+        """
+        return self.entities.get(name, {}).get("value", None)
 
 
 class OpsdroidStarted(Event):

--- a/opsdroid/parsers/luisai.py
+++ b/opsdroid/parsers/luisai.py
@@ -83,7 +83,7 @@ async def parse_luisai(opsdroid, skills, message, config):
                             message.luisai = result
                             for entity in message.luisai["entities"]:
                                 if "role" in entity:
-                                    await message.update_entity(
+                                    message.update_entity(
                                         entity["role"],
                                         entity["entity"],
                                         result["topScoringIntent"]["score"],

--- a/opsdroid/parsers/parseformat.py
+++ b/opsdroid/parsers/parseformat.py
@@ -33,7 +33,7 @@ async def parse_format(opsdroid, skills, message):
                     message.parse_result = result
                     _LOGGER.debug(result.__dict__)
                     for group, value in result.named.items():
-                        await message.update_entity(group, value, None)
+                        message.update_entity(group, value, None)
                     matched_skills.append(
                         {
                             "score": await calculate_score(

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -213,7 +213,7 @@ async def parse_rasanlu(opsdroid, skills, message, config):
                     if matcher["rasanlu_intent"] == result["intent"]["name"]:
                         message.rasanlu = result
                         for entity in result["entities"]:
-                            await message.update_entity(
+                            message.update_entity(
                                 entity["entity"], entity["value"], entity["confidence"]
                             )
                         matched_skills.append(

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -41,7 +41,7 @@ async def parse_regex(opsdroid, skills, message):
                 if regex:
                     message.regex = regex
                     for regroup, value in regex.groupdict().items():
-                        await message.update_entity(regroup, value, None)
+                        message.update_entity(regroup, value, None)
                     matched_skills.append(
                         {
                             "score": await calculate_score(

--- a/opsdroid/parsers/sapcai.py
+++ b/opsdroid/parsers/sapcai.py
@@ -77,7 +77,7 @@ async def parse_sapcai(opsdroid, skills, message, config):
                             for key, entity in (
                                 result["results"].get("entities", {}).items()
                             ):
-                                await message.update_entity(
+                                message.update_entity(
                                     key, entity[0]["raw"], entity[0]["confidence"]
                                 )
                             _LOGGER.debug(

--- a/opsdroid/parsers/watson.py
+++ b/opsdroid/parsers/watson.py
@@ -140,7 +140,7 @@ async def parse_watson(opsdroid, skills, message, config):
                                 result["output"]["entities"]
                             )
                             for key, value in entities.items():
-                                await message.update_entity(
+                                message.update_entity(
                                     key,
                                     value,
                                     result["output"]["intents"][0]["confidence"],

--- a/opsdroid/parsers/witai.py
+++ b/opsdroid/parsers/witai.py
@@ -68,7 +68,7 @@ async def parse_witai(opsdroid, skills, message, config):
                             message.witai = result
                             for key, entity in result["entities"].items():
                                 if key != "intent":
-                                    await message.update_entity(
+                                    message.update_entity(
                                         key, entity[0]["value"], entity[0]["confidence"]
                                     )
                             matched_skills.append(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -36,6 +36,16 @@ class TestEvent(asynctest.TestCase):
         self.assertEqual(event.user, "user")
         self.assertEqual(event.target, "default")
 
+    async def test_entities(self):
+        opsdroid = amock.CoroutineMock()
+        mock_connector = Connector({}, opsdroid=opsdroid)
+        event = events.Event("user_id", "user", "default", mock_connector)
+
+        event.update_entity("city", "London", 0.8)
+        assert event.entities["city"]["value"] == "London"
+        assert event.entities["city"]["confidence"] == 0.8
+        assert event.get_entity("city") == "London"
+
     def test_unique_subclasses(self):
         with self.assertRaises(NameError):
 

--- a/tests/test_parser_event_type.py
+++ b/tests/test_parser_event_type.py
@@ -43,7 +43,7 @@ class TestParserEvent(asynctest.TestCase):
 
             mock_connector = amock.CoroutineMock()
             message1 = events.Message("Hello World", "user", "default", mock_connector)
-            await message1.update_entity("value", "click_me_123")
+            message1.update_entity("value", "click_me_123")
 
             await opsdroid.parse(message1)
             self.assertTrue(opsdroid.run_skill.called)
@@ -51,7 +51,7 @@ class TestParserEvent(asynctest.TestCase):
             opsdroid.run_skill.reset_mock()
 
             message2 = events.Message("Hello World", "user", "default", mock_connector)
-            await message2.update_entity("value", "click_me_456")
+            message2.update_entity("value", "click_me_456")
 
             await opsdroid.parse(message2)
             self.assertFalse(opsdroid.run_skill.called)


### PR DESCRIPTION
As `opsdroid.events.Event.update_entity` does not make any IO calls it makes more sense for it to be a sync function.

I've also added a helper function called `opsdroid.events.Event.get_entity` for quickly and easily getting the value of an entity.