### PR TITLE
Update validated config with defaults

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -41,6 +41,18 @@ skills:
 
 For more information about the various ways you can package skills and other modules and tell opsdroid about them see the [packaging section](../packaging).
 
+It is also possible to specify your expected configuration schema by setting the `CONFIG_SCHEMA` constant within your skill. We use the [voluptuous](https://github.com/alecthomas/voluptuous) library for validating configuration.
+
+```python
+from voluptuous import Required
+
+CONFIG_SCHEMA = {
+  Required("foo", default="bar"): str,
+  Required("baz"): int}
+```
+
+By adding this to the top of your skill you are specifying that you expect the user to set `foo` and `baz` in their config. If they fail to specify `foo` it will use the default value of `bar`, but if they fail to specify `baz` the skill will fail to load.
+
 ## Matchers
 
 Opsdroid contains a vraiety of matchers you can use to make use of advanced parsing services such as natural language understanding APIs or non-chat events such as cron based scheduled tasks or webhooks.
@@ -100,4 +112,4 @@ You can also specify code to run when your skill is loaded. Perhaps you want to 
 
 For examples of the kind of skills you can build in opsdroid see the [examples section](../examples/index). Or continue reading about more of the features you can use to create your skills.
 
-*If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
+_If you need help or if you are unsure about something join our_ [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) _and ask away! We are more than happy to help you._

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -55,7 +55,7 @@ By adding this to the top of your skill you are specifying that you expect the u
 
 ## Matchers
 
-Opsdroid contains a vraiety of matchers you can use to make use of advanced parsing services such as natural language understanding APIs or non-chat events such as cron based scheduled tasks or webhooks.
+Opsdroid contains a variety of matchers you can use to make use of advanced parsing services such as natural language understanding APIs or non-chat events such as cron based scheduled tasks or webhooks.
 
 ```eval_rst
 .. toctree::

--- a/opsdroid/configuration/__init__.py
+++ b/opsdroid/configuration/__init__.py
@@ -115,7 +115,7 @@ def load_config_file(config_paths):
             validate_data_type(data)
 
             configuration = update_pre_0_17_config_format(data)
-            validate_configuration(configuration, BASE_SCHEMA)
+            configuration = validate_configuration(configuration, BASE_SCHEMA)
 
             return configuration
 

--- a/opsdroid/configuration/validation.py
+++ b/opsdroid/configuration/validation.py
@@ -49,7 +49,7 @@ def validate_configuration(config, schema):
     """
     validate = Schema(schema, extra=ALLOW_EXTRA)
     try:
-        validate(config)
+        return validate(config)
     except MultipleInvalid as error:
         _LOGGER.critical(
             _("Configuration for %s failed validation! %s - '%s'."),

--- a/opsdroid/configuration/validation.py
+++ b/opsdroid/configuration/validation.py
@@ -49,10 +49,7 @@ def validate_configuration(config, schema):
     """
     validate = Schema(schema, extra=ALLOW_EXTRA)
     try:
-        config = validate(config)
-        if config is None:
-            config = {}
-        return config
+        return validate(config)
     except MultipleInvalid as error:
         _LOGGER.critical(
             _("Configuration for %s failed validation! %s - '%s'."),

--- a/opsdroid/configuration/validation.py
+++ b/opsdroid/configuration/validation.py
@@ -49,7 +49,10 @@ def validate_configuration(config, schema):
     """
     validate = Schema(schema, extra=ALLOW_EXTRA)
     try:
-        return validate(config)
+        config = validate(config)
+        if config is None:
+            config = {}
+        return config
     except MultipleInvalid as error:
         _LOGGER.critical(
             _("Configuration for %s failed validation! %s - '%s'."),

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -471,7 +471,7 @@ class Loader:
 
             # Suppress exception if module doesn't contain CONFIG_SCHEMA
             with contextlib.suppress(AttributeError):
-                validate_configuration(config, module.CONFIG_SCHEMA)
+                config = validate_configuration(config, module.CONFIG_SCHEMA)
 
             # Load intents
             intents = self._load_intents(config)

--- a/tests/mockmodules/skills/schema_skill/__init__.py
+++ b/tests/mockmodules/skills/schema_skill/__init__.py
@@ -1,0 +1,21 @@
+"""A mocked skill."""
+
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
+from voluptuous import Required
+
+CONFIG_SCHEMA = {Required("foo", default="bar"): str}
+
+
+class TestSkill(Skill):
+    """A mocked skill."""
+
+    @match_regex("test")
+    def test_method(self, message):
+        """A test method skill."""
+        pass
+
+    @property
+    def bad_property(self):
+        """Bad property which raises exceptions."""
+        raise Exception

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -6,6 +6,7 @@ import contextlib
 import unittest
 import unittest.mock as mock
 
+from opsdroid.core import OpsDroid
 from opsdroid.cli.start import configure_lang
 from opsdroid import loader as ld
 from opsdroid.configuration import (
@@ -35,9 +36,6 @@ class TestConfiguration(unittest.TestCase):
         shutil.rmtree(self._tmp_dir, onerror=del_rw)
 
     def test_schema(self):
-        import os.path
-        from opsdroid.core import OpsDroid
-
         skill_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             "mockmodules/skills/schema_skill",
@@ -47,9 +45,7 @@ class TestConfiguration(unittest.TestCase):
             "skills": {"test": {"path": skill_path}},
         }
         with OpsDroid(config=example_config) as opsdroid:
-            opsdroid.setup_skills(
-                opsdroid.loader.load_modules_from_config(opsdroid.config)["skills"]
-            )
+            opsdroid.sync_load()
             assert opsdroid.skills
             assert len(opsdroid.skills) == 1
             assert "foo" in opsdroid.skills[0].config

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -34,6 +34,27 @@ class TestConfiguration(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self._tmp_dir, onerror=del_rw)
 
+    def test_schema(self):
+        import os.path
+        from opsdroid.core import OpsDroid
+
+        skill_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "mockmodules/skills/schema_skill",
+        )
+        example_config = {
+            "connectors": {"websocket": {}},
+            "skills": {"test": {"path": skill_path}},
+        }
+        with OpsDroid(config=example_config) as opsdroid:
+            opsdroid.setup_skills(
+                opsdroid.loader.load_modules_from_config(opsdroid.config)["skills"]
+            )
+            assert opsdroid.skills
+            assert len(opsdroid.skills) == 1
+            assert "foo" in opsdroid.skills[0].config
+            assert opsdroid.skills[0].config["foo"] == "bar"
+
     def test_load_config_file(self):
         config = load_config_file([os.path.abspath("tests/configs/minimal.yaml")])
         self.assertIsNotNone(config)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -281,8 +281,6 @@ class TestLoader(unittest.TestCase):
     def test_load_minimal_config_file(self):
         opsdroid, loader = self.setup()
         config = load_config_file([os.path.abspath("tests/configs/minimal.yaml")])
-        loader._install_module = mock.MagicMock()
-        loader.import_module = mock.MagicMock()
         modules = loader.load_modules_from_config(config)
         self.assertIsNotNone(modules["connectors"])
         self.assertIsNone(modules["databases"])
@@ -291,8 +289,6 @@ class TestLoader(unittest.TestCase):
 
     def test_load_minimal_config_file_2(self):
         opsdroid, loader = self.setup()
-        loader._install_module = mock.MagicMock()
-        loader.import_module = mock.MagicMock()
         config = load_config_file([os.path.abspath("tests/configs/minimal_2.yaml")])
         modules = loader.load_modules_from_config(config)
         self.assertIsNotNone(modules["connectors"])
@@ -679,7 +675,7 @@ class TestLoader(unittest.TestCase):
 
     def test_setup_module_bad_config(self):
         opsdroid, loader = self.setup()
-        with mock.patch("sys.exit") as mock_sysexit:
+        with mock.patch("sys.exit") as mock_sysexit, contextlib.suppress(TypeError):
             config = load_config_file(
                 [os.path.abspath("tests/configs/broken_modules.yaml")]
             )


### PR DESCRIPTION
# Description

When setting your `CONFIG_SCHEMA` with voluptuous it is possible to set default values for the configuration. However we are not actually capturing the output of the `validate` command which returns the validated config with the defaults applied.

This PR returns the validated config and updates it so you can set default config values in your skills like this:

```python
from voluptuous import Required

CONFIG_SCHEMA = {Required("foo", default="bar"): str}
```

Related to #1347


## Status
**READY** 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've added a new test which loads in a skill that has a default configuration option set and asserts that value is correct in the `config` object.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
