### PR TITLE
Document sending messages to the default connector target

### DIFF
--- a/docs/skills/matchers/crontab.md
+++ b/docs/skills/matchers/crontab.md
@@ -15,21 +15,41 @@ from opsdroid.events import Message
 
 class CrontabSkill(Skill):
     @match_crontab('* * * * *', timezone="Europe/London")
-    async def mycrontabskill(self, message):
-
-        # Get the default connector
-        connector = self.opsdroid.default_connector
-
-        # Get the default room for that connector
-        room = connector.default_target
-
-        # Create an empty message to respond to
-        message = Message(text="", target=room, connector=connector)
-
-        # Respond
-        await message.respond('Hey')
+    async def mycrontabskill(self, event):
+        await opsdroid.send(Message(text="Hey"))
 ```
 
-The above skill would be called every minute. As the skill is being triggered by something other than a message the `message` argument being passed in will be set to `None`, this means you need to create an empty message to respond to. You will also need to know which connector, and possibly which room, to send the message back to. For this you can use the `opsdroid.default_connector` and `opsdroid.default_connector.default_target` properties to get some sensible defaults.
+The above skill would be called every minute. The skill then asks opsdroid to send a message with the text `Hey` and because we do not tell opsdroid where to send the message it will be sent to the default target of the default connector. You can also access these defaults yourself at `opsdroid.default_connector` and `opsdroid.default_connector.default_target`.
 
 You can also set the timezone that the skill crontab is aligned with. This is useful if you want to have different time zones between skills. This kwarg is optional, if not set it will default to the timezone specified in the root of the configuration or failing that UTC.
+
+You may also want to be able to configure where messages are sent by default on a skill by skill basis.
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_crontab
+from opsdroid.events import Message
+
+class CrontabSkill(Skill):
+    @match_crontab('* * * * *', timezone="Europe/London")
+    async def mycrontabskill(self, event):
+        await self.opsdroid.send(
+            Message(
+                text="Hey",
+                connector=self.config.get("default-connector"),
+                target=self.config.get("default-target")
+            )
+        )
+```
+
+```yaml
+# ...
+
+skills:
+  mycrontabskills:
+    path: /path/to/skill
+    default-connector: "slack"
+    default-target: "#random"
+```
+
+In the above example we are specifying that the message should be sent to Slack in the `#random` room by setting these values in our config and accessing them within the skill. If we removed the configuration options then the `self.config.get` calls would return `None` and opsdroid would again fall back to the main defaults from the first example.


### PR DESCRIPTION
# Description

The documentation was outdated and described creating a dummy message with the default connector and target in order to be able to respond to it. However we do not need to do that any more as we can just call `opsdroid.send` with a new `Message` object and sensible defaults will be used.

I also documented a quick example of overriding these defaults from your config on a skill by skill basis. This should satisfy the discussion in #1349.


## Status
**READY** 


## Type of change

- Documentation (fix or adds documentation)


# How Has This Been Tested?
NA


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
