### PR TITLE
Fix Slack connector exiting on messages with no user

### DIFF
--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -144,7 +144,8 @@ class ConnectorSlack(Connector):
         _LOGGER.debug(_("Looking up sender username."))
         try:
             user_info = await self.lookup_username(message["user"])
-        except ValueError:
+        except (ValueError, KeyError) as error:
+            _LOGGER.error(_("Username lookup failed for %s."), error)
             return
 
         # Replace usernames in the message

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -148,6 +148,11 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         await connector.process_message(data=message)
         self.assertFalse(connector.opsdroid.parse.called)
 
+        connector.opsdroid.parse.reset_mock()
+        connector.lookup_username.side_effect = KeyError
+        await connector.process_message(data=message)
+        self.assertFalse(connector.opsdroid.parse.called)
+
     async def test_lookup_username(self):
         """Test that looking up a username works and that it caches."""
         connector = ConnectorSlack({"token": "abc123"}, opsdroid=OpsDroid())


### PR DESCRIPTION
# Description
Added a check for `KeyError` in Slack initialisation. If the exception raised is of type `KeyError`, an error will be logged using `_Logger`. No dependencies needed.

Fixes #1361


## Status
READY


## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
