### PR TITLE
Create event for users joining a room in Matrix

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -108,11 +108,7 @@ class ConnectorMatrix(Connector):
             "event_format": "client",
             "account_data": {"limit": 0, "types": []},
             "presence": {"limit": 0, "types": []},
-            "room": {
-                "account_data": {"types": []},
-                "ephemeral": {"types": []},
-                "state": {"types": []},
-            },
+            "room": {"account_data": {"types": []}, "ephemeral": {"types": []}},
         }
 
     async def make_filter(self, api):

--- a/opsdroid/connector/matrix/create_events.py
+++ b/opsdroid/connector/matrix/create_events.py
@@ -36,6 +36,7 @@ class MatrixEventCreator(events.EventCreator):
         self.event_types["m.room.topic"] = self.create_room_description
         self.event_types["m.room.name"] = self.create_room_name
         self.event_types["m.reaction"] = self.create_reaction
+        self.event_types["m.room.member"] = self.create_join_room
 
         self.message_events = defaultdict(lambda: self.skip)
         self.message_events.update(
@@ -147,3 +148,15 @@ class MatrixEventCreator(events.EventCreator):
             linked_event=parent_event,
             raw_event=event,
         )
+
+    async def create_join_room(self, event, roomid):
+        """Send a JoinRoomEvent."""
+        if event["content"]["membership"] == "join":
+            return events.JoinRoom(
+                user=await self.connector.get_nick(roomid, event["sender"]),
+                user_id=event["sender"],
+                target=roomid,
+                connector=self.connector,
+                event_id=event["event_id"],
+                raw_event=event,
+            )

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -896,6 +896,23 @@ class TestEventCreatorAsync(asynctest.TestCase):
         }
 
     @property
+    def join_room_json(self):
+        return {
+            "content": {
+                "avatar_url": "mxc://example.org/SEsfnsuifSDFSSEF",
+                "displayname": "Alice Margatroid",
+                "membership": "join",
+            },
+            "event_id": "$143273582443PhrSn:example.org",
+            "origin_server_ts": 1432735824653,
+            "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+            "sender": "@example:example.org",
+            "state_key": "@alice:example.org",
+            "type": "m.room.member",
+            "unsigned": {"age": 1234},
+        }
+
+    @property
     def event_creator(self):
         patched_get_nick = amock.MagicMock()
         patched_get_nick.return_value = asyncio.Future()
@@ -1017,3 +1034,12 @@ class TestEventCreatorAsync(asynctest.TestCase):
         assert event.raw_event == self.reply_json
 
         assert isinstance(event.linked_event, events.Message)
+
+    async def test_create_joinroom(self):
+        event = await self.event_creator.create_event(self.join_room_json, "hello")
+        assert isinstance(event, events.JoinRoom)
+        assert event.user == "Rabbit Hole"
+        assert event.user_id == "@example:example.org"
+        assert event.target == "hello"
+        assert event.event_id == "$143273582443PhrSn:example.org"
+        assert event.raw_event == self.join_room_json


### PR DESCRIPTION
# Description
Listens to matrix state events and creates a JoinRoom event when a `m.room.member` event with content `"membership": "join"` occurs.

## Status
**READY**

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested with this skill:
```
@match_event(JoinRoom)
    async def hello_join(self, event):
        text = random.choice(
            ["Welcome {}", "Hey {}, nice to meet you"]).format(event.user)
        await event.respond(Message(text))
```

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
