### PR TITLE
Add matcher that fires when bot is mentioned

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -30,6 +30,7 @@ from opsdroid.parsers.witai import parse_witai
 from opsdroid.parsers.watson import parse_watson
 from opsdroid.parsers.rasanlu import parse_rasanlu, train_rasanlu
 from opsdroid.parsers.crontab import parse_crontab
+from opsdroid.parsers.mention import parse_mention
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -420,6 +421,7 @@ class OpsDroid:
         if isinstance(message, events.Message):
             ranked_skills += await parse_regex(self, skills, message)
             ranked_skills += await parse_format(self, skills, message)
+            ranked_skills += await parse_mention(self, skills, message)
 
         if "parsers" in self.config:
             _LOGGER.debug(_("Processing parsers..."))

--- a/opsdroid/matchers.py
+++ b/opsdroid/matchers.py
@@ -358,3 +358,25 @@ def match_always(func=None):
     if callable(func):
         return matcher(func)
     return matcher
+
+
+def match_mention(func=None):
+    """Return mention match decorator.
+
+    Decorator that calls the decorated function if the bot is mentioned.
+
+    Returns:
+        Decorated Function
+
+    """
+
+    def matcher(func):
+        """Add decorated function to skills list for always matching."""
+        func = add_skill_attributes(func)
+        func.matchers.append({"mention": True})
+        return func
+
+    # Allow for decorator with or without parenthesis as there are no args.
+    if callable(func):
+        return matcher(func)
+    return matcher

--- a/opsdroid/parsers/mention.py
+++ b/opsdroid/parsers/mention.py
@@ -1,13 +1,24 @@
 """A helper function for parsing and executing mention skills."""
 
 import logging
+import re
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def parse_mention(opsdroid, skills, message):
-    """Parse a message if the bot is mentioned."""
+    """Parse a message if the bot is mentioned.
+
+    Args:
+        opsdroid (OpsDroid): An instance of opsdroid.core.
+        skills (list): A list containing all skills available.
+        message(object): An instance of events.message.
+
+    Return:
+        Either empty list or a list containing all matched skills.
+    """
+
     matched_skills = []
     mentions = {}
 
@@ -19,11 +30,9 @@ async def parse_mention(opsdroid, skills, message):
         for matcher in skill.matchers:
             if "mention" in matcher:
                 if "matrix" in mentions:
-                    if "formatted_body" in message.raw_event["content"] and (
-                        '<a href="https://matrix.to/#/' + mentions["matrix"] + '">'
-                        in message.raw_event["content"]["formatted_body"]
-                        or "<a href='https://matrix.to/#/" + mentions["matrix"] + "'>"
-                        in message.raw_event["content"]["formatted_body"]
+                    if "formatted_body" in message.raw_event["content"] and re.search(
+                        "https://matrix.to/#/" + mentions["matrix"],
+                        message.raw_event["content"]["formatted_body"],
                     ):
                         matched_skills.append(
                             {

--- a/opsdroid/parsers/mention.py
+++ b/opsdroid/parsers/mention.py
@@ -1,0 +1,37 @@
+"""A helper function for parsing and executing mention skills."""
+
+import logging
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def parse_mention(opsdroid, skills, message):
+    """Parse a message if the bot is mentioned."""
+    matched_skills = []
+    mentions = {}
+
+    for connector in opsdroid.connectors:
+        if connector.config["name"] == "matrix":
+            mentions.update({"matrix": connector.config["mxid"]})
+
+    for skill in skills:
+        for matcher in skill.matchers:
+            if "mention" in matcher:
+                if "matrix" in mentions:
+                    if "formatted_body" in message.raw_event["content"] and (
+                        '<a href="https://matrix.to/#/' + mentions["matrix"] + '">'
+                        in message.raw_event["content"]["formatted_body"]
+                        or "<a href='https://matrix.to/#/" + mentions["matrix"] + "'>"
+                        in message.raw_event["content"]["formatted_body"]
+                    ):
+                        matched_skills.append(
+                            {
+                                "score": 1,
+                                "skill": skill,
+                                "config": skill.config,
+                                "message": message,
+                            }
+                        )
+
+    return matched_skills

--- a/tests/test_parser_mention.py
+++ b/tests/test_parser_mention.py
@@ -1,0 +1,125 @@
+import asynctest
+import asynctest.mock as amock
+
+from opsdroid.cli.start import configure_lang
+from opsdroid.core import OpsDroid
+from opsdroid.matchers import match_mention
+from opsdroid.events import Message
+from opsdroid.parsers.mention import parse_mention
+from opsdroid.connector.matrix import ConnectorMatrix
+
+
+class TestParserMention(asynctest.TestCase):
+    """Test the opsdroid mention parser."""
+
+    @property
+    def message_json(self):
+        return {
+            "content": {
+                "body": "Hello Alice!",
+                "msgtype": "m.text",
+                "format": "org.matrix.custom.html",
+                "formatted_body": "Hello <a href='https://matrix.to/#/@alice:example.org'>Alice</a>!",
+            },
+            "event_id": "$eventid:localhost",
+            "origin_server_ts": 1547124373956,
+            "sender": "@bob:example.com",
+            "type": "m.room.message",
+            "unsigned": {"age": 3498},
+        }
+
+    async def setup(self):
+        configure_lang({})
+
+    async def getMockSkill(self):
+        async def mockedskill(config, message):
+            pass
+
+        mockedskill.config = {}
+        return mockedskill
+
+    async def getRaisingMockSkill(self):
+        async def mockedskill(config, message):
+            raise Exception()
+
+        mockedskill.config = {}
+        return mockedskill
+
+    async def test_parse_mention_decorator_parens(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(match_mention()(mock_skill))
+            opsdroid.run_skill = amock.CoroutineMock()
+
+            connector = ConnectorMatrix(
+                {
+                    "name": "matrix",
+                    "rooms": {"main": "#test:localhost"},
+                    "mxid": "@alice:example.org",
+                    "password": "hello",
+                    "homeserver": "http://localhost:8008",
+                },
+                opsdroid=OpsDroid(),
+            )
+            opsdroid.connectors.append(connector)
+
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=connector,
+                raw_event=self.message_json,
+            )
+
+            await parse_mention(opsdroid, opsdroid.skills, message)
+            skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
+            self.assertEqual(mock_skill, skills[0]["skill"])
+
+    async def test_parse_mention_decorate_no_parens(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = await self.getMockSkill()
+            opsdroid.skills.append(match_mention(mock_skill))
+            opsdroid.run_skill = amock.CoroutineMock()
+
+            connector = ConnectorMatrix(
+                {
+                    "name": "matrix",
+                    "rooms": {"main": "#test:localhost"},
+                    "mxid": "@alice:example.org",
+                    "password": "hello",
+                    "homeserver": "http://localhost:8008",
+                },
+                opsdroid=OpsDroid(),
+            )
+            opsdroid.connectors.append(connector)
+
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=connector,
+                raw_event=self.message_json,
+            )
+
+            await parse_mention(opsdroid, opsdroid.skills, message)
+            skills = await opsdroid.get_ranked_skills(opsdroid.skills, message)
+            self.assertEqual(mock_skill, skills[0]["skill"])
+
+    async def test_parse_mention_raises(self):
+        with OpsDroid() as opsdroid:
+            mock_skill = await self.getRaisingMockSkill()
+            mock_skill.config = {"name": "greetings"}
+            opsdroid.skills.append(match_mention()(mock_skill))
+            self.assertEqual(len(opsdroid.skills), 1)
+
+            mock_connector = amock.MagicMock()
+            mock_connector.send = amock.CoroutineMock()
+            message = Message(
+                text="Hello world",
+                user="user",
+                target="default",
+                connector=mock_connector,
+            )
+
+            await parse_mention(opsdroid, opsdroid.skills, message)
+            self.assertLogs("_LOGGER", "exception")


### PR DESCRIPTION
# Description
Adds a matcher that listens for messages in that the bot is mentioned. Currently only for matrix connector. I would add slack mentions if I knew how to get the bots slack intern user id.

## Status
**READY**

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
