### PR TITLE
Add kwargs to shell message constructor

### DIFF
--- a/opsdroid/connector/shell/__init__.py
+++ b/opsdroid/connector/shell/__init__.py
@@ -84,7 +84,7 @@ class ConnectorShell(Connector):
         """Parseloop moved out for testing."""
         self.draw_prompt()
         user_input = await self.async_input()
-        message = Message(user_input, self.user, None, self)
+        message = Message(text=user_input, user=self.user, target=None, connector=self)
         await self.opsdroid.parse(message)
 
     async def _parse_message(self):


### PR DESCRIPTION
This PR switches the message constructor from the shell connector to use kwargs instead of positional arguments.

Didn't create a new issue because I think the bug/fix is similar to [this one](https://github.com/opsdroid/opsdroid/issues/1310) (Merged PR:#1328). I got exactly the same [Exception](https://github.com/opsdroid/opsdroid/issues/1310#issue-541307161) using the shell connector :)

Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>