### PR TITLE
Update Slack docs requirements section to create classic app and use RTM API

### DIFF
--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -5,11 +5,11 @@ A connector for [Slack](https://slack.com/).
 ## Requirements
 
 * A Slack account
-* A [Slack App bot token](https://api.slack.com/bot-users).
-  * Create a [new Slack App](https://api.slack.com/apps/new) and select the workspace you would like it in.
-  * Navigate to the "Bot Users" section and add a bot, giving it a display name and username.
+* Create a [new classic Slack App](https://api.slack.com/apps?new_classic_app=1) give it a name and select the workspace you would like it in.
+  * Select `Bots` option inside the `Add features and functionality` tab
+  * Click Add Legacy Bot User and give it a name and a username
   * Navigate to the "Install App" section and install the app in your workspace.
-  * Take note of the "Bot User OAuth Access Token" as this will be the `token` you need for your configuration.
+  * Take note of the "Bot User OAuth Access Token" as this will be the `token` you need for your configuration (the token will start with `xoxb-`).
 
 ## Configuration
 
@@ -17,7 +17,7 @@ A connector for [Slack](https://slack.com/).
 connectors:
   slack:
     # required
-    token: "zyxw-abdcefghi-12345"
+    token: "xoxb-abdcefghi-12345"
     # optional
     bot-name: "mybot" # default "opsdroid"
     default-room: "#random" # default "#general"


### PR DESCRIPTION
# Description

When following the docs on how to use the slack api it sends the users to the normal 'create an app' for a workspace. The new apps don't have access to the RTM API so the user needs to create a `Classic App` in order to use the legacy bot user and have access to the RTM API.

This PR updates the docs to point the users the right way to use opsdroid with slack

Fixes #1382


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Created new bot following steps - bot and opsdroid worked as expected

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
