### PR TITLE
Removed single room option for matrix connector from example config

### DIFF
--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -136,9 +136,7 @@ connectors:
 #    # Required
 #    mxid: "@username:matrix.org"
 #    password: "mypassword"
-#    # Name of a single room to connect to
-#    room: "#matrix:matrix.org"
-#    # Alternatively, a dictionary of multiple rooms
+#    # A dictionary of multiple rooms
 #    # One of these should be named 'main'
 #    rooms:
 #      'main': '#matrix:matrix.org'


### PR DESCRIPTION
# Description

The example configuration file had an option for a single room as an alternative to the dictionary of rooms. This was removed from the connector as well as the documentation but not in the config.

## Status
**READY** 


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation (fix or adds documentation)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
