### PR TITLE
Add option to use access token instead of mxid+password for matrix connector

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -542,17 +542,28 @@ Let's take the example of our matrix connector. Inside the module we set the con
 
 ```python
 from voluptuous import Required
-
-CONFIG_SCHEMA = {
-    Required("credentials"): dict,
-    Required("rooms"): dict,
-    "homeserver": str,
-    "nick": str,
-    "room_specific_nicks": bool,
-}
+CONFIG_SCHEMA = Any(
+    {
+        Required("mxid"): str,
+        Required("password"): str,
+        Required("rooms"): dict,
+        "homeserver": str,
+        "nick": str,
+        "room_specific_nicks": bool,
+    },
+    {
+        Required("token"): str,
+        Required("rooms"): dict,
+        "homeserver": str,
+        "nick": str,
+        "room_specific_nicks": bool,
+    },
+)
 ```
 
-As you can see 'credentials` and `rooms` are required fields for this connector and we expect them to be dictionaries.
+As you can see 'mxid`, 'password', 'token' and `rooms` are required fields for this connector and we expect them to be strings and a dictionary.
+
+You can use the Any() method to return one of either dictionaries to provide alternative required fields
 
 Since we don't need to explicitly declare a value as Optional we can just write the expected value and type.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -544,8 +544,7 @@ Let's take the example of our matrix connector. Inside the module we set the con
 from voluptuous import Required
 
 CONFIG_SCHEMA = {
-    Required("mxid"): str,
-    Required("password"): str,
+    Required("credentials"): dict,
     Required("rooms"): dict,
     "homeserver": str,
     "nick": str,
@@ -553,7 +552,7 @@ CONFIG_SCHEMA = {
 }
 ```
 
-As you can see `mxid`, `password` and `rooms` are required fields for this connector and we expect them to be either strings or a dictionary.
+As you can see 'credentials` and `rooms` are required fields for this connector and we expect them to be dictionaries.
 
 Since we don't need to explicitly declare a value as Optional we can just write the expected value and type.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -554,14 +554,14 @@ CONFIG_SCHEMA = Any(
     {
         Required("token"): str,
         Required("rooms"): dict,
-        "homeserver": str,
+        Required("homeserver"): str,
         "nick": str,
         "room_specific_nicks": bool,
     },
 )
 ```
 
-As you can see 'mxid`, 'password', 'token' and `rooms` are required fields for this connector and we expect them to be strings and a dictionary.
+As you can see 'mxid`, 'password', 'token', 'rooms' and `homeserver` are required fields for this connector and we expect them to be strings and a dictionary.
 
 You can use the Any() method to return one of either dictionaries to provide alternative required fields
 

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -6,7 +6,8 @@ Maintained by [@SolarDrew](https://github.com/SolarDrew).
 
 ## Requirements
 
-To use this connector you will need to have a Matrix account, and login using your Matrix username (mxid) and access token. You can find the access token in the **Advanced** section of the **Help & About** tab in the **Settings** of the official <Riot.im> web client.
+To use this connector you will need to have a Matrix account, and login using either your Matrix username (mxid) and password or your access token. You can find the access token in the **Advanced** section of the **Help & About** tab in the **Settings** of the official <Riot.im> web client. 
+If you use your mxid and password or if your homeserver is matrix.org, the homeserver field is optional.
 
 ## Configuration
 
@@ -14,17 +15,17 @@ To use this connector you will need to have a Matrix account, and login using yo
 connectors:
   matrix:
     # Required
-    'token': 'mytoken'  # Your matrix Access Token
-    # Alternatively, you could use your matrix username and password
     'mxid' : '@username:matrix.org'
     'password': 'mypassword'
-    # A dictionary of rooms to connect to
-    # One of these have to be named 'main'
+    # Alternatively, you could use your matrix access token
+    'token': 'mytoken'
+    # A dictionary of multiple rooms
+    # One of these should be named 'main'
     rooms:
       'main': '#matrix:matrix.org'
       'other': '#riot:matrix.org'
+    homeserver: "https://matrix.org" # Optional if you've specified mxid and password or if the homeserver is https://matrix.org
     # Optional
-    homeserver: "https://matrix.org"
     nick: "Botty McBotface"  # The nick will be set on startup
     room_specific_nicks: False  # Look up room specific nicknames of senders (expensive in large rooms)
 ```

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -14,11 +14,10 @@ To use this connector you will need to have a Matrix account, and login using yo
 connectors:
   matrix:
     # Required
-    credentials:
-      'token': 'mytoken'  # Your matrix Access Token
-      # Alternatively, you could use your matrix username and password (not recommended)
-      'mxid' : '@username:matrix.org'
-      'password': 'mypassword'
+    'token': 'mytoken'  # Your matrix Access Token
+    # Alternatively, you could use your matrix username and password
+    'mxid' : '@username:matrix.org'
+    'password': 'mypassword'
     # A dictionary of rooms to connect to
     # One of these have to be named 'main'
     rooms:

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -7,7 +7,7 @@ Maintained by [@SolarDrew](https://github.com/SolarDrew).
 ## Requirements
 
 To use this connector you will need to have a Matrix account, and login using either your Matrix username (mxid) and password or your access token. You can find the access token in the **Advanced** section of the **Help & About** tab in the **Settings** of the official <Riot.im> web client. 
-If you use your mxid and password or if your homeserver is matrix.org, the homeserver field is optional.
+If your homeserver is matrix.org, the homeserver field is optional.
 
 ## Configuration
 
@@ -24,7 +24,7 @@ connectors:
     rooms:
       'main': '#matrix:matrix.org'
       'other': '#riot:matrix.org'
-    homeserver: "https://matrix.org" # Optional if you've specified mxid and password or if the homeserver is https://matrix.org
+    homeserver: "https://matrix.org" # Optional if the homeserver is https://matrix.org
     # Optional
     nick: "Botty McBotface"  # The nick will be set on startup
     room_specific_nicks: False  # Look up room specific nicknames of senders (expensive in large rooms)

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -14,8 +14,11 @@ To use this connector you will need to have a Matrix account, and login using yo
 connectors:
   matrix:
     # Required
-    mxid: "@username:matrix.org"
-    token: "mytoken"
+    credentials:
+      'token': 'mytoken'  # Your matrix Access Token
+      # Alternatively, you could use your matrix username and password (not recommended)
+      'mxid' : '@username:matrix.org'
+      'password': 'mypassword'
     # A dictionary of rooms to connect to
     # One of these have to be named 'main'
     rooms:

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -6,7 +6,7 @@ Maintained by [@SolarDrew](https://github.com/SolarDrew).
 
 ## Requirements
 
-To use this connector you will need to have a Matrix account, and login using your Matrix username (mxid) and password.
+To use this connector you will need to have a Matrix account, and login using your Matrix username (mxid) and access token. You can find the access token in the **Advanced** section of the **Help & About** tab in the **Settings** of the official <Riot.im> web client.
 
 ## Configuration
 
@@ -15,7 +15,7 @@ connectors:
   matrix:
     # Required
     mxid: "@username:matrix.org"
-    password: "mypassword"
+    token: "mytoken"
     # A dictionary of rooms to connect to
     # One of these have to be named 'main'
     rooms:

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -135,7 +135,7 @@ connectors:
 #  matrix:
 #    # Required
 #    mxid: "@username:matrix.org"
-#    password: "mypassword"
+#    token: "mytoken"
 #    # A dictionary of multiple rooms
 #    # One of these should be named 'main'
 #    rooms:

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -134,17 +134,17 @@ connectors:
 #  ## Matrix (core)
 #  matrix:
 #    # Required
-#    'token': 'mytoken'  # Your matrix Access Token
-#    # Alternatively, you could use your matrix username and password
 #    'mxid' : '@username:matrix.org'
 #    'password': 'mypassword'
+#    # Alternatively, you could use your matrix access token
+#    'token': 'mytoken'
 #    # A dictionary of multiple rooms
 #    # One of these should be named 'main'
 #    rooms:
 #      'main': '#matrix:matrix.org'
 #      'other': '#riot:matrix.org'
+#    homeserver: "https://matrix.org" # Optional if you've specified mxid and password or if the homeserver is https://matrix.org
 #    # Optional
-#    homeserver: "https://matrix.org"
 #    nick: "Botty McBotface"  # The nick will be set on startup
 #    room_specific_nicks: False  # Look up room specific nicknames of senders (expensive in large rooms)
 #

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -143,7 +143,7 @@ connectors:
 #    rooms:
 #      'main': '#matrix:matrix.org'
 #      'other': '#riot:matrix.org'
-#    homeserver: "https://matrix.org" # Optional if you've specified mxid and password or if the homeserver is https://matrix.org
+#    homeserver: "https://matrix.org" # Optional if the homeserver is https://matrix.org
 #    # Optional
 #    nick: "Botty McBotface"  # The nick will be set on startup
 #    room_specific_nicks: False  # Look up room specific nicknames of senders (expensive in large rooms)

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -134,8 +134,11 @@ connectors:
 #  ## Matrix (core)
 #  matrix:
 #    # Required
-#    mxid: "@username:matrix.org"
-#    token: "mytoken"
+#    credentials:
+#      'token': 'mytoken'  # Your matrix Access Token
+#      # Alternatively, you could use your matrix username and password (not recommended)
+#      'mxid' : '@username:matrix.org'
+#      'password': 'mypassword'
 #    # A dictionary of multiple rooms
 #    # One of these should be named 'main'
 #    rooms:

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -134,11 +134,10 @@ connectors:
 #  ## Matrix (core)
 #  matrix:
 #    # Required
-#    credentials:
-#      'token': 'mytoken'  # Your matrix Access Token
-#      # Alternatively, you could use your matrix username and password (not recommended)
-#      'mxid' : '@username:matrix.org'
-#      'password': 'mypassword'
+#    'token': 'mytoken'  # Your matrix Access Token
+#    # Alternatively, you could use your matrix username and password
+#    'mxid' : '@username:matrix.org'
+#    'password': 'mypassword'
 #    # A dictionary of multiple rooms
 #    # One of these should be named 'main'
 #    rooms:

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -34,7 +34,7 @@ CONFIG_SCHEMA = Any(
     {
         Required("token"): str,
         Required("rooms"): dict,
-        "homeserver": str,
+        Required("homeserver"): str,
         "nick": str,
         "room_specific_nicks": bool,
     },

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -24,7 +24,7 @@ from . import events as matrixevents
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = {
     Required("mxid"): str,
-    Required("password"): str,
+    Required("token"): str,
     Required("rooms"): dict,
     "homeserver": str,
     "nick": str,
@@ -72,7 +72,7 @@ class ConnectorMatrix(Connector):
         self.mxid = config["mxid"]
         self.nick = config.get("nick", None)
         self.homeserver = config.get("homeserver", "https://matrix.org")
-        self.password = config["password"]
+        self.token = config["token"]
         self.room_specific_nicks = config.get("room_specific_nicks", False)
         self.send_m_notice = config.get("send_m_notice", False)
         self.session = None
@@ -123,10 +123,7 @@ class ConnectorMatrix(Connector):
         mapi = AsyncHTTPAPI(self.homeserver, session)
 
         self.session = session
-        login_response = await mapi.login(
-            "m.login.password", user=self.mxid, password=self.password
-        )
-        mapi.token = login_response["access_token"]
+        mapi.token = self.token
         mapi.sync_token = None
 
         for roomname, room in self.rooms.items():

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -11,7 +11,7 @@ import aiohttp
 
 from matrix_api_async.api_asyncio import AsyncHTTPAPI
 from matrix_client.errors import MatrixRequestError
-from voluptuous import Required
+from voluptuous import Required, Any
 
 from opsdroid.connector import Connector, register_event
 from opsdroid import events
@@ -22,13 +22,23 @@ from . import events as matrixevents
 
 
 _LOGGER = logging.getLogger(__name__)
-CONFIG_SCHEMA = {
-    Required("credentials"): dict,
-    Required("rooms"): dict,
-    "homeserver": str,
-    "nick": str,
-    "room_specific_nicks": bool,
-}
+CONFIG_SCHEMA = Any(
+    {
+        Required("mxid"): str,
+        Required("password"): str,
+        Required("rooms"): dict,
+        "homeserver": str,
+        "nick": str,
+        "room_specific_nicks": bool,
+    },
+    {
+        Required("token"): str,
+        Required("rooms"): dict,
+        "homeserver": str,
+        "nick": str,
+        "room_specific_nicks": bool,
+    },
+)
 
 __all__ = ["ConnectorMatrix"]
 
@@ -68,11 +78,11 @@ class ConnectorMatrix(Connector):
         self.rooms = self._process_rooms_dict(config["rooms"])
         self.room_ids = {}
         self.default_target = self.rooms["main"]["alias"]
-        self.mxid = config["credentials"].get("mxid", None)
-        self.nick = config.get("nick", None)
+        self.mxid = config.get("mxid")
+        self.nick = config.get("nick")
         self.homeserver = config.get("homeserver", "https://matrix.org")
-        self.password = config["credentials"].get("password", None)
-        self.token = config["credentials"].get("token", None)
+        self.password = config.get("password")
+        self.token = config.get("token")
         self.room_specific_nicks = config.get("room_specific_nicks", False)
         self.send_m_notice = config.get("send_m_notice", False)
         self.session = None


### PR DESCRIPTION
# Description

The matrix connector needed the user's password in plaintext for its configuration. Changed that to allow either the mxid+password or access token.

Fixes #813 

## Status
**READY**

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)

# How Has This Been Tested?

- Tried the default Hello skill with matrix - bot connected successfully and replied as expected.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
