### PR TITLE
Skill constraints for all event types

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -210,12 +210,10 @@ class ConnectorMatrix(Connector):
             except Exception:  # pylint: disable=W0703
                 _LOGGER.exception(_("Matrix sync error."))
 
-    def lookup_target(self, alias):
-        """Convert a room alias to the corresponding room ID."""
-        try:
-            return self.room_ids[alias]
-        except KeyError:
-            return alias
+    def lookup_target(self, room):
+        """Convert name or alias of a room to the corresponding room ID."""
+        room = self.get_roomname(room)
+        return self.room_ids.get(room, room)
 
     async def get_nick(self, roomid, mxid):
         """

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -210,6 +210,13 @@ class ConnectorMatrix(Connector):
             except Exception:  # pylint: disable=W0703
                 _LOGGER.exception(_("Matrix sync error."))
 
+    def lookup_target(self, alias):
+        """Convert a room alias to the corresponding room ID."""
+        try:
+            return self.room_ids[alias]
+        except KeyError:
+            return alias
+
     async def get_nick(self, roomid, mxid):
         """
         Get nickname from user ID.

--- a/opsdroid/constraints.py
+++ b/opsdroid/constraints.py
@@ -32,9 +32,7 @@ def constrain_rooms(rooms, invert=False):
         def constraint_callback(message, rooms=rooms):
             """Check if the room is correct."""
             if hasattr(message.connector, "lookup_target"):
-                return message.target in list(
-                    map(message.connector.lookup_target, rooms)
-                )
+                rooms = list(map(message.connector.lookup_target, rooms))
 
             return message.target in rooms
 

--- a/opsdroid/constraints.py
+++ b/opsdroid/constraints.py
@@ -7,7 +7,7 @@ having a matcher which matches the current message.
 import logging
 from functools import wraps
 
-from opsdroid.helper import add_skill_attributes, lookup_target
+from opsdroid.helper import add_skill_attributes
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,12 @@ def constrain_rooms(rooms, invert=False):
 
         def constraint_callback(message, rooms=rooms):
             """Check if the room is correct."""
-            return message.target in lookup_target(message, rooms)
+            if hasattr(message.connector, "lookup_target"):
+                return message.target in list(
+                    map(message.connector.lookup_target, rooms)
+                )
+
+            return message.target in rooms
 
         func = add_skill_attributes(func)
         if invert:

--- a/opsdroid/constraints.py
+++ b/opsdroid/constraints.py
@@ -7,7 +7,7 @@ having a matcher which matches the current message.
 import logging
 from functools import wraps
 
-from opsdroid.helper import add_skill_attributes
+from opsdroid.helper import add_skill_attributes, lookup_target
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ def constrain_rooms(rooms, invert=False):
 
         def constraint_callback(message, rooms=rooms):
             """Check if the room is correct."""
-            return message.target in rooms
+            return message.target in lookup_target(message, rooms)
 
         func = add_skill_attributes(func)
         if invert:

--- a/opsdroid/helper.py
+++ b/opsdroid/helper.py
@@ -325,3 +325,30 @@ register_json_type(
         dct["hour"], dct["minute"], dct["second"], dct["microsecond"]
     ),
 )
+
+
+def lookup_target(event, aliases):
+    """Convert room aliases to ID's.
+
+    Converts chat room aliases to room ID's with connector object of event.
+    Translation based on `event.connector.room_ids` dict object.
+
+    Args:
+        event (object): An Event object.
+        aliases (list): List of room aliases.
+
+    Returns:
+        list: List of room ID's.
+
+    """
+    if not hasattr(event.connector, "room_ids"):
+        return aliases
+
+    rooms = []
+    for alias in aliases:
+        try:
+            rooms.append(event.connector.room_ids[alias])
+        except (KeyError, TypeError):
+            rooms.append(alias)
+
+    return rooms

--- a/opsdroid/helper.py
+++ b/opsdroid/helper.py
@@ -325,30 +325,3 @@ register_json_type(
         dct["hour"], dct["minute"], dct["second"], dct["microsecond"]
     ),
 )
-
-
-def lookup_target(event, aliases):
-    """Convert room aliases to ID's.
-
-    Converts chat room aliases to room ID's with connector object of event.
-    Translation based on `event.connector.room_ids` dict object.
-
-    Args:
-        event (object): An Event object.
-        aliases (list): List of room aliases.
-
-    Returns:
-        list: List of room ID's.
-
-    """
-    if not hasattr(event.connector, "room_ids"):
-        return aliases
-
-    rooms = []
-    for alias in aliases:
-        try:
-            rooms.append(event.connector.room_ids[alias])
-        except (KeyError, TypeError):
-            rooms.append(alias)
-
-    return rooms

--- a/opsdroid/parsers/event_type.py
+++ b/opsdroid/parsers/event_type.py
@@ -51,6 +51,9 @@ async def match_event(event, event_opts):
 async def parse_event_type(opsdroid, event):
     """Parse an event if it's of a certain type."""
     for skill in opsdroid.skills:
+        for constraint in skill.constraints:
+            if not constraint(event):
+                return
         for matcher in skill.matchers:
             event_opts = matcher.get("event_type", {})
             result = await match_event(event, event_opts)

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -414,6 +414,15 @@ class TestConnectorMatrixAsync(asynctest.TestCase):
         assert self.connector.get_roomname("!aroomid:localhost") == "main"
         assert self.connector.get_roomname("someroom") == "someroom"
 
+    def test_lookup_target(self):
+        self.connector.room_ids = {"main": "!aroomid:localhost"}
+
+        assert self.connector.lookup_target("main") == "!aroomid:localhost"
+        assert self.connector.lookup_target("#test:localhost") == "!aroomid:localhost"
+        assert (
+            self.connector.lookup_target("!aroomid:localhost") == "!aroomid:localhost"
+        )
+
     async def test_respond_image(self):
         gif_bytes = (
             b"GIF89a\x01\x00\x01\x00\x00\xff\x00,"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1381 
This code patch is checks all constraints of all skills for the relevant event when `parse_event_type` triggered.

~By the way, `@constrain_rooms` for the skills isn't works with room aliases which are specified in configuration file (because `message.target` and `rooms` doesn't match [here](https://github.com/opsdroid/opsdroid/blob/master/opsdroid/constraints.py#L34), I guess). It works with exact room ids (at least for Matrix connector). First of all, is this behavior a bug or a feature? And if it is a bug, should be fixed in this PR?~

This code patch adds `lookup_target` method for connectors which converts a room name to corresponding room id, and with this, skill constraints works.

## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Tested with current Matrix connector like:
- Added two public rooms to localhost matrix home-server
- Wrote a skill like the skill in the issue


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
