### PR TITLE
Remove duplicated shell prompt

### DIFF
--- a/opsdroid/connector/shell/__init__.py
+++ b/opsdroid/connector/shell/__init__.py
@@ -125,7 +125,6 @@ class ConnectorShell(Connector):
         _LOGGER.debug(_("Responding with: %s."), message.text)
         self.clear_prompt()
         print(message.text)
-        self.draw_prompt()
 
     async def disconnect(self):
         """Disconnects the connector."""


### PR DESCRIPTION
Signed-off-by: QidongS <qidongsun@berkeley.edu>

# Description

Fixes #1407 

In connector/shell/__init__.py, since `parseloop` calls  `self.draw_prompt` already, we should get rid of the extra `self.draw_prompt()` statement in `respond` .

```
async def parseloop(self):
        """Parseloop moved out for testing."""
        self.draw_prompt()
        user_input = await self.async_input()
        message = Message(text=user_input, user=self.user, target=None, connector=self)
        await self.opsdroid.parse(message)

```
```
@register_event(Message)
    async def respond(self, message):
        """Respond with a message.

        Args:
            message (object): An instance of Message

        """
        _LOGGER.debug(_("Responding with: %s."), message.text)
        self.clear_prompt()
        print(message.text)
        self.draw_prompt()

```



## Status
**READY** 


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- I tested with the Hello skill and the output is correct as expected.  


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
