### PR TITLE
Fix formatter variable referenced before assignment 

### DIFF
--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -82,15 +82,14 @@ def configure_logging(config):
         log_level = logging.INFO
 
     rootlogger.setLevel(log_level)
-        
-        
+
     formatter = logging.Formatter("%(levelname)s %(name)s: %(message)s")
 
     with contextlib.suppress(KeyError):
         if config["logging"]["extended"]:
             formatter = logging.Formatter(
                 "%(levelname)s %(name)s.%(funcName)s(): %(message)s"
-                )
+            )
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -82,14 +82,15 @@ def configure_logging(config):
         log_level = logging.INFO
 
     rootlogger.setLevel(log_level)
+        
+        
+    formatter = logging.Formatter("%(levelname)s %(name)s: %(message)s")
 
-    try:
+    with contextlib.suppress(KeyError):
         if config["logging"]["extended"]:
             formatter = logging.Formatter(
                 "%(levelname)s %(name)s.%(funcName)s(): %(message)s"
-            )
-    except KeyError:
-        formatter = logging.Formatter("%(levelname)s %(name)s: %(message)s")
+                )
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)


### PR DESCRIPTION
# Description

Moved `formatter = logging.Formatter("%(levelname)s %(name)s: %(message)s")` line outside try/except block. Removed try/except and added a suppress if KeyError is raised on `config['logging']['extended']`.

Note: For some reason black and tox didn't run on my end so I was unabled to check tests before raising the PR

Fixes #1429


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tested bot with `extended` flag set to true - worked as expected. 
- Tested bot without `extended` flag set - worked as expected.
- Ran Travis - all Green

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
