### PR TITLE
Add File support for Telegram connector.

### DIFF
--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -7,7 +7,7 @@ import asynctest.mock as amock
 
 from opsdroid.core import OpsDroid
 from opsdroid.connector.telegram import ConnectorTelegram
-from opsdroid.events import Message, Image
+from opsdroid.events import Message, Image, File
 from opsdroid.cli.start import configure_lang
 
 
@@ -508,6 +508,38 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
             patched_request.return_value.set_result(post_response)
 
             await self.connector.send_image(image)
+            self.assertLogs("_LOOGER", "debug")
+
+    async def test_respond_file(self):
+        post_response = amock.Mock()
+        post_response.status = 200
+
+        file_bytes = b'plain text file example'
+
+        file = File(file_bytes=file_bytes, target={"id": "123"})
+
+        with amock.patch.object(self.connector.session, "post") as patched_request:
+
+            patched_request.return_value = asyncio.Future()
+            patched_request.return_value.set_result(post_response)
+
+            await self.connector.send_file(file)
+            self.assertTrue(patched_request.called)
+
+    async def test_respond_file_failure(self):
+        post_response = amock.Mock()
+        post_response.status = 400
+
+        file_bytes = b'plain text file example'
+
+        file = File(file_bytes=file_bytes, target={"id": "123"})
+
+        with amock.patch.object(self.connector.session, "post") as patched_request:
+
+            patched_request.return_value = asyncio.Future()
+            patched_request.return_value.set_result(post_response)
+
+            await self.connector.send_file(file)
             self.assertLogs("_LOOGER", "debug")
 
     async def test_listen(self):

--- a/tests/test_connector_telegram.py
+++ b/tests/test_connector_telegram.py
@@ -514,7 +514,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
         post_response = amock.Mock()
         post_response.status = 200
 
-        file_bytes = b'plain text file example'
+        file_bytes = b"plain text file example"
 
         file = File(file_bytes=file_bytes, target={"id": "123"})
 
@@ -530,7 +530,7 @@ class TestConnectorTelegramAsync(asynctest.TestCase):
         post_response = amock.Mock()
         post_response.status = 400
 
-        file_bytes = b'plain text file example'
+        file_bytes = b"plain text file example"
 
         file = File(file_bytes=file_bytes, target={"id": "123"})
 


### PR DESCRIPTION
# Description

Fixes #1434

If you try to send a File using the Telegram connector you get the following error. As there is no method in the connector class register with @register_event(File)

`TypeError: Connector <class 'opsdroid.connector.telegram.ConnectorTelegram'> can not handle the 'File' event type.`

Using this PR as a base, [Adds Image support for Telegram #929](https://github.com/opsdroid/opsdroid/pull/929), I have add a method which send documents. I have used the sendDocument method from the telegram API. You can check de documentation for the method [here](https://core.telegram.org/bots/api#senddocument).

## Status
**READY** | ~~UNDER DEVELOPMENT~~ |~~ON HOLD~~


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- I have developed a really simple Skill which returns a pdf file from your file system. https://github.com/misTrasteos/sendFileTelegramSkill

![imagen](https://user-images.githubusercontent.com/5575151/79644422-32cd6880-81a9-11ea-927d-0c27d256de02.png)

- I have added some test similar to the sendImages

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
