### PR TITLE
Implement a Generic Event type for all unsupported matrix events

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -491,3 +491,10 @@ class ConnectorMatrix(Connector):
             state_event.content,
             state_key=state_event.state_key,
         )
+
+    @register_event(matrixevents.UnknownMatrixRoomEvent)
+    @ensure_room_id_and_send
+    async def _send_unknown_event(self, unknown):
+        return await self.connection.send_message_event(
+            unknown.target, unknown.event_type, unknown.content
+        )

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -487,14 +487,14 @@ class ConnectorMatrix(Connector):
         _LOGGER.debug(f"Sending State Event {state_event}")
         return await self.connection.send_state_event(
             state_event.target,
-            state_event.key,
+            state_event.event_type,
             state_event.content,
             state_key=state_event.state_key,
         )
 
     @register_event(matrixevents.UnknownMatrixRoomEvent)
     @ensure_room_id_and_send
-    async def _send_unknown_event(self, unknown):
+    async def _send_generic_event(self, event):
         return await self.connection.send_message_event(
-            unknown.target, unknown.event_type, unknown.content
+            event.target, event.event_type, event.content
         )

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -492,7 +492,7 @@ class ConnectorMatrix(Connector):
             state_key=state_event.state_key,
         )
 
-    @register_event(matrixevents.UnknownMatrixRoomEvent)
+    @register_event(matrixevents.GenericMatrixRoomEvent)
     @ensure_room_id_and_send
     async def _send_generic_event(self, event):
         return await self.connection.send_message_event(

--- a/opsdroid/connector/matrix/create_events.py
+++ b/opsdroid/connector/matrix/create_events.py
@@ -60,7 +60,7 @@ class MatrixEventCreator(events.EventCreator):
     async def skip(self, event, roomid):
         """Attempt to generate an UnknownMatrixEvent."""
         try:
-            return matrix_events.GenericMatrixRoomEvent(
+            event = matrix_events.GenericMatrixRoomEvent(
                 content=event["content"],
                 event_type=event["type"],
                 user_id=event["sender"],
@@ -70,6 +70,8 @@ class MatrixEventCreator(events.EventCreator):
                 raw_event=event,
                 event_id=event["event_id"],
             )
+            _LOGGER.debug(f"Got {event}")
+            return event
         except Exception as e:  # pragma: nocover
             _LOGGER.debug(
                 f"Matrix connector failed to parse event {event} as a room event.\n{e}"

--- a/opsdroid/connector/matrix/create_events.py
+++ b/opsdroid/connector/matrix/create_events.py
@@ -60,7 +60,7 @@ class MatrixEventCreator(events.EventCreator):
     async def skip(self, event, roomid):
         """Attempt to generate an UnknownMatrixEvent."""
         try:
-            return matrix_events.UnknownMatrixRoomEvent(
+            return matrix_events.GenericMatrixRoomEvent(
                 content=event["content"],
                 event_type=event["type"],
                 user_id=event["sender"],
@@ -70,7 +70,7 @@ class MatrixEventCreator(events.EventCreator):
                 raw_event=event,
                 event_id=event["event_id"],
             )
-        except Exception as e:
+        except Exception as e:  # pragma: nocover
             _LOGGER.debug(
                 f"Matrix connector failed to parse event {event} as a room event.\n{e}"
             )

--- a/opsdroid/connector/matrix/create_events.py
+++ b/opsdroid/connector/matrix/create_events.py
@@ -58,7 +58,7 @@ class MatrixEventCreator(events.EventCreator):
         )
 
     async def skip(self, event, roomid):
-        """Attempt to generate an UnknownMatrixEvent."""
+        """Generate a generic event (state event if appropriate)."""
         kwargs = dict(
             content=event["content"],
             event_type=event["type"],
@@ -75,11 +75,10 @@ class MatrixEventCreator(events.EventCreator):
             kwargs["state_key"] = event["state_key"]
         try:
             event = event_type(**kwargs)
-            _LOGGER.debug(f"Got {event}")
             return event
-        except Exception as e:  # pragma: nocover
-            _LOGGER.debug(
-                f"Matrix connector failed to parse event {event} as a room event.\n{e}"
+        except Exception:  # pragma: nocover
+            _LOGGER.exception(
+                f"Matrix connector failed to parse event {event} as a room event."
             )
             return None
 

--- a/opsdroid/connector/matrix/events.py
+++ b/opsdroid/connector/matrix/events.py
@@ -59,3 +59,12 @@ class MatrixRoomAvatar(MatrixStateEvent):
         key = "m.room.avatar"
         content = {"url": url}
         super().__init__(key, content, *args, **kwargs)
+
+
+class UnknownMatrixRoomEvent(Event):
+    """A matrix event which we don't understand."""
+
+    def __init__(self, event_type, content, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.content = content
+        self.event_type = event_type

--- a/opsdroid/connector/matrix/events.py
+++ b/opsdroid/connector/matrix/events.py
@@ -21,12 +21,12 @@ class GenericMatrixRoomEvent(Event):
     matrix specific events.
     """
 
-    def __init__(self, event_type, content, *args, **kwargs):
+    def __init__(self, event_type, content, *args, **kwargs):  # noqa: D107
         super().__init__(*args, **kwargs)
         self.content = content
         self.event_type = event_type
 
-    def __repr__(self):  # noqa: D107
+    def __repr__(self):  # noqa: D105
         return f"<GenericMatrixRoomEvent(room_id={self.target}, event_type={self.event_type}, content={self.content})>"
 
 
@@ -37,7 +37,7 @@ class MatrixStateEvent(GenericMatrixRoomEvent):
         super().__init__(*args, **kwargs)
         self.state_key = state_key
 
-    def __repr__(self):  # noqa: D107
+    def __repr__(self):  # noqa: D105
         return f"<MatrixStateEvent(room_id={self.target}, event_type={self.event_type}, state_key={self.state_key}, content={self.content})>"
 
 
@@ -46,7 +46,8 @@ class MatrixPowerLevels(MatrixStateEvent):
 
     # Deprecate old name for event_type
     @property
-    def key(self):
+    def key(self):  # noqa: D401
+        """Deprecated alias for event_type."""
         warnings.warn(
             "key has been renamed event_type to reduce confusion with state_key",
             DeprecationWarning,

--- a/opsdroid/connector/matrix/events.py
+++ b/opsdroid/connector/matrix/events.py
@@ -1,9 +1,11 @@
 """Matrix specific events."""
+import warnings
 
 from opsdroid.events import Event
 
 
 __all__ = [
+    "GenericMatrixRoomEvent",
     "MatrixRoomAvatar",
     "MatrixHistoryVisibility",
     "MatrixJoinRules",
@@ -12,59 +14,76 @@ __all__ = [
 ]
 
 
-class MatrixStateEvent(Event):
+class GenericMatrixRoomEvent(Event):
+    """A generic matrix room event.
+
+    Used for things which don't have a specific event type or as a base for
+    matrix specific events.
+    """
+
+    def __init__(self, event_type, content, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.content = content
+        self.event_type = event_type
+
+    def __repr__(self):  # noqa: D107
+        return f"<GenericMatrixRoomEvent(room_id={self.target}, event_type={self.event_type}, content={self.content})>"
+
+
+class MatrixStateEvent(GenericMatrixRoomEvent):
     """A Generic matrix state event."""
 
-    def __init__(self, key, content, *args, state_key=None, **kwargs):  # noqa: D107
+    def __init__(self, *args, state_key=None, **kwargs):  # noqa: D107
         super().__init__(*args, **kwargs)
-        self.key = key
-        self.content = content
         self.state_key = state_key
 
-    def __repr__(self):
-        """Pretty representation of state events."""
-        return f"<MatrixStateEvent(room_id={self.target}, key={self.key}, content={self.content})>"
+    def __repr__(self):  # noqa: D107
+        return f"<MatrixStateEvent(room_id={self.target}, event_type={self.event_type}, state_key={self.state_key}, content={self.content})>"
 
 
 class MatrixPowerLevels(MatrixStateEvent):
     """Send power levels."""
 
+    # Deprecate old name for event_type
+    @property
+    def key(self):
+        warnings.warn(
+            "key has been renamed event_type to reduce confusion with state_key",
+            DeprecationWarning,
+        )
+        return self.event_type
+
+    @key.setter
+    def _(self, val):
+        self.event_type = key
+
     def __init__(self, power_levels, *args, **kwargs):  # noqa: D107
-        key = "m.room.power_levels"
-        super().__init__(key, power_levels, *args, **kwargs)
+        event_type = "m.room.power_levels"
+        super().__init__(event_type, power_levels, *args, **kwargs)
 
 
 class MatrixJoinRules(MatrixStateEvent):
     """The room's join rules."""
 
     def __init__(self, join_rule, *args, **kwargs):  # noqa: D107
-        key = "m.room.join_rules"
+        event_type = "m.room.join_rules"
         content = {"join_rule": join_rule}
-        super().__init__(key, content, *args, **kwargs)
+        super().__init__(event_type, content, *args, **kwargs)
 
 
 class MatrixHistoryVisibility(MatrixStateEvent):
     """The room's history visibility."""
 
     def __init__(self, history_visibility, *args, **kwargs):  # noqa: D107
-        key = "m.room.history_visibility"
+        event_type = "m.room.history_visibility"
         content = {"history_visibility": history_visibility}
-        super().__init__(key, content, *args, **kwargs)
+        super().__init__(event_type, content, *args, **kwargs)
 
 
 class MatrixRoomAvatar(MatrixStateEvent):
     """The room's avatar."""
 
     def __init__(self, url, *args, **kwargs):  # noqa: D107
-        key = "m.room.avatar"
+        event_type = "m.room.avatar"
         content = {"url": url}
-        super().__init__(key, content, *args, **kwargs)
-
-
-class UnknownMatrixRoomEvent(Event):
-    """A matrix event which we don't understand."""
-
-    def __init__(self, event_type, content, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.content = content
-        self.event_type = event_type
+        super().__init__(event_type, content, *args, **kwargs)

--- a/opsdroid/connector/matrix/events.py
+++ b/opsdroid/connector/matrix/events.py
@@ -51,12 +51,12 @@ class MatrixPowerLevels(MatrixStateEvent):
         warnings.warn(
             "key has been renamed event_type to reduce confusion with state_key",
             DeprecationWarning,
-        )
-        return self.event_type
+        )  # pragma: nocover
+        return self.event_type  # pragma: nocover
 
     @key.setter
     def _(self, val):
-        self.event_type = key
+        self.event_type = key  # pragma: nocover
 
     def __init__(self, power_levels, *args, **kwargs):  # noqa: D107
         event_type = "m.room.power_levels"

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -981,6 +981,9 @@ class TestEventCreatorAsync(asynctest.TestCase):
         event = await self.event_creator.create_event(json, "hello")
         assert isinstance(event, matrix_events.GenericMatrixRoomEvent)
         assert event.event_type == "wibble"
+        assert "wibble" in repr(event)
+        assert event.target in repr(event)
+        assert str(event.content) in repr(event)
 
     async def test_unsupported_message_type(self):
         json = self.message_json
@@ -1089,3 +1092,27 @@ class TestEventCreatorAsync(asynctest.TestCase):
         assert event.raw_event == self.custom_json
         assert event.content == {"hello": "world"}
         assert event.event_type == "opsdroid.dev"
+
+    @property
+    def custom_state_json(self):
+        return {
+            "content": {"hello": "world"},
+            "type": "wibble.opsdroid.dev",
+            "unsigned": {"age": 137},
+            "origin_server_ts": 1575306720044,
+            "state_key": "",
+            "sender": "@neo:matrix.org",
+            "event_id": "$bEg2XISusHMKLBw9b4lMNpB2r9qYoesp512rKvbo5LA",
+        }
+
+    async def test_create_generic_state(self):
+        event = await self.event_creator.create_event(self.custom_state_json, "hello")
+        assert isinstance(event, matrix_events.MatrixStateEvent)
+        assert event.user == "Rabbit Hole"
+        assert event.user_id == "@neo:matrix.org"
+        assert event.target == "hello"
+        assert event.event_id == "$bEg2XISusHMKLBw9b4lMNpB2r9qYoesp512rKvbo5LA"
+        assert event.raw_event == self.custom_state_json
+        assert event.content == {"hello": "world"}
+        assert event.event_type == "wibble.opsdroid.dev"
+        assert event.state_key == ""

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -780,7 +780,6 @@ class TestEventCreatorAsync(asynctest.TestCase):
             "sender": "@neo:matrix.org",
             "type": "m.room.message",
             "unsigned": {"age": 48926251},
-            "user_id": "@nso:matrix.org",
             "age": 48926251,
         }
 
@@ -799,7 +798,6 @@ class TestEventCreatorAsync(asynctest.TestCase):
             "room_id": "!MeRdFpEonLoCwhoHeT:matrix.org",
             "type": "m.room.message",
             "unsigned": {"age": 23394532373},
-            "user_id": "@neo:matrix.org",
             "age": 23394532373,
         }
 
@@ -830,7 +828,6 @@ class TestEventCreatorAsync(asynctest.TestCase):
             "sender": "@neo:matrix.org",
             "type": "m.room.message",
             "unsigned": {"age": 2542608318},
-            "user_id": "@neo:matrix.org",
             "age": 2542608318,
         }
 
@@ -982,13 +979,15 @@ class TestEventCreatorAsync(asynctest.TestCase):
         json = self.message_json
         json["type"] = "wibble"
         event = await self.event_creator.create_event(json, "hello")
-        assert event is None
+        assert isinstance(event, matrix_events.GenericMatrixRoomEvent)
+        assert event.event_type == "wibble"
 
     async def test_unsupported_message_type(self):
         json = self.message_json
         json["content"]["msgtype"] = "wibble"
         event = await self.event_creator.create_event(json, "hello")
-        assert event is None
+        assert isinstance(event, matrix_events.GenericMatrixRoomEvent)
+        assert event.content["msgtype"] == "wibble"
 
     async def test_room_name(self):
         event = await self.event_creator.create_event(self.room_name_json, "hello")
@@ -1077,7 +1076,6 @@ class TestEventCreatorAsync(asynctest.TestCase):
             "sender": "@neo:matrix.org",
             "type": "opsdroid.dev",
             "unsigned": {"age": 48926251},
-            "user_id": "@nso:matrix.org",
             "age": 48926251,
         }
 


### PR DESCRIPTION
# Description

This PR implements a `GenericMatrixRoomEvent` class which is accepted for send or emitted when we receive an event over matrix which we don't support.


## Status
**Done**


## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
