### PR TITLE
Refactor Memory to remove in-memory cache of database values

### DIFF
--- a/opsdroid/database/__init__.py
+++ b/opsdroid/database/__init__.py
@@ -89,3 +89,24 @@ class Database:
 
         """
         raise NotImplementedError
+
+
+class InMemoryDatabase(Database):
+    """A simple in memory implementation of the database API."""
+
+    def __init__(self, config={}, opsdroid=None):  # noqa: D107
+        super().__init__(config, opsdroid)
+        self.memory = {}
+
+    async def connect(self):  # noqa: D102
+        pass
+
+    async def get(self, key):  # noqa: D102
+        return self.memory.get(key)
+
+    async def put(self, key, value):  # noqa: D102
+        self.memory[key] = value
+
+    async def delete(self, key):  # noqa: D102
+        if key in self.memory:
+            del self.memory[key]

--- a/opsdroid/database/__init__.py
+++ b/opsdroid/database/__init__.py
@@ -99,7 +99,7 @@ class InMemoryDatabase(Database):
         self.memory = {}
 
     async def connect(self):  # noqa: D102
-        pass
+        pass  # pragma: nocover
 
     async def get(self, key):  # noqa: D102
         return self.memory.get(key)

--- a/opsdroid/memory.py
+++ b/opsdroid/memory.py
@@ -78,7 +78,7 @@ class Memory:
 
         """
         if not self.databases:
-            return None
+            return None  # pragma: nocover
 
         results = []
         for database in self.databases:

--- a/opsdroid/memory.py
+++ b/opsdroid/memory.py
@@ -19,7 +19,6 @@ class Memory:
 
     def __init__(self):
         """Create object with minimum properties."""
-        self.memory = {}
         self.databases = []
 
     async def get(self, key):
@@ -35,13 +34,7 @@ class Memory:
 
         """
         _LOGGER.debug(_("Getting %s from memory."), key)
-        database_result = await self._get_from_database(key)
-        if database_result is not None:
-            self.memory[key] = database_result
-        if key in self.memory:
-            return self.memory[key]
-
-        return None
+        return await self._get_from_database(key)
 
     async def put(self, key, data):
         """Put a data object to a given key.
@@ -54,8 +47,7 @@ class Memory:
 
         """
         _LOGGER.debug(_("Putting %s to memory."), key)
-        self.memory[key] = data
-        await self._put_to_database(key, self.memory[key])
+        await self._put_to_database(key, data)
 
     async def delete(self, key):
         """Delete data object for a given key.
@@ -67,8 +59,6 @@ class Memory:
 
         """
         _LOGGER.debug(_("Deleting %s from memory."), key)
-        if key in self.memory:
-            del self.memory[key]
         await self._delete_from_database(key)
 
     async def _get_from_database(self, key):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2,13 +2,16 @@ import asynctest
 import asynctest.mock as mock
 
 from opsdroid.memory import Memory
+from opsdroid.database import InMemoryDatabase
 
 
 class TestMemory(asynctest.TestCase):
     """Test the opsdroid memory class."""
 
     def setup(self):
-        return Memory()
+        mem = Memory()
+        mem.databases = [InMemoryDatabase()]
+        return mem
 
     async def test_memory(self):
         memory = self.setup()


### PR DESCRIPTION
# Description

The matrix database https://github.com/solardrew/database-matrix has a thing where you can have a database per-room. This refactoring removes the concept of "one opdroid" memory by moving the in-memory thing to a dedicated database which is used if no databases are specified in the config.

## Status
**READY**

## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
