### PR TITLE
Update release procedure

### DIFF
--- a/docs/maintaining/making-a-release.md
+++ b/docs/maintaining/making-a-release.md
@@ -24,7 +24,7 @@ Before creating the release do some final local testing:
 - Checkout master and run the `tox` suite locally.
 - Run opsdroid and do some manual testing to ensure there are no glaring issues.
 
-### Increment the version number
+### Decide the next version number
 
 As opsdroid follows [SemVer 2.0](http://semver.org/) (`major.minor.patch`) the version number increase will depend on what has changed since the previous release.
 
@@ -36,59 +36,17 @@ Keep a note of what the new version will be as it will be needed later.
 
 ### Generate release text
 
-The release description to be posted on GitHub should be a bulleted list of changes separated into sections for **Enhancements**, **Bug fixes**, **Breaking changes** and **Documentation updates**. Each bullet should be the PR name and number which introduced the change.
+We use [Release Drafter](https://github.com/marketplace/actions/release-drafter) to automatically draft our next release using GitHub Releases.
 
-It is possible to partially automatically generate this using a utility script:
+Release Drafter will create a draft release with the release notes automatically populated based on the titles of each PR that has been merged since the last release and grouped together using the labels `enhancement`, `bug` and `documentation`.
 
-```shell
-# Pull the tags from opsdroid/opsdroid so that only commits since the last tag are listed
-git pull upstream master --tags
-# List the commits
-python scripts/release_notes/release_notes.py
-```
+You need to review these notes to ensure all PRs have suitable titles and have been grouped successfully. If there are any issues then edit the release and manually make corrections.
 
-This will print a list of all the commits in the history since the last release, which due to the "squash and merge" feature in GitHub will be correctly formatted into one commit per PR with the title and number.
-
-_You will need to add markdown bullets, sort into sections, tidy up the names and remove anything which is not relevant to the application itself (e.g changes to the GitHub PR and Issue templates). This can be done when drafting the release._
-
-### Backports
-
-As opsdroid releases are infrequent they often include many differen't PRs, which usually results in a `minor` release as at least one PR will introduce a new feature.
-
-In the mean time there may be bug fixes merged into master which we want to release on a shorter timescale, these should be backported into the current minor version.
-
-Steps
-
-```console
-# Pull down all tags
-$ git pull upstream master --tags
-
-# Checkout the latest tag
-$ git checkout x.x.x
-
-# Create a new dev branch for this minor version (e.g dev-0.14.x for the 0.14 minor release)
-$ git checkout -b dev-x.x.x
-
-# Cherry pick the bug fix from master
-$ git cherry-pick -x <COMMIT HASH>
-
-# Push branch to your fork and open a PR to the upstream branch
-$ git push origin dev-x.x.x
-```
-
-Once tests have passed and you merge the patch into the dev branch you can perform a new release which targets the dev branch following the rest of this guide.
-
-### Draft the release
-
-Following steps 1-3 of the [GitHub releases guide](https://help.github.com/articles/creating-releases/) draft a new release.
-
-Set the "Tag version" and "Release title" to the version number prefixed with the letter `v` (e.g `v0.9.1`). Ensure the tag target points to `master`.
-
-Copy and paste the release text into the description section and make the changes specified above.
+Release Drafter also assumes the next release will be a minor version change, if this is not the case then update the release title and tag to match the version number you decided on earlier.
 
 ### Publish the release
 
-Once you are happy with the release notes click "Publish release".
+Once you are happy with the release notes click "Publish release" on the draft.
 
 This will result in a number of automated actions:
 
@@ -100,11 +58,3 @@ This will result in a number of automated actions:
 There are also the following manual actions which need to be performed:
 
 - A PR will automatically be raised on the [opsdroid feedstock on Conda Forge](https://github.com/conda-forge/opsdroid-feedstock). This needs to be reviewed and merged.
-
-### Announce the release
-
-If the version is not a simple `patch` release then the last action is to write a post on the @opsdroid [Medium blog](https://medium.com/opsdroid) about the release.
-
-_If it is a `patch` release then add a note to the bottom of the last release blog post._
-
-This post should include some preamble about the contents of the release, highlighting anything particularly exciting. It should then include a copy of the release notes.


### PR DESCRIPTION
Now that we are using Release Drafter and not publishing release blog posts as discussed in #1422 we can simplify the release procedure here.

This also means any maintainer should be able to make a release.