### PR TITLE
Reload opsdroid if a local module is modified

### DIFF
--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -101,9 +101,15 @@ class Loader:
                 continue
 
         if module_spec:
-            module = Loader.import_module_from_spec(module_spec)
-            _LOGGER.debug(_("Loaded %s: %s."), config["type"], config["module_path"])
-            return module
+            try:
+                module = Loader.import_module_from_spec(module_spec)
+            except Exception as e:
+                _LOGGER.error(str(e))
+            else:
+                _LOGGER.debug(
+                    _("Loaded %s: %s."), config["type"], config["module_path"]
+                )
+                return module
 
         _LOGGER.error(
             _("Failed to load %s: %s."), config["type"], config["module_path"]
@@ -595,8 +601,7 @@ class Loader:
             else:
                 _LOGGER.error(_("Could not find local git repo %s."), git_url)
 
-    @staticmethod
-    def _install_local_module(config):
+    def _install_local_module(self, config):
         """Install a module from a local path.
 
         Args:
@@ -625,6 +630,8 @@ class Loader:
 
         if not installed:
             _LOGGER.error("Failed to install from %s.", str(config["path"]))
+        else:
+            self.opsdroid.reload_paths.append(config["path"])
 
     def _install_gist_module(self, config):
         """Install a module from gist path.

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -104,7 +104,7 @@ class Loader:
             try:
                 module = Loader.import_module_from_spec(module_spec)
             except Exception as e:
-                _LOGGER.error(
+                _LOGGER.error(_("The following exception was raised while importing %s %s"), config["type"], config["module_path"])
                     "The following exception was raised while importing %s %s",
                     config["type"],
                     config["module_path"],

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -104,7 +104,7 @@ class Loader:
             try:
                 module = Loader.import_module_from_spec(module_spec)
             except Exception as e:
-                _LOGGER.error(str(e))
+                _LOGGER.error("Exception raised while importing skill - %s", str(e))
             else:
                 _LOGGER.debug(
                     _("Loaded %s: %s."), config["type"], config["module_path"]

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -104,8 +104,8 @@ class Loader:
             try:
                 module = Loader.import_module_from_spec(module_spec)
             except Exception as e:
-                _LOGGER.error(_("The following exception was raised while importing %s %s"), config["type"], config["module_path"])
-                    "The following exception was raised while importing %s %s",
+                _LOGGER.error(
+                    _("The following exception was raised while importing %s %s"),
                     config["type"],
                     config["module_path"],
                 )

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -12,7 +12,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import traceback
 import urllib.request
 from collections.abc import Mapping
 from pkg_resources import iter_entry_points

--- a/opsdroid/loader.py
+++ b/opsdroid/loader.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import traceback
 import urllib.request
 from collections.abc import Mapping
 from pkg_resources import iter_entry_points
@@ -104,7 +105,12 @@ class Loader:
             try:
                 module = Loader.import_module_from_spec(module_spec)
             except Exception as e:
-                _LOGGER.error("Exception raised while importing skill - %s", str(e))
+                _LOGGER.error(
+                    "The following exception was raised while importing %s %s",
+                    config["type"],
+                    config["module_path"],
+                )
+                _LOGGER.error(str(e))
             else:
                 _LOGGER.debug(
                     _("Loaded %s: %s."), config["type"], config["module_path"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ websockets==8.1
 webexteamssdk==1.3
 voluptuous==0.11.7
 regex==2020.5.7
+watchgod==0.6

--- a/tests/mockmodules/skills/broken_skill.py
+++ b/tests/mockmodules/skills/broken_skill.py
@@ -1,1 +1,3 @@
+"""A broken skill with a bad import."""
+
 import czxlkjhzfdlkjhzfd

--- a/tests/mockmodules/skills/broken_skill.py
+++ b/tests/mockmodules/skills/broken_skill.py
@@ -1,0 +1,1 @@
+import czxlkjhzfdlkjhzfd

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import os
 import asyncio
+import contextlib
 import unittest
 import unittest.mock as mock
 import asynctest
@@ -523,3 +524,55 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.config["parsers"] = {"rasanlu": {"enabled": True}}
             with amock.patch("opsdroid.parsers.rasanlu.train_rasanlu"):
                 await opsdroid.train_parsers({})
+
+    async def test_watchdog_works(self):
+        from watchgod import awatch, PythonWatcher
+        from tempfile import TemporaryDirectory
+        import os.path
+        import asyncio
+
+        async def watch_dirs(directories):
+            async def watch_dir(directory):
+                async for changes in awatch(directory, watcher_cls=PythonWatcher):
+                    assert changes
+                    break
+
+            await asyncio.gather(*[watch_dir(directory) for directory in directories])
+
+        async def modify_dir(directory):
+            await asyncio.sleep(0.1)
+            with open(os.path.join(directory, "test.py"), "w") as fh:
+                fh.write("")
+
+        with TemporaryDirectory() as directory:
+            await asyncio.gather(watch_dirs([directory]), modify_dir(directory))
+
+    async def test_watchdog(self):
+        skill_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "mockmodules/skills/skill/skilltest",
+        )
+        example_config = {
+            "connectors": {"websocket": {}},
+            "skills": {"test": {"path": skill_path}},
+        }
+
+        async def modify_dir(opsdroid, directory):
+            await asyncio.sleep(0.1)
+            mock_file_path = os.path.join(directory, "mock.py")
+            with open(mock_file_path, "w") as fh:
+                fh.write("")
+            await asyncio.sleep(0.5)
+            opsdroid.path_watch_task.cancel()
+            os.remove(mock_file_path)
+
+        with OpsDroid(config=example_config) as opsdroid:
+            opsdroid.reload = amock.CoroutineMock()
+            await opsdroid.load()
+
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.gather(
+                    opsdroid.path_watch_task, modify_dir(opsdroid, skill_path)
+                )
+
+            assert opsdroid.reload.called

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -243,6 +243,10 @@ class TestCoreAsync(asynctest.TestCase):
             opsdroid.cron_task.cancel = amock.CoroutineMock()
             mock_cron_task = opsdroid.cron_task
 
+            opsdroid.path_watch_task = amock.CoroutineMock()
+            opsdroid.path_watch_task.cancel = amock.CoroutineMock()
+            mock_path_watch_task = opsdroid.path_watch_task
+
             async def task():
                 await asyncio.sleep(0.5)
 
@@ -256,6 +260,7 @@ class TestCoreAsync(asynctest.TestCase):
             self.assertTrue(mock_web_server.stop.called)
             self.assertTrue(opsdroid.web_server is None)
             self.assertTrue(mock_cron_task.cancel.called)
+            self.assertTrue(mock_path_watch_task.cancel.called)
             self.assertTrue(opsdroid.cron_task is None)
             self.assertFalse(opsdroid.connectors)
             self.assertFalse(opsdroid.memory.databases)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -8,6 +8,7 @@ import unittest.mock as mock
 from types import ModuleType
 
 import pkg_resources
+from opsdroid.core import OpsDroid
 from opsdroid.cli.start import configure_lang
 from opsdroid.configuration import load_config_file
 from opsdroid.const import ENV_VAR_REGEX
@@ -253,6 +254,19 @@ class TestLoader(unittest.TestCase):
             mock_iter_entry_points.return_value = (ep,)
             loaded = loader._load_modules("database", modules)
             self.assertEqual(loaded[0]["config"]["name"], "myep")
+
+    def test_import_broken_module(self):
+        skill_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "mockmodules/skills/broken_skill.py",
+        )
+        config = {
+            "connectors": {"websocket": {}},
+            "skills": {"test": {"path": skill_path}},
+        }
+        with OpsDroid(config=config) as opsdroid:
+            opsdroid.sync_load()
+            assert len(opsdroid.skills) == 0
 
     def test_load_config(self):
         opsdroid, loader = self.setup()


### PR DESCRIPTION
If you write your own opsdroid skill and configure it via the `path` option that path will now be watched and if any changes are made to python files within that path opsdroid will automatically reload to pick up those changes.

```yaml
...

skills:
  test:
    path: /path/to/my/skill
```

Modifying any Python file within `/path/to/my/skill` will trigger a reload.

---

For this to work I also had to handle importing a broken module better, the import exception is now logged with an error.

If `/path/to/my/skill/__init__.py` looks something like:

```python
import loging  # Should be logging

...
```

we now see:

```
ERROR opsdroid.loader: The following exception was raised while importing skill opsdroid-modules.skill.test
ERROR opsdroid.loader: No module named 'loging'
ERROR opsdroid.loader: Failed to load skill: opsdroid-modules.skill.test.
ERROR opsdroid.loader: Module test failed to import.
```