### PR TITLE
Fix custom config path being ignored during reload

### DIFF
--- a/opsdroid/cli/start.py
+++ b/opsdroid/cli/start.py
@@ -32,11 +32,12 @@ def start(path):
     """
     check_dependencies()
 
-    config = load_config_file([path] if path else DEFAULT_CONFIG_LOCATIONS)
+    config_path = [path] if path else DEFAULT_CONFIG_LOCATIONS
+    config = load_config_file(config_path)
 
     configure_lang(config)
     configure_logging(config)
     welcome_message(config)
 
-    with OpsDroid(config=config) as opsdroid:
+    with OpsDroid(config=config, config_path=config_path) as opsdroid:
         opsdroid.run()

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -12,7 +12,7 @@ import inspect
 from watchgod import awatch, PythonWatcher
 
 from opsdroid import events
-from opsdroid.const import DEFAULT_CONFIG_PATH
+from opsdroid.const import DEFAULT_CONFIG_LOCATIONS
 from opsdroid.memory import Memory
 from opsdroid.connector import Connector
 from opsdroid.configuration import load_config_file
@@ -44,7 +44,7 @@ class OpsDroid:
 
     instances = []
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, config_path=None):
         """Start opsdroid."""
         self.bot_name = "opsdroid"
         self._running = False
@@ -63,6 +63,7 @@ class OpsDroid:
         self.modules = {}
         self.cron_task = None
         self.loader = Loader(self)
+        self.config_path = [config_path] if config_path else DEFAULT_CONFIG_LOCATIONS
         if config is None:
             self.config = {}
         else:
@@ -238,13 +239,7 @@ class OpsDroid:
     async def reload(self):
         """Reload opsdroid."""
         await self.unload()
-        self.config = load_config_file(
-            [
-                "configuration.yaml",
-                DEFAULT_CONFIG_PATH,
-                "/etc/opsdroid/configuration.yaml",
-            ]
-        )
+        self.config = load_config_file(self.config_path)
         await self.load()
 
     def setup_skills(self, skills):


### PR DESCRIPTION
When opsdroid reloads it also reloads its config. Currently this is loaded from the default paths even if a custom path was passed in as a cli argument.

This PR passes any custom paths through to opsdroid for use when reloading.