### PR TITLE
Add support for env var expansion in JSON configs

### DIFF
--- a/opsdroid/configuration/__init__.py
+++ b/opsdroid/configuration/__init__.py
@@ -112,11 +112,10 @@ def load_config_file(config_paths):
             # Resolvers do not run correctly on JSON so if the config is a JSON
             # file dump it to a temporary file as YAML and read it back in again.
             if config_path.endswith(".json"):
-                with tempfile.NamedTemporaryFile() as tmp:
-                    with open(tmp.name, "w") as fh:
-                        yaml.dump(data, fh, allow_unicode=True)
-                    with open(tmp.name, "r") as fh:
-                        data = yaml.load(fh, Loader=yaml.SafeLoader)
+                with tempfile.NamedTemporaryFile("r+") as tmp:
+                    yaml.dump(data, tmp, allow_unicode=True)
+                    tmp.seek(0)
+                    data = yaml.load(tmp, Loader=yaml.SafeLoader)
 
             validate_data_type(data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ emoji==0.5.4
 mattermostdriver==7.0.1
 matrix-api-async==0.1.0
 motor==2.1.0
-multidict==4.7.5
+multidict==4.7.6
 nbconvert==5.6.1
 nbformat==5.0.6
 opsdroid-get-image-size==0.2.2

--- a/tests/configs/minimal_with_envs.json
+++ b/tests/configs/minimal_with_envs.json
@@ -1,0 +1,10 @@
+{
+    "connectors": {
+        "shell": {
+            "bot-name": "$ENVVAR"
+        }
+    },
+    "skills": {
+        "hello": {}
+    }
+}

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -81,9 +81,12 @@ class TestConfiguration(unittest.TestCase):
         config = load_config_file(
             [os.path.abspath("tests/configs/minimal_with_envs.yaml")]
         )
-        self.assertEqual(
-            config["connectors"]["shell"]["bot-name"], os.environ["ENVVAR"]
+        assert config["connectors"]["shell"]["bot-name"] == os.environ["ENVVAR"]
+
+        config = load_config_file(
+            [os.path.abspath("tests/configs/minimal_with_envs.json")]
         )
+        assert config["connectors"]["shell"]["bot-name"] == os.environ["ENVVAR"]
 
     def test_create_default_config(self):
         test_config_path = os.path.join(


### PR DESCRIPTION
As YAML is a superset of JSON it should be possible to provide config to opsdroid in JSON format. However it appears that environment variable are not expanded correctly when reading JSON files.

This is due to the way pyyaml handles resolvers on JSON files. As a workaround if a config file is JSON it gets written to a temporary file as YAML and read back in again to ensure things are resolved as expected. Not the most elegant solution but config files should be small and overhead should be minimal.

I also noticed while reading Stack Overflow to look into this that someone suggested simply using `os.path.expandvars` for replacing variables in strings as it will have better OS support and also will replace variables within strings. Currently it only works if the whole string is an env var.