### PR TITLE
Labeler doesn't work from forks so switching to a cron action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,7 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+  schedule:
+  - cron: "0 * * * *"
 
 jobs:
   triage:


### PR DESCRIPTION
The labeler action doesn't have the correct permissions in the token when running from a fork. 

As suggested [here ](https://github.com/actions/starter-workflows/pull/78/files)the workaround is to run the action on cron instead as that will have permissions to modify the main repo.