### PR TITLE
Rename sqlite database location config option to 'path' to match other config

### DIFF
--- a/docs/databases/sqlite.md
+++ b/docs/databases/sqlite.md
@@ -7,7 +7,7 @@ A database module for opsdroid to persist memory in a [SQLite](https://www.sqlit
 ```yaml
 databases:
   sqlite:
-    file: "my_file.db"  # (optional) default "~/.opsdroid/sqlite.db"
+    path: "my_file.db"  # (optional) default "~/.opsdroid/sqlite.db"
     table: "my_table"  # (optional) default "opsdroid"
 ```
 

--- a/tests/test_database_sqlite.py
+++ b/tests/test_database_sqlite.py
@@ -25,14 +25,13 @@ class TestDatabaseSqlite(unittest.TestCase):
 
         This method will test the initialisation of the database
         class. It will assert if the database class properties are
-        declared and equated to None.
+        declared.
 
         """
-        database = DatabaseSqlite({"file": "sqlite.db"})
+        database = DatabaseSqlite({"path": "sqlite.db"})
         self.assertEqual(None, database.client)
-        self.assertEqual(None, database.database)
-        self.assertEqual(None, database.db_file)
-        self.assertEqual(None, database.table)
+        self.assertEqual("sqlite.db", database.db_file)
+        self.assertEqual("opsdroid", database.table)
         self.assertEqual({"isolation_level": None}, database.conn_args)
 
 
@@ -50,7 +49,7 @@ class TestDatabaseSqliteAsync(asynctest.TestCase):
         As the database is created `opsdroid` table is created first.
 
         """
-        database = DatabaseSqlite({"file": "sqlite.db"})
+        database = DatabaseSqlite({"path": "sqlite.db"})
         opsdroid = amock.CoroutineMock()
         opsdroid.eventloop = self.loop
 
@@ -71,7 +70,7 @@ class TestDatabaseSqliteAsync(asynctest.TestCase):
         This method will test the database disconnection of sqlite database.
 
         """
-        database = DatabaseSqlite({"file": "sqlite.db"})
+        database = DatabaseSqlite({"path": "sqlite.db"})
         opsdroid = amock.CoroutineMock()
         opsdroid.eventloop = self.loop
 
@@ -92,7 +91,7 @@ class TestDatabaseSqliteAsync(asynctest.TestCase):
         followed by the `delete` operation which deletes the key.
 
         """
-        database = DatabaseSqlite({"file": "sqlite.db"})
+        database = DatabaseSqlite({"path": "sqlite.db"})
         opsdroid = amock.CoroutineMock()
         opsdroid.eventloop = self.loop
 
@@ -110,3 +109,7 @@ class TestDatabaseSqliteAsync(asynctest.TestCase):
             self.assertEqual("opsdroid", table)
             self.assertEqual({}, data)
             self.assertEqual("Connection", client)
+
+    async def test_deprecated_path(self):
+        database = DatabaseSqlite({"file": "sqlite.db"})
+        assert database.db_file == "sqlite.db"


### PR DESCRIPTION
I noticed that the sqlite database has a config option `file` to set where the database is, but other options such as skills use the key `path` to set where something is.

This PR updates the sqlite database to use `path` but also includes `file` as an alias with a deprecation warning.


## Status
**READY**

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Updated unit tests to use new `path` option
- Added unit test for old `file` option to ensure backward compatibility


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
