### PR TITLE
Make autoreload optional and disabled by default

### DIFF
--- a/opsdroid/configuration/validation.py
+++ b/opsdroid/configuration/validation.py
@@ -25,6 +25,7 @@ BASE_SCHEMA = {
     "logging": logging,
     "module-path": str,
     "welcome-message": bool,
+    "autoreload": bool,
     "web": web,
 }
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -297,9 +297,16 @@ class OpsDroid:
             async for _ in awatch(path, watcher_cls=PythonWatcher):
                 await opsdroid.reload()
 
-        await asyncio.gather(
-            *[watch_and_reload(self, path) for path in self.reload_paths]
-        )
+        if self.config.get("autoreload", False):
+            _LOGGER.warning(
+                _(
+                    "Watching module files for changes. "
+                    "Warning autoreload is an experimental feature."
+                ),
+            )
+            await asyncio.gather(
+                *[watch_and_reload(self, path) for path in self.reload_paths]
+            )
 
     async def train_parsers(self, skills):
         """Train the parsers.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -558,6 +558,7 @@ class TestCoreAsync(asynctest.TestCase):
             "mockmodules/skills/skill/skilltest",
         )
         example_config = {
+            "autoreload": True,
             "connectors": {"websocket": {}},
             "skills": {"test": {"path": skill_path}},
         }


### PR DESCRIPTION
Autoreloading isn't working perfectly at the moment.

So for now I'm putting it behind a feature gate. To enable it you need to add `autoreload: true` to your config.