### PR TITLE
Add convenience functions for getting connectors and databases

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -108,6 +108,25 @@ You can also specify code to run when your skill is loaded. Perhaps you want to 
    setup
 ```
 
+## Helper functions
+
+When you have a skill there will automatically be a pointer to the core opsdroid object. This object has helper functions which enable you to access different things within opsdroid.
+
+For example if you wish to get a pointer to a connector or database object by name you can use the convenience functions.
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
+
+class HelloSkill(Skill):
+    @match_regex(r'hi')
+    async def hello(self, message):
+        slack = self.opsdroid.get_connector("slack")
+        redis = self.opsdroid.get_database("redis")
+```
+
+If you try to access a connector or database which has not been configured these functions will return `None.`.
+
 ## Examples
 
 For examples of the kind of skills you can build in opsdroid see the [examples section](../examples/index). Or continue reading about more of the features you can use to create your skills.

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -486,6 +486,44 @@ class OpsDroid:
 
         return sorted(ranked_skills, key=lambda k: k["score"], reverse=True)
 
+    def get_connector(self, name):
+        """Get a connector object.
+
+        Get a specific connector by name from the list of active connectors.
+
+        Args:
+            name (string): Name of the connector we want to access.
+
+        Returns:
+            connector (opsdroid.connector.Connector): An opsdroid connector.
+        """
+        try:
+            [connector] = [
+                connector for connector in self.connectors if connector.name == name
+            ]
+            return connector
+        except ValueError:
+            return None
+
+    def get_database(self, name):
+        """Get a database object.
+
+        Get a specific database by name from the list of active databases.
+
+        Args:
+            name (string): Name of the database we want to access.
+
+        Returns:
+            database (opsdroid.database.Database): An opsdroid database.
+        """
+        try:
+            [database] = [
+                database for database in self.memory.databases if database.name == name
+            ]
+            return database
+        except ValueError:
+            return None
+
     async def _constrain_skills(self, skills, message):
         """Remove skills with contraints which prohibit them from running.
 

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -496,6 +496,7 @@ class OpsDroid:
 
         Returns:
             connector (opsdroid.connector.Connector): An opsdroid connector.
+
         """
         try:
             [connector] = [
@@ -515,6 +516,7 @@ class OpsDroid:
 
         Returns:
             database (opsdroid.database.Database): An opsdroid database.
+
         """
         try:
             [database] = [

--- a/opsdroid/database/__init__.py
+++ b/opsdroid/database/__init__.py
@@ -97,6 +97,7 @@ class InMemoryDatabase(Database):
     def __init__(self, config={}, opsdroid=None):  # noqa: D107
         super().__init__(config, opsdroid)
         self.memory = {}
+        self.name = "inmem"
 
     async def connect(self):  # noqa: D102
         pass  # pragma: nocover

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -582,3 +582,21 @@ class TestCoreAsync(asynctest.TestCase):
                 )
 
             assert opsdroid.reload.called
+
+    async def test_get_connector_database(self):
+        skill_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "mockmodules/skills/skill/skilltest",
+        )
+        example_config = {
+            "connectors": {"websocket": {}},
+            "skills": {"test": {"path": skill_path}},
+        }
+        with OpsDroid(config=example_config) as opsdroid:
+            await opsdroid.load()
+
+            assert opsdroid.get_connector("websocket") is not None
+            assert opsdroid.get_connector("slack") is None
+
+            assert opsdroid.get_database("inmem") is not None
+            assert opsdroid.get_database("redis") is None


### PR DESCRIPTION
# Description
Adds `get_connector` and `get_database` convenience methods to the opsdroid object.

Useful in skills when wanting a pointer to the connector and database instances.

```python
from opsdroid.skill import Skill
from opsdroid.matchers import match_regex

class HelloSkill(Skill):
    @match_regex(r'hi')
    async def hello(self, message):
        slack = self.opsdroid.get_connector("slack")
        redis = self.opsdroid.get_database("redis")
```

Fixes #1345 


## Status
**READY** 


## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- Added unit test


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
