### PR TITLE
Fix webex teams config

### DIFF
--- a/opsdroid/connector/webexteams/__init__.py
+++ b/opsdroid/connector/webexteams/__init__.py
@@ -14,7 +14,7 @@ from opsdroid.events import Message
 
 
 _LOGGER = logging.getLogger(__name__)
-CONFIG_SCHEMA = {Required("webhook-url"): Url, Required("token"): str}
+CONFIG_SCHEMA = {Required("webhook-url"): Url(), Required("token"): str}
 
 
 class ConnectorWebexTeams(Connector):

--- a/tests/test_connector_webexteams.py
+++ b/tests/test_connector_webexteams.py
@@ -24,6 +24,10 @@ class TestConnectorCiscoWebexTeams(unittest.TestCase):
         self.assertEqual("webexteams", connector.name)
         self.assertEqual("opsdroid", connector.bot_name)
 
+    def test_webhook_url_is_valid(self):
+        connector = ConnectorWebexTeams({"webhook-url": "https://example.com"})
+        assert connector.config.get("webhook-url").startswith("https")
+
     def test_missing_api_key(self):
         """Test that creating without an API without config raises an error."""
         with self.assertRaises(TypeError):


### PR DESCRIPTION
# Description

Looks like there was a bug in the voluptuous config for the WebEx Teams connector. The URL option is a function and needs to be called.

https://github.com/alecthomas/voluptuous#urls

Fixes #1501


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Added unit test


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
