### PR TITLE
Change the deploy workflow so it is triggered on the release event

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   deploy:


### PR DESCRIPTION
The pypi release was never triggered on the 0.19 release, this should hopefully fix it.