### PR TITLE
Update support table to indicate we support Python 3.8

### DIFF
--- a/docs/maintaining/supported-python-versions.md
+++ b/docs/maintaining/supported-python-versions.md
@@ -13,6 +13,6 @@ In addition to this we will also endeavour to support new minor versions of Pyth
 | 3.5.0   | September 2015 | March 2016    | March 2019    | No longer supported |
 | 3.6.0   | December 2016  | June 2017     | June 2020     | Supported           |
 | 3.7.0   | June 2018      | December 2018 | December 2021 | Supported           |
-| 3.8.0   | October 2019   | April 2020    | April 2023    | Not yet supported   |
+| 3.8.0   | October 2019   | April 2020    | April 2023    | Supported           |
 
 _If you think this table may be out of date please help by raising a [Pull Request](https://github.com/opsdroid/opsdroid/edit/master/docs/project/supported-python-versions.md) to fix it._

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Communications :: Chat",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
# Description

Fixed issue #1534 by updating the metadata in ```setup.py```  and docs in ```docs/maintaining/supported-python-versions.md```  indicating that Python 3.8 is now supported. 

Fixes #1534


## Status
**READY**


## Type of change
- Documentation (fix or adds documentation)


# How Has This Been Tested?
- Tox

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
