### PR TITLE
Make additional GitHub api request before making user request

### DIFF
--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -32,16 +32,20 @@ class ConnectorGitHub(Connector):
 
     async def connect(self):
         """Connect to GitHub."""
-        url = "{}/user?access_token={}".format(GITHUB_API_URL, self.github_token)
-        async with aiohttp.ClientSession(trust_env=True) as session:
-            response = await session.get(url)
-            if response.status >= 300:
-                _LOGGER.error(_("Error connecting to GitHub: %s."), response.text())
+        url = "{}".format(GITHUB_API_URL)
+        headers = {"Authorization": "token {}".format(self.github_token)}
+        async with aiohttp.ClientSession(trust_env=True, headers=headers) as session:
+            auth_response = await session.get(url)
+            if auth_response.status >= 300:
+                response_text = await auth_response.text()
+                _LOGGER.error(_("Error connecting to GitHub: %s."), response_text)
                 return False
+            user_url = "{}/user".format(GITHUB_API_URL)
+            user_response = await session.get(user_url)
             _LOGGER.debug(_("Reading bot information..."))
-            bot_data = await response.json()
-        _LOGGER.debug(_("Done."))
-        self.github_username = bot_data["login"]
+            bot_data = await user_response.json()
+            _LOGGER.debug(_("Done."))
+            self.github_username = bot_data["login"]
 
         self.opsdroid.web_server.web_app.router.add_post(
             "/connector/{}".format(self.name), self.github_message_handler

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -32,20 +32,18 @@ class ConnectorGitHub(Connector):
 
     async def connect(self):
         """Connect to GitHub."""
-        url = "{}".format(GITHUB_API_URL)
-        headers = {"Authorization": "token {}".format(self.github_token)}
+        headers = {"Authorization": f"token {self.github_token}"}
         async with aiohttp.ClientSession(trust_env=True, headers=headers) as session:
-            auth_response = await session.get(url)
-            if auth_response.status >= 300:
-                response_text = await auth_response.text()
+            url = f"{GITHUB_API_URL}/user"
+            response = await session.get(url)
+            if response.status >= 300:
+                response_text = await response.text()
                 _LOGGER.error(_("Error connecting to GitHub: %s."), response_text)
                 return False
-            user_url = "{}/user".format(GITHUB_API_URL)
-            user_response = await session.get(user_url)
             _LOGGER.debug(_("Reading bot information..."))
-            bot_data = await user_response.json()
-            _LOGGER.debug(_("Done."))
-            self.github_username = bot_data["login"]
+            bot_data = await response.json()
+        _LOGGER.debug(_("Done."))
+        self.github_username = bot_data["login"]
 
         self.opsdroid.web_server.web_app.router.add_post(
             "/connector/{}".format(self.name), self.github_message_handler

--- a/tests/test_connector_github.py
+++ b/tests/test_connector_github.py
@@ -4,12 +4,10 @@ import os.path
 
 import asyncio
 import unittest
-import unittest.mock as mock
 import asynctest
 import asynctest.mock as amock
 
 from opsdroid.cli.start import configure_lang
-from opsdroid.core import OpsDroid
 from opsdroid.connector.github import ConnectorGitHub
 from opsdroid.events import Message
 
@@ -56,16 +54,14 @@ class TestConnectorGitHubAsync(asynctest.TestCase):
             )
 
     async def test_connect_failure(self):
-        result = amock.MagicMock()
-        result.status = 401
-
-        with OpsDroid() as opsdroid, amock.patch(
-            "aiohttp.ClientSession.get"
-        ) as patched_request:
-
+        with amock.patch("aiohttp.ClientSession.get") as patched_request:
+            mockresponse = amock.CoroutineMock()
+            mockresponse.status = 401
+            mockresponse.text = amock.CoroutineMock(
+                return_value='{"message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"}'
+            )
             patched_request.return_value = asyncio.Future()
-            patched_request.return_value.set_result(result)
-
+            patched_request.return_value.set_result(mockresponse)
             await self.connector.connect()
             self.assertLogs("_LOGGER", "error")
 


### PR DESCRIPTION
# Description

This is a fix to a deprecated way of determining the authenticated GitHub user that is implemented by the Opsdroid GitHub connector. Instead of trying to retrieve the user in one request to the GitHub API (using the access token in query params), there are now two requests that are made:

1. One to authenticate with the token provided in `configuration.yaml`
2. An additional request to determine the username of the user authenticated in the first request

Fixes: #1546 

## Status
**READY**

I think?

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have not added any additional tests, but I have modified an existing test so that it continues to pass.

- `tests/test_connector_github.py::TestConnectorGitHubAsync::test_connect_failure`

# Checklist:

- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] I have made corresponding changes to the documentation (not applicable)
- [X] I have added tests that prove my fix is effective or that my feature works (not applicable)
