### PR TITLE
Fix some modules not being removed properly when closing opsdroid

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -201,19 +201,19 @@ class OpsDroid:
         _LOGGER.info(_("Received stop signal, exiting."))
 
         _LOGGER.info(_("Removing skills..."))
-        for skill in self.skills:
+        for skill in self.skills[:]:
             _LOGGER.info(_("Removed %s."), skill.config["name"])
             self.skills.remove(skill)
         if self.path_watch_task:
             self.path_watch_task.cancel()
 
-        for connector in self.connectors:
+        for connector in self.connectors[:]:
             _LOGGER.info(_("Stopping connector %s..."), connector.name)
             await connector.disconnect()
             self.connectors.remove(connector)
             _LOGGER.info(_("Stopped connector %s."), connector.name)
 
-        for database in self.memory.databases:
+        for database in self.memory.databases[:]:
             _LOGGER.info(_("Stopping database %s..."), database.name)
             await database.disconnect()
             self.memory.databases.remove(database)


### PR DESCRIPTION
# Description

Some modules were not being removed when the user closed opsdroid since we were iterating through the list of modules while modifying it which caused it to skip every other module

## Status
**READY**


## Type of change


- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
