### PR TITLE
dropping python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 version: 2
 
 python:
-  version: 3.6
+  version: 3.7
   install:
     - requirements: requirements.txt
     - requirements: requirements_test.txt

--- a/docs/maintaining/supported-python-versions.md
+++ b/docs/maintaining/supported-python-versions.md
@@ -11,7 +11,7 @@ In addition to this we will also endeavour to support new minor versions of Pyth
 | Version | Release Date   | Start Support | End Support   | Status              |
 |---------|----------------|---------------|---------------|---------------------|
 | 3.5.0   | September 2015 | March 2016    | March 2019    | No longer supported |
-| 3.6.0   | December 2016  | June 2017     | June 2020     | Supported           |
+| 3.6.0   | December 2016  | June 2017     | June 2020     | No longer supported |
 | 3.7.0   | June 2018      | December 2018 | December 2021 | Supported           |
 | 3.8.0   | October 2019   | April 2020    | April 2023    | Supported           |
 

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -115,8 +115,8 @@ def check_dependencies():
         below 3.6.
 
     """
-    if sys.version_info.major < 3 or sys.version_info.minor < 6:
-        logging.critical(_("Whoops! opsdroid requires python 3.6 or above."))
+    if sys.version_info.major < 3 or sys.version_info.minor < 7:
+        logging.critical(_("Whoops! opsdroid requires python 3.7 or above."))
         sys.exit(1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Communications :: Chat",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,12 +103,10 @@ class TestCLI(unittest.TestCase):
         with mock.patch.object(sys, "version_info") as version_info:
             version_info.major = 3
             version_info.minor = 6
-            try:
+            with self.assertRaises(SystemExit):
                 from opsdroid.cli.utils import check_dependencies
 
                 check_dependencies()
-            except SystemExit:
-                self.fail("check_dependencies() exited unexpectedly!")
 
     def test_check_version_37(self):
         with mock.patch.object(sys, "version_info") as version_info:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py36, py37, py38, lint, docker
+envlist = py37, py38, lint, docker
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
 


### PR DESCRIPTION
# Description

Removed the python 3.6 dependencies from the following locations : 
    setup.py, ci.yml, tox.ini, .readthedocs..yml, opsdroid/cli/utils.py, supported-python-versions.md

Fixes #<issue>
#1541 

## Status
**READY** 


## Type of change

- Updating the existing dependencies and documentations.



# Checklist:
- [x]  I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have modified the tests so that python3.6 is accordingly verified.
- [x] New and existing unit tests pass locally with my changes
