### PR TITLE
Add xfail to watchdog test, fix deprecation warning for logging

### DIFF
--- a/opsdroid/database/sqlite/__init__.py
+++ b/opsdroid/database/sqlite/__init__.py
@@ -41,7 +41,9 @@ class DatabaseSqlite(Database):
         self.conn_args = {"isolation_level": None}
         if "file" in self.config:
             self.db_file = self.config["file"]
-            _LOGGER.warn("The option 'file' is deprecated, please use 'path' instead.")
+            _LOGGER.warning(
+                "The option 'file' is deprecated, please use 'path' instead."
+            )
         else:
             self.db_file = self.config.get(
                 "path", os.path.join(DEFAULT_ROOT_PATH, "sqlite.db")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,11 +1,13 @@
 import os
 import asyncio
 import contextlib
+import pytest
 import unittest
 import unittest.mock as mock
 import asynctest
 import asynctest.mock as amock
 import importlib
+import time
 
 from opsdroid.cli.start import configure_lang
 from opsdroid.core import OpsDroid
@@ -575,6 +577,7 @@ class TestCoreAsync(asynctest.TestCase):
         with TemporaryDirectory() as directory:
             await asyncio.gather(watch_dirs([directory]), modify_dir(directory))
 
+    @pytest.mark.xfail()
     async def test_watchdog(self):
         skill_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
@@ -589,9 +592,11 @@ class TestCoreAsync(asynctest.TestCase):
         async def modify_dir(opsdroid, directory):
             await asyncio.sleep(0.1)
             mock_file_path = os.path.join(directory, "mock.py")
+
             with open(mock_file_path, "w") as fh:
                 fh.write("")
-            await asyncio.sleep(0.5)
+                fh.flush()
+
             opsdroid.path_watch_task.cancel()
             os.remove(mock_file_path)
 
@@ -603,6 +608,12 @@ class TestCoreAsync(asynctest.TestCase):
                 await asyncio.gather(
                     opsdroid.path_watch_task, modify_dir(opsdroid, skill_path)
                 )
+
+            timeout = 5
+            start = time.time()
+            while not opsdroid.reload.called and start + timeout > time.time():
+                print("sleeping...")
+                await asyncio.sleep(0.5)
 
             assert opsdroid.reload.called
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -577,6 +577,7 @@ class TestCoreAsync(asynctest.TestCase):
         with TemporaryDirectory() as directory:
             await asyncio.gather(watch_dirs([directory]), modify_dir(directory))
 
+    # TODO: Test fails on mac only, needs investigating
     @pytest.mark.xfail()
     async def test_watchdog(self):
         skill_path = os.path.join(
@@ -612,7 +613,6 @@ class TestCoreAsync(asynctest.TestCase):
             timeout = 5
             start = time.time()
             while not opsdroid.reload.called and start + timeout > time.time():
-                print("sleeping...")
                 await asyncio.sleep(0.5)
 
             assert opsdroid.reload.called


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I've tried to implement your suggestion Jacob but on my mac this test keeps failing even after I bumped the timeout to 30seconds. So I'm not too sure about how to fix this problem. Since you mentioned that we could add xfail to this particular test this is what I have done as well as a temporary fix until we can figure out how to fix it properly.


## Status
**READY** 


## Type of change

<!-- Please delete options that are not relevant. -->

- Tests



# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tox - Green
- test_watchdog passes due to xfail.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
