### PR TITLE
Temporarily pin black to version 19.10b0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ database_mongo =
 # testing
 test =
 	flake8>=3.8.1
-	black>=19.10b0
+	black==19.10b0
 	coveralls>=2.0.0
 	dialogflow>=0.8.0
 	astroid>=2.4.1


### PR DESCRIPTION
# Description

Black's new release has a [bug](https://github.com/psf/black/issues/1629) that makes it pretty much unusable, so pinning the older one till that gets fixed

## Status
**READY** 

## Type of change


- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
