### PR TITLE
Handle KeyError exception when requesting twitch token

### DIFF
--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -152,7 +152,8 @@ class ConnectorSlack(Connector):
                 data["thread_ts"] = message.linked_event.event_id
 
         await self.slack.api_call(
-            "chat.postMessage", data=data,
+            "chat.postMessage",
+            data=data,
         )
 
     @register_event(Blocks)

--- a/opsdroid/connector/twitch/__init__.py
+++ b/opsdroid/connector/twitch/__init__.py
@@ -188,8 +188,11 @@ class ConnectorTwitch(Connector):
             resp = await session.post(TWITCH_OAUTH_ENDPOINT, params=params)
             data = await resp.json()
 
-            self.token = data["access_token"]
-            self.save_authentication_data(data)
+            try:
+                self.token = data["access_token"]
+                self.save_authentication_data(data)
+            except KeyError:
+                _LOGGER.warning(_("Unable to request oauth token - %s"), data)
 
     async def refresh_token(self):
         """Attempt to refresh the oauth token.
@@ -721,7 +724,9 @@ class ConnectorTwitch(Connector):
 
             param = {"title": event.status, "broadcaster_id": self.user_id}
             resp = await session.patch(
-                f"{TWITCH_API_ENDPOINT}/channels", headers=headers, params=param,
+                f"{TWITCH_API_ENDPOINT}/channels",
+                headers=headers,
+                params=param,
             )
 
             if resp.status == 204:

--- a/opsdroid/database/matrix/__init__.py
+++ b/opsdroid/database/matrix/__init__.py
@@ -89,7 +89,8 @@ class DatabaseMatrix(Database):
                         )
                     )
                     await self.connector.connection.room_redact(
-                        room_id=self.room_id, event_id=event["event_id"],
+                        room_id=self.room_id,
+                        event_id=event["event_id"],
                     )
 
         self.should_migrate = False
@@ -164,7 +165,9 @@ class DatabaseMatrix(Database):
         )
 
         ori_data = await self.connector.connection.room_get_state_event(
-            room_id=self.room_id, event_type=self._event_type, state_key=state_key,
+            room_id=self.room_id,
+            event_type=self._event_type,
+            state_key=state_key,
         )
         if isinstance(ori_data, RoomGetStateEventError):
             raise RuntimeError(
@@ -194,7 +197,8 @@ class DatabaseMatrix(Database):
         for k, v in data.items():
             if isinstance(v, dict) and len(v) == 1 and "encrypted_val" in v:
                 resp = await self.connector.connection.room_get_event(
-                    room_id=self.room_id, event_id=v["encrypted_val"],
+                    room_id=self.room_id,
+                    event_id=v["encrypted_val"],
                 )
                 if isinstance(resp, RoomGetEventError):
                     _LOGGER.error(
@@ -226,7 +230,9 @@ class DatabaseMatrix(Database):
         )
 
         data = await self.connector.connection.room_get_state_event(
-            room_id=self.room_id, event_type=self._event_type, state_key=state_key,
+            room_id=self.room_id,
+            event_type=self._event_type,
+            state_key=state_key,
         )
         if isinstance(data, RoomGetStateEventError):
             _LOGGER.error(

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ database_matrix =
 # testing
 test =
 	flake8>=3.8.1
-	black==19.10b0
+	black==20.8b1
 	coveralls>=2.0.0
 	dialogflow>=0.8.0
 	astroid>=2.4.1

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -1167,7 +1167,10 @@ class TestConnectorMatrixAsync:
 
     async def test_send_reaction(self, connector):
         message = events.Message(
-            "hello", event_id="$11111", connector=connector, target="!test:localhost",
+            "hello",
+            event_id="$11111",
+            connector=connector,
+            target="!test:localhost",
         )
         reaction = events.Reaction("⭕")
         with OpsDroid() as _:
@@ -1191,7 +1194,10 @@ class TestConnectorMatrixAsync:
 
     async def test_send_reply(self, connector):
         message = events.Message(
-            "hello", event_id="$11111", connector=connector, target="!test:localhost",
+            "hello",
+            event_id="$11111",
+            connector=connector,
+            target="!test:localhost",
         )
         reply = events.Reply("reply")
         with OpsDroid() as _:

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -164,7 +164,10 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         connector.slack.api_call = amock.CoroutineMock()
         await connector.send(
             events.Message(
-                text="test", user="user", target="room", connector=connector,
+                text="test",
+                user="user",
+                target="room",
+                connector=connector,
             )
         )
         self.assertTrue(connector.slack.api_call.called)

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -106,8 +106,8 @@ class TestParserRasaNLU(asynctest.TestCase):
         result.text = amock.CoroutineMock()
         result.text.return_value = "unauthorized"
         with amock.patch("aiohttp.ClientSession.post") as patched_request:
-            patched_request.side_effect = aiohttp.client_exceptions.ClientConnectorError(
-                "key", amock.Mock()
+            patched_request.side_effect = (
+                aiohttp.client_exceptions.ClientConnectorError("key", amock.Mock())
             )
             self.assertEqual(None, await rasanlu.call_rasanlu(message.text, config))
 
@@ -519,8 +519,8 @@ class TestParserRasaNLU(asynctest.TestCase):
 
             mock_gem.return_value = []
             mock_btu.return_value = "http://example.com"
-            patched_request.side_effect = aiohttp.client_exceptions.ClientConnectorError(
-                "key", amock.Mock()
+            patched_request.side_effect = (
+                aiohttp.client_exceptions.ClientConnectorError("key", amock.Mock())
             )
             self.assertEqual(await rasanlu.train_rasanlu({}, {}), False)
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Hello,

when running opsdroid from a clean installation, I've noticed that the method `request_oauth` of the Twitch connect was giving me a KeyError on line 191 - `self.token=data["access_token"]`

The reason for this, was that I wrote the redirect URL wrong, but we should really handle any status code != 200

This PR fixes this bug and logs a warning when data doesn't contain the access_token.


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tox - all green
- Ran opsdroid - works as expected


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
