### PR TITLE
Add a SIGHUP handler to reload opsdroid

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -58,6 +58,9 @@ class OpsDroid:
                 self.eventloop.add_signal_handler(
                     sig, lambda: asyncio.ensure_future(self.handle_signal())
                 )
+            self.eventloop.add_signal_handler(
+                signal.SIGHUP, lambda: asyncio.ensure_future(self.reload())
+            )
         self.eventloop.set_exception_handler(self.handle_async_exception)
         self.skills = []
         self.memory = Memory()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,7 +85,10 @@ class TestCore(unittest.TestCase):
             self.assertTrue(mock_sysexit.called)
 
     def test_signals(self):
-        with OpsDroid() as opsdroid:
+        loop = asyncio.get_event_loop()
+
+        def real_test_signals(opsdroid):
+            asyncio.set_event_loop(loop)
             opsdroid.load = amock.CoroutineMock()
             opsdroid.unload = amock.CoroutineMock()
             opsdroid.reload = amock.CoroutineMock()
@@ -95,6 +98,11 @@ class TestCore(unittest.TestCase):
                 opsdroid.run()
             self.assertTrue(opsdroid.reload.called)
             self.assertTrue(mock_sysexit.called)
+
+        with OpsDroid() as opsdroid:
+            thread = threading.Thread(target=real_test_signals, args=(opsdroid,))
+            thread.start()
+            thread.join()
 
     def test_run_cancelled(self):
         with OpsDroid() as opsdroid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,6 +85,8 @@ class TestCore(unittest.TestCase):
             self.assertTrue(mock_sysexit.called)
 
     def test_signals(self):
+        if os.name == "nt":
+            pytest.skip("SIGHUP unsupported on windows")
         loop = asyncio.get_event_loop()
 
         def real_test_signals(opsdroid):


### PR DESCRIPTION
# Description

This PR adds ability to reload opsdroid by SIGHUP signal.

Should I also add this to documentation somewhere? In overview page?
Also: from what I see sigint and other signals are not tested, should I add tests for sighup?
Also, glad to see that opsdroid is improving! Lots of changes since my last contributions during previous Hacktoberfest :tada: 

Fixes #1631


## Status
**READY** 


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`opsdroid start` in one terminal, in other one `kill -SIGHUP <pid>`
Opsdroid successfully restarted and used new configuration file.
![изображение](https://user-images.githubusercontent.com/39452697/94829332-12216400-0413-11eb-82cf-9148c3b06d06.png)



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
