### PR TITLE
Fix broken webhook - use base_url from web or twitch config

### DIFF
--- a/opsdroid/connector/twitch/__init__.py
+++ b/opsdroid/connector/twitch/__init__.py
@@ -61,10 +61,13 @@ class ConnectorTwitch(Connector):
         # TODO: Allow usage of SSL connection
         self.server = "ws://irc-ws.chat.twitch.tv"
         self.port = "80"
-        self.base_url = config.get("base-url")
         self.loop = asyncio.get_event_loop()
         self.reconnections = 0
         self.auth_file = TWITCH_JSON
+        try:
+            self.base_url = opsdroid.config["web"]["base-url"]
+        except KeyError:
+            self.base_url = config.get("forward-url")
 
     async def validate_request(self, request, secret):
         """Compute sha256 hash of request and secret.

--- a/opsdroid/connector/twitch/tests/test_connector_twitch.py
+++ b/opsdroid/connector/twitch/tests/test_connector_twitch.py
@@ -33,6 +33,35 @@ def test_init(opsdroid):
     assert connector.reconnections == 0
 
 
+def test_base_url_twitch_config(opsdroid):
+    config = {
+        "code": "yourcode",
+        "channel": "test",
+        "client-id": "client-id",
+        "client-secret": "client-secret",
+        "forward-url": "http://my-awesome-url",
+    }
+
+    connector = ConnectorTwitch(config, opsdroid=opsdroid)
+
+    assert connector.base_url == "http://my-awesome-url"
+
+
+def test_base_url_web_config(opsdroid):
+    config = {
+        "code": "yourcode",
+        "channel": "test",
+        "client-id": "client-id",
+        "client-secret": "client-secret",
+    }
+
+    opsdroid.config["web"] = {"base-url": "http://my-awesome-url"}
+
+    connector = ConnectorTwitch(config, opsdroid=opsdroid)
+
+    assert connector.base_url == "http://my-awesome-url"
+
+
 @pytest.mark.asyncio
 async def test_validate_request(opsdroid):
     connector = ConnectorTwitch(connector_config, opsdroid=opsdroid)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I've fixed the issue where the webhook URL was getting None. On this fix, we are checking if the `web` config has a `base-url` parameter, if not we will use the `forward-url` parameter from twitch config.

This fix might be a bit silly, but whenever we implement that `base-url` this connector will work as intended - so I tried to cover all the bases.

I've also added two tests to check that `twitch.base_url` exists and not break webhooks again. Sorry!

Fixes #1658


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tox - all green


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
