### PR TITLE
Add a config option to disable registering a route for / (#1656)

### DIFF
--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -37,6 +37,7 @@ welcome-message: true
 ## Configure the web server
 # web:
 #   host: '127.0.0.1'
+#   disable_web_index_handler_in_root: true
 #   port: 8080
 #   ssl:
 #     cert: /path/to/cert.pem

--- a/opsdroid/tests/test_web.py
+++ b/opsdroid/tests/test_web.py
@@ -40,20 +40,20 @@ async def test_web_get_host(opsdroid):
 
 async def test_web_disable_web_index_handler_in_root(opsdroid):
     """Check disabling of web index handler in root."""
-    opsdroid.config["web"] = {'disable_web_index_handler_in_root': True}
+    opsdroid.config["web"] = {"disable_web_index_handler_in_root": True}
     app = web.Web(opsdroid)
     canonicals = [resource.canonical for resource in app.web_app._router.resources()]
-    assert '/' not in canonicals
+    assert "/" not in canonicals
 
-    opsdroid.config["web"] = {'disable_web_index_handler_in_root': False}
+    opsdroid.config["web"] = {"disable_web_index_handler_in_root": False}
     app = web.Web(opsdroid)
     canonicals = [resource.canonical for resource in app.web_app._router.resources()]
-    assert '/' in canonicals
+    assert "/" in canonicals
 
     opsdroid.config["web"] = {}
     app = web.Web(opsdroid)
     canonicals = [resource.canonical for resource in app.web_app._router.resources()]
-    assert '/' in canonicals
+    assert "/" in canonicals
 
 
 async def test_web_get_ssl(opsdroid):

--- a/opsdroid/tests/test_web.py
+++ b/opsdroid/tests/test_web.py
@@ -38,6 +38,24 @@ async def test_web_get_host(opsdroid):
     assert app.get_host == "127.0.0.1"
 
 
+async def test_web_disable_web_index_handler_in_root(opsdroid):
+    """Check disabling of web index handler in root."""
+    opsdroid.config["web"] = {'disable_web_index_handler_in_root': True}
+    app = web.Web(opsdroid)
+    canonicals = [resource.canonical for resource in app.web_app._router.resources()]
+    assert '/' not in canonicals
+
+    opsdroid.config["web"] = {'disable_web_index_handler_in_root': False}
+    app = web.Web(opsdroid)
+    canonicals = [resource.canonical for resource in app.web_app._router.resources()]
+    assert '/' in canonicals
+
+    opsdroid.config["web"] = {}
+    app = web.Web(opsdroid)
+    canonicals = [resource.canonical for resource in app.web_app._router.resources()]
+    assert '/' in canonicals
+
+
 async def test_web_get_ssl(opsdroid):
     """Check the host getter."""
     opsdroid.config["web"] = {}

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -25,7 +25,7 @@ class Web:
         self.web_app = web.Application()
         self.runner = web.AppRunner(self.web_app)
         self.site = None
-        if not self.config.get('disable_web_index_handler_in_root', False):
+        if not self.config.get("disable_web_index_handler_in_root", False):
             self.web_app.router.add_get("/", self.web_index_handler)
             self.web_app.router.add_get("", self.web_index_handler)
 

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -25,8 +25,10 @@ class Web:
         self.web_app = web.Application()
         self.runner = web.AppRunner(self.web_app)
         self.site = None
-        self.web_app.router.add_get("/", self.web_index_handler)
-        self.web_app.router.add_get("", self.web_index_handler)
+        if not self.config.get('disable_web_index_handler_in_root', False):
+            self.web_app.router.add_get("/", self.web_index_handler)
+            self.web_app.router.add_get("", self.web_index_handler)
+
         self.web_app.router.add_get("/stats", self.web_stats_handler)
         self.web_app.router.add_get("/stats/", self.web_stats_handler)
 


### PR DESCRIPTION
# Description

The intent is to let users to register any route for web index handling instead of
forcing the app to use just / address. New config param `disable_web_index_handler_in_root`
is added to let disabling that root route. The default value is false.

Unit tests have been added to verify that the config variable actually is treated correctly.

The default value for this disabling key is False, which means that disabling / registration
is not done, in order to keep things backwards compatible.

Fixes #1656


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update:  Not sure, if documentation is still needed?


# How Has This Been Tested?

- The new unit test tests/test_web verifies that the registration is not applied if this new 
config key is set to True.  
- Tested that adding `disable_web_index_handler_in_root` into YAML file with value
true is translated into Python True boolean value. 


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opsdroid/opsdroid/1660)
<!-- Reviewable:end -->
