### PR TITLE
Pin GitHub Actions docker builds to Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,42 +4,42 @@ on:
   push:
   pull_request:
   schedule:
-  - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   test:
-    runs-on:  ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.7, 3.8]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install libolm
-      if: runner.os != 'Windows'
-      run: |
-        if [ $RUNNER_OS = Linux ]; then
-            sudo apt install libolm3 libolm-dev
-        else
-            brew install libolm
-        fi
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -U tox tox-gh-actions
-    - name: Run tests
-      env:
-        PLATFORM: ${{ runner.os }}
-      run: tox
-    - name: Upload coverage report
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./cov.xml
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install libolm
+        if: runner.os != 'Windows'
+        run: |
+          if [ $RUNNER_OS = Linux ]; then
+              sudo apt install libolm3 libolm-dev
+          else
+              brew install libolm
+          fi
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -U tox tox-gh-actions
+      - name: Run tests
+        env:
+          PLATFORM: ${{ runner.os }}
+        run: tox
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./cov.xml
 
   check:
     runs-on: ubuntu-20.04
@@ -47,14 +47,14 @@ jobs:
       matrix:
         component: [docker-full, docker-min, lint]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -U tox
-    - name: Run checks
-      run: tox -e ${{ matrix.component }}
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -U tox
+      - name: Run checks
+        run: tox -e ${{ matrix.component }}


### PR DESCRIPTION
There seems to be some problem with Docker builds in recent PRs. 

[Example](https://github.com/opsdroid/opsdroid/pull/1662/checks?check_run_id=1320205258)

It looks like GitHub Actions has been updated with Python 3.9, and weirdly the build failures mention 3.9 even though they are building Docker containers.

Pinning to 3.8 for now to see if it resolves the issue.