### PR TITLE
Add ability to Edit Messages and Edit Blocks in Slack

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: stable
     hooks:
       - id: black
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
         language_version: python3

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -53,7 +53,7 @@ Slack has support for [rich layouts](https://api.slack.com/messaging/composing/l
 
 To do this you need to respond with an `opsdroid.connector.slack.events.Blocks` event which is constructed with a list of blocks.
 
-### Example
+### Send Block
 
 ```python
 from opsdroid.skill import Skill
@@ -94,10 +94,27 @@ class BlocksSkill(Skill):
                 }
             ]
         ))
-
 ```
 
 ![](https://user-images.githubusercontent.com/1610850/58658951-ac523300-8319-11e9-8c2a-011469a436d0.png)
+
+### Edit an existing Block
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
+from opsdroid.connector.slack.events import EditedBlocks
+
+
+class UpdateBlocksSkill(Skill):
+
+    @match_regex(r"edit block with ts 1605646357.261200")
+    async def who_are_you(self, event):
+    	# linked_event == the timestamp of the block to edit
+    	# target == channel id
+	blocks = ["the blocks datastructure"]
+        await self.opsdroid.send(EditedBlocks(blocks, linked_event=1605646357.261200, target="channel_id"))
+```
 
 ## Interactive Actions
 

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -191,7 +191,7 @@ class ConnectorSlack(Connector):
 
     @register_event(EditedBlocks)
     async def _edit_blocks(self, blocks):
-        """Edit a particular block"""
+        """Edit a particular block."""
         _LOGGER.debug(
             _("Editing interactive blocks with timestamp: '%s' in room  %s."),
             blocks.linked_event,

--- a/opsdroid/connector/slack/__init__.py
+++ b/opsdroid/connector/slack/__init__.py
@@ -152,7 +152,10 @@ class ConnectorSlack(Connector):
             elif self.start_thread:
                 data["thread_ts"] = message.linked_event.event_id
 
-        return await self.slack.api_call("chat.postMessage", data=data,)
+        return await self.slack.api_call(
+            "chat.postMessage",
+            data=data,
+        )
 
     @register_event(opsdroid.events.EditedMessage)
     async def _edit_message(self, message):
@@ -170,7 +173,10 @@ class ConnectorSlack(Connector):
             "as_user": self.chat_as_user,
         }
 
-        return await self.slack.api_call("chat.update", data=data,)
+        return await self.slack.api_call(
+            "chat.update",
+            data=data,
+        )
 
     @register_event(Blocks)
     async def _send_blocks(self, blocks):
@@ -204,7 +210,10 @@ class ConnectorSlack(Connector):
             "as_user": self.chat_as_user,
         }
 
-        return await self.slack.api_call("chat.update", data=data,)
+        return await self.slack.api_call(
+            "chat.update",
+            data=data,
+        )
 
     @register_event(opsdroid.events.Reaction)
     async def send_reaction(self, reaction):

--- a/opsdroid/connector/slack/events.py
+++ b/opsdroid/connector/slack/events.py
@@ -51,6 +51,14 @@ class Blocks(events.Message):
             self.blocks = json.dumps(self.blocks)
 
 
+class EditedBlocks(Blocks):
+    """A  `Blocks` slack instance which has been edited.
+
+    The ``linked_event`` property should hold Time Stamp (ts) of the Block
+    to be edited
+    """
+
+
 class InteractiveAction(events.Event):
     """Super class to represent Slack interactive actions."""
 

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -287,6 +287,7 @@ class EditedMessage(Message):
 
     The ``linked_event`` property should hold either an `opsdroid.events.Event`
     class or an id for an event to which the edit applies.
+    The linked_event for Slack is the ts (timestamp) of the message to be edited
     """
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -163,7 +163,10 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         connector.slack.api_call = amock.CoroutineMock()
         await connector.send(
             events.Message(
-                text="test", user="user", target="room", connector=connector,
+                text="test",
+                user="user",
+                target="room",
+                connector=connector,
             )
         )
         self.assertTrue(connector.slack.api_call.called)

--- a/tests/test_connector_slack.py
+++ b/tests/test_connector_slack.py
@@ -1,20 +1,19 @@
 """Tests for the ConnectorSlack class."""
 import asyncio
+import collections
+import json
 import unittest
 import unittest.mock as mock
+
+import aiohttp
 import asynctest
 import asynctest.mock as amock
 import slack
-import json
-import collections
-
-import aiohttp
-
-from opsdroid.core import OpsDroid
-from opsdroid.connector.slack import ConnectorSlack
-from opsdroid.connector.slack import events as slackevents
 from opsdroid import events
 from opsdroid.cli.start import configure_lang
+from opsdroid.connector.slack import ConnectorSlack
+from opsdroid.connector.slack import events as slackevents
+from opsdroid.core import OpsDroid
 
 
 class TestConnectorSlack(unittest.TestCase):
@@ -164,10 +163,7 @@ class TestConnectorSlackAsync(asynctest.TestCase):
         connector.slack.api_call = amock.CoroutineMock()
         await connector.send(
             events.Message(
-                text="test",
-                user="user",
-                target="room",
-                connector=connector,
+                text="test", user="user", target="room", connector=connector,
             )
         )
         self.assertTrue(connector.slack.api_call.called)
@@ -228,6 +224,30 @@ class TestConnectorSlackAsync(asynctest.TestCase):
             },
         )
 
+    async def test_edit_message(self):
+        connector = ConnectorSlack({"token": "abc123"}, opsdroid=self.od)
+        connector.slack.api_call = amock.CoroutineMock()
+        linked_event = "1582838099.000600"
+
+        edited_message = events.EditedMessage(
+            text="edited_message",
+            user="user",
+            target="room",
+            connector=connector,
+            linked_event=linked_event,
+        )
+
+        await connector.send(edited_message)
+        connector.slack.api_call.assert_called_once_with(
+            "chat.update",
+            data={
+                "channel": "room",
+                "ts": "1582838099.000600",
+                "text": "edited_message",
+                "as_user": False,
+            },
+        )
+
     async def test_send_blocks(self):
         connector = ConnectorSlack({"token": "abc123"}, opsdroid=self.od)
         connector.slack.api_call = amock.CoroutineMock()
@@ -237,6 +257,20 @@ class TestConnectorSlackAsync(asynctest.TestCase):
                 "user",
                 "room",
                 connector,
+            )
+        )
+        self.assertTrue(connector.slack.api_call.called)
+
+    async def test_update_blocks(self):
+        connector = ConnectorSlack({"token": "abc123"}, opsdroid=self.od)
+        connector.slack.api_call = amock.CoroutineMock()
+        await connector.send(
+            slackevents.EditedBlocks(
+                [{"type": "section", "text": {"type": "mrkdwn", "text": "*Test*"}}],
+                user="user",
+                target="room",
+                connector=connector,
+                linked_event="1358878749.000002",
             )
         )
         self.assertTrue(connector.slack.api_call.called)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Add ability to Edit Messages and Blocks in the slack connector
- Add `return` call to chat.postMessage and chat.update slack methods, in order to retrieve details of the response from the slack API

## Status
**READY** 


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Tests have been added to this to cover new functionalities
EditedBlocks have been tested in a prod system


# Checklist:

- [ X] I have performed a self-review of my own code
- [ X] I have made corresponding changes to the documentation (if applicable)
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
