### PR TITLE
switched json load to use object_hook to fix data serialization

### DIFF
--- a/opsdroid/database/redis/__init__.py
+++ b/opsdroid/database/redis/__init__.py
@@ -94,7 +94,7 @@ class RedisDatabase(Database):
             data = await self.client.execute("GET", key)
 
             if data:
-                return json.loads(data, encoding=JSONDecoder)
+                return json.loads(data, object_hook=JSONDecoder())
 
             return None
 


### PR DESCRIPTION
# redis database:  changed json.loads() to properly identify serialized json objects

This is a one-line change in the redis database get() call.    This same json.loads() line is used in the sqlite database get() function.    Open to learning best way to run tests in the opsdroid project. 

Fixes #1673

## Status
**READY**

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- tested using the example `skill-seen`.  

# Checklist:

- [ X ] I have performed a self-review of my own code
- [ N/A ] I have made corresponding changes to the documentation (if applicable)
- [ N/A ] I have added tests that prove my fix is effective or that my feature works
- [ not sure ] New and existing unit tests pass locally with my changes
