### PR TITLE
Handling encryption with matrix connection in the Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG EXTRAS=.[all]
 COPY . .
 
 RUN apk update \
-    && apk add --no-cache build-base linux-headers musl-dev python3-dev libzmq zeromq-dev git openssh-client olm olm-dev \
+    && apk add --no-cache build-base linux-headers musl-dev python3-dev libzmq zeromq-dev git openssh-client olm olm-dev libffi-dev \
     && pip3 install --upgrade pip \
     && pip3 install --no-cache-dir $EXTRAS \
     && apk del build-base linux-headers musl-dev python3-dev zeromq-dev

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ console_scripts =
 connector_matrix =
 	bleach>=3.1.5
 	matrix-nio>=0.14.1
-	python-olm
+connector_matrix_e2e =
 	matrix-nio[e2e]
 connector_mattermost =
 	mattermostdriver>=7.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,8 @@ console_scripts =
 connector_matrix =
 	bleach>=3.1.5
 	matrix-nio>=0.14.1
+	python-olm
+	matrix-nio[e2e]
 connector_mattermost =
 	mattermostdriver>=7.0.1
 connector_slack =

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,16 @@ class Sdist(sdist):
 
 
 extras = read_configuration("setup.cfg")["options"]["extras_require"]
-common_extras = [
-    "connector_matrix",
-    "connector_slack",
-    "database_sqlite",
-]
-extras["all"] = list(chain(*(extras[key] for key in extras.keys() if key != "test")))
+common_extras = ["connector_matrix", "connector_slack", "database_sqlite"]
+not_all = (
+    "test",
+    # We want people to have to opt-into e2ee at the moment because of
+    # difficult compile time dependancies.
+    "connector_matrix_e2e",
+)
+extras["all"] = list(
+    chain(*(extras[key] for key in extras.keys() if key not in not_all))
+)
 extras["all_connectors"] = list(
     chain(*(extras[key] for key in extras.keys() if key.startswith("connector")))
 )

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,10 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands =
      py.test -v --timeout=30 --cov=opsdroid --cov-report term-missing:skip-covered --cov-report=xml:cov.xml {posargs}
-deps =
-     e2e-!noe2e: matrix-nio[e2e]
-extras = all, test
+extras =
+     all
+     test
+     e2e-!noe2e: connector_matrix_e2e
 
 [testenv:docker-{full,min}]
 basepython = python3
@@ -56,7 +57,6 @@ commands =
 
 [testenv:lint]
 basepython = python3
-skip_install = true
 ignore_errors = True
 commands =
      flake8 --builtins='_' opsdroid

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ extras = all, test
 
 [testenv:docker-{full,min}]
 basepython = python3
+skipsdist = true
 ignore_errors = True
 whitelist_externals =
     docker
@@ -55,6 +56,7 @@ commands =
 
 [testenv:lint]
 basepython = python3
+skipsdist = true
 ignore_errors = True
 commands =
      flake8 --builtins='_' opsdroid

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ extras = all, test
 
 [testenv:docker-{full,min}]
 basepython = python3
-skipsdist = true
+skip_install = true
 ignore_errors = True
 whitelist_externals =
     docker
@@ -56,7 +56,7 @@ commands =
 
 [testenv:lint]
 basepython = python3
-skipsdist = true
+skip_install = true
 ignore_errors = True
 commands =
      flake8 --builtins='_' opsdroid


### PR DESCRIPTION
The matrix connection's encryption handling doesn't work with the current dev docker build due to missing dependencies. `nio.crypto.ENCRYPTION_ENABLED` returns `False`

To solve this, 3 dependencies are installed:
* `libffi-dev` via `apk`
* `python-olm` via `pip`
* `matrix-nio[e2e]` via `pip`

I've tested this in an encrypted room.

It should be noted that this by default **doesn't have persistence on the generated device key** and it can be a tad annoying if you name the device the same thing: Matrix doesn't see the new key. Using a volume for the `matrix_store` solves this.

Relates to #1676 