### PR TITLE
better handling for OSError in opsdroid.web.start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           if [ $RUNNER_OS = Linux ]; then
+              sudo apt update || true
               sudo apt install ffmpeg -y
           fi
       - name: Install ffmpeg on windows

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -17,6 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 class Web:
     """Create class for opsdroid Web server."""
 
+    start_timeout = 10  # seconds
+
     def __init__(self, opsdroid):
         """Create web object."""
         self.opsdroid = opsdroid
@@ -106,7 +108,7 @@ class Web:
         _LOGGER.info(_(f"Started web server on {self.base_url}"))
         await self.runner.setup()
 
-        timeout = Timeout(10, "Timed out starting web server")
+        timeout = Timeout(self.start_timeout, "Timed out starting web server")
         while timeout.run():
             try:
                 # We need to recreate the site each time we retry after an OSError.

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -115,11 +115,14 @@ class Web:
         timeout = Timeout(10, "Timed out starting web server")
         while timeout.run():
             try:
+                # this is not safe to run repeatedly or the "site" gets registered
+                # multiple times in the aiohttp web_runner
                 await self.site.start()
                 break
             except OSError as e:
                 await asyncio.sleep(0.1)
                 timeout.set_exception(e)
+                raise
 
     async def stop(self):
         """Stop the web server."""

--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -125,10 +125,7 @@ class Web:
             except OSError as e:
                 await asyncio.sleep(0.1)
                 timeout.set_exception(e)
-                try:
-                    await self.site.stop()
-                except RuntimeError:  # already unregistered
-                    pass
+                await self.site.stop()
 
     async def stop(self):
         """Stop the web server."""


### PR DESCRIPTION
# Description

Windows tests were apparently broken in #1682 .
This makes sure that site.start() is called safely (ie site needs to be recreated before being started)
And then test to make sure OSError gets raised correctly when the port is in use.


## Status
**DONE**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I don't have windows, so I'm using GHA to test this on windows.
Locally, the new test works for linux as well.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
