### PR TITLE
Add Twilio SMS connector

### DIFF
--- a/docs/connectors/sms.md
+++ b/docs/connectors/sms.md
@@ -1,0 +1,46 @@
+# SMS
+
+A connector for text messages, using the [Twilio](https://twil.io) API.
+
+## Requirements
+
+This requires a Twilio API Key, which is availible from [here](https://twil.io). Follow the below steps to set it up:
+
+1. Create a free or paid Twilio account. If you sign up through [this link](https://www.twilio.com/try-twilio?promo=YbalWV)  you will get a $10 credit when you upgrade.
+
+2. Install the Twilio CLI <div><details> <summary>Mac</summary> <code>brew tap twilio/brew && brew install twilio</code><br/><h4>Or Install via npm</h4><code>npm install twilio-cli -g</code></details><details><summary>Windows</summary><code>npm install twilio-cli -g
+</code></details><details><summary>Linux</summary>Please see the Twilio Docs</details></div>
+
+3. Run `twilio login`. Use the account information from you [Twilio console](https://www.twilio.com/console).Click the eye icon as shown below to reveal your account secret. <br/> ![account secret](https://twilio-cms-prod.s3.amazonaws.com/images/account_sid_auth_token.width-800.png)
+
+4. Run `twilio phone-numbers:buy:local --country-code US --sms-enabled` if you need to buy a phone number.
+
+## Configuration
+
+```yaml
+connectors:
+  sms:
+    name: "bot-name"  #optional
+    account_sid: "ACxxxxxxxxxxxxxx" # required
+    auth_token: "token"
+    phone_number: "+1555555555"
+    is_trial: true
+    approved_trial_numbers: # required if is_trial is true
+        - "+15555555555"
+```
+
+`name`: optional, string, bot name
+
+`account_sid`: required, string, your Twilio Account SID <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Go to [your Twilio Console](https://twilio.com/console) to find your SID. See the below image.
+
+`auth_token`: required, string, your Twilio Account Auth Token <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Go to [your Twilio Console](https://twilio.com/console) and click the eye icon to reveal your token.
+
+![account secret](https://twilio-cms-prod.s3.amazonaws.com/images/account_sid_auth_token.width-800.png)
+
+`phone_number`: required, string, the phone number from you Twilio account. If you followed the setup, this is the number you registered. <br/>
+
+`is_trial`: required, boolean <br/>
+
+`approved_trial_numbers`: required if `is_trial ` is set to "true", list

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Opsdroid Imports
+from opsdroid.connector import Connector, register_event
+from opsdroid.events import Message
+import logging
+
+# Twilio Imports
+from twilio.rest import Client
+
+_LOGGER = logging.getLogger(__name__)
+CONFIG_SCHEMA = {
+    "name": str,
+    "account_sid": str,
+    "auth_token": str,
+    "phone_number": str,
+    "host": str,
+    "port": int,
+}
+
+
+class SMSConnector(Connector):
+    """A connector for Twilio-powered SMS"""
+
+    def __init__(self, config, opsdroid):
+        super().__init__(config, opsdroid=opsdroid)
+        self.name = config["name"]
+        self.config = config
+
+    async def connect(self):
+        """Connect to Twilio and setup webhooks"""
+        self.connection = await Client(
+            self.config["account_sid"], self.config["auth_token"]
+        )
+        self.opsdroid.web_server.web_app.router.add_get(
+            f"/connector/{self.name}", self.handle_messages
+        )
+
+    async def handle_messages(self, request):
+        req_data = await request.json()
+        try:
+            message = Message(req_data["Body"], req_data["From"], None, self,)
+            await self.opsdroid.parse(message)
+        except Exception as e:
+            _LOGGER.error(f"ERROR: {e}")
+
+    @register_event(Message)
+    async def send_message(self, message):
+        try:
+            self.connection.messages.create(
+                from_=self.config["number"], to=message.user, body=message.text
+            )
+        except Exception as e:
+            _LOGGER.error(
+                f"{str(self.name).upper} COULD NOT SEND MESSAGE \n [ERROR]: {e}"
+            )
+
+    async def listen(self):
+        pass

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
+'''A SMS connector for opsdroid'''
 # Opsdroid Imports
 from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
@@ -22,7 +20,7 @@ CONFIG_SCHEMA = {
 
 
 class ConnectorSMS(Connector):
-    """A connector for Twilio-powered SMS"""
+    """A connector for SMS."""
 
     def __init__(self, config, opsdroid):
         super().__init__(config, opsdroid=opsdroid)

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -28,8 +28,10 @@ class ConnectorSMS(Connector):
         self.bot_name = config.get("bot-name", "opsdroid")
         self.config = config
 
-        if self.config["is_trial"] and len(self.config["approved_trial_numbers"]) == 0:
-            _LOGGER.warn("[WARNING] Please Set Approved Trial Numbers")
+        for key in range(len(list(CONFIG_SCHEMA.keys()).remove('name')) - 1 ): # loop through all the keys except the last one
+            assert(self.config.get(list(CONFIG_SCHEMA.keys()).remove('name')[key]) != None)
+        
+        assert(len(config.get('approved_trial_numbers' != 0 )), 'Please set approved_trial_numbers') if self.config['is_trial'] == True
 
     async def connect(self):
         """Connect to Twilio and setup webhooks"""

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -40,7 +40,12 @@ class ConnectorSMS(Connector):
     async def handle_messages(self, request):
         req_data = await request.json()
         try:
-            message = Message(req_data["Body"], req_data["From"], None, self,)
+            message = Message(
+                text=req_data["Body"],
+                user=req_data["From"],
+                user_id=req_data["From"],
+                connector=self,
+            )
             await self.opsdroid.parse(message)
         except Exception as e:
             _LOGGER.error(f"ERROR: {e}")

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -20,12 +20,13 @@ CONFIG_SCHEMA = {
 }
 
 
-class SMSConnector(Connector):
+class ConnectorSMS(Connector):
     """A connector for Twilio-powered SMS"""
 
     def __init__(self, config, opsdroid):
         super().__init__(config, opsdroid=opsdroid)
-        self.name = config["name"]
+        self.name = self.config.get("name", "sms")
+        self.bot_name = config.get("bot-name", "opsdroid")
         self.config = config
 
     async def connect(self):

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -58,7 +58,7 @@ class ConnectorSMS(Connector):
     @register_event(Message)
     async def send_message(self, message):
         if (
-            self.config["isTrial"]
+            self.config["is_trial"]
             and message.user not in self.config["allowed_trial_users"]
         ):
             _LOGGER.error(

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -4,6 +4,7 @@
 # Opsdroid Imports
 from opsdroid.connector import Connector, register_event
 from opsdroid.events import Message
+from voluptuous import Required
 import logging
 
 # Twilio Imports
@@ -12,11 +13,9 @@ from twilio.rest import Client
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = {
     "name": str,
-    "account_sid": str,
-    "auth_token": str,
-    "phone_number": str,
-    "host": str,
-    "port": int,
+    Required("account_sid"): str,
+    Required("auth_token"): str,
+    Required("phone_number"): str,
 }
 
 

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -48,7 +48,7 @@ class ConnectorSMS(Connector):
         )
 
     async def handle_messages(self, request):
-        req_data = await request.json()
+        req_data = await request.post()
         message = Message(
             text=req_data["Body"],
             user=req_data["From"],

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -43,7 +43,7 @@ class ConnectorSMS(Connector):
             self.config["account_sid"],
             self.config["auth_token"]
         )
-        self.opsdroid.web_server.web_app.router.add_get(
+        self.opsdroid.web_server.web_app.router.add_post(
             f"/connector/{self.name}", self.handle_messages
         )
 

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -37,7 +37,7 @@ class ConnectorSMS(Connector):
 
     async def connect(self):
         """Connect to Twilio and setup webhooks"""
-        self.connection = await Client(
+        self.connection = Client(
             self.config["account_sid"], self.config["auth_token"]
         )
         self.opsdroid.web_server.web_app.router.add_get(
@@ -46,16 +46,13 @@ class ConnectorSMS(Connector):
 
     async def handle_messages(self, request):
         req_data = await request.json()
-        try:
-            message = Message(
-                text=req_data["Body"],
-                user=req_data["From"],
-                user_id=req_data["From"],
-                connector=self,
-            )
-            await self.opsdroid.parse(message)
-        except Exception as e:
-            _LOGGER.error(f"ERROR: {e}")
+        message = Message(
+            text=req_data["Body"],
+            user=req_data["From"],
+            user_id=req_data["From"],
+            connector=self,
+        )
+        await self.opsdroid.parse(message)
 
     @register_event(Message)
     async def send_message(self, message):

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -5,8 +5,8 @@ import logging
 from twilio.rest import Client
 from voluptuous import Required
 
-from . import Connector, register_event
-from ..events import Message
+from .. import Connector, register_event
+from ...events import Message
 
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = {

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -69,7 +69,7 @@ class ConnectorSMS(Connector):
         else:
             await asyncio.get_running_loop().run_in_executor(
                 self.connection.messages.create,
-                from_=self.config["number"],
+                from_=self.config["phone_number"],
                 to=message.user,
                 body=message.text
             )

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -19,6 +19,10 @@ CONFIG_SCHEMA = {
 }
 
 
+class SMSConnectorException(Exception):
+    ...
+
+
 class ConnectorSMS(Connector):
     """A connector for SMS."""
 
@@ -28,10 +32,8 @@ class ConnectorSMS(Connector):
         self.bot_name = config.get("bot-name", "opsdroid")
         self.config = config
 
-        for key in range(len(list(CONFIG_SCHEMA.keys()).remove('name')) - 1 ): # loop through all the keys except the last one
-            assert(self.config.get(list(CONFIG_SCHEMA.keys()).remove('name')[key]) != None)
-        
-        assert(len(config.get('approved_trial_numbers' != 0 )), 'Please set approved_trial_numbers') if self.config['is_trial'] == True
+        if self.config['is_trial'] and not config.get('approved_trial_numbers'):
+            raise SMSConnectorException('Please set approved_trial_numbers')
 
     async def connect(self):
         """Connect to Twilio and setup webhooks"""

--- a/opsdroid/connector/sms/__init__.py
+++ b/opsdroid/connector/sms/__init__.py
@@ -1,8 +1,11 @@
 '''A SMS connector for opsdroid'''
+import aiohttp.web
 import asyncio
+import functools
 import logging
 
 from twilio.rest import Client
+from twilio.request_validator import RequestValidator
 from voluptuous import Required
 
 from .. import Connector, register_event
@@ -35,6 +38,8 @@ class ConnectorSMS(Connector):
         if self.config['is_trial'] and not config.get('approved_trial_numbers'):
             raise SMSConnectorException('Please set approved_trial_numbers')
 
+        self.validator = RequestValidator(config.get('auth_token'))
+
     async def connect(self):
         """Connect to Twilio and setup webhooks"""
         self.connection = await asyncio.get_running_loop().run_in_executor(
@@ -43,16 +48,29 @@ class ConnectorSMS(Connector):
             self.config["account_sid"],
             self.config["auth_token"]
         )
+        # This route must be configured manually in the Twilio web GUI.
+        # There is no API for configuring it.
+        # Watch this SO post for any developments.
+        # Last updated by Twilio as of August 2019.
+        # https://stackoverflow.com/a/57420558/1221924
         self.opsdroid.web_server.web_app.router.add_post(
             f"/connector/{self.name}", self.handle_messages
         )
 
     async def handle_messages(self, request):
-        req_data = await request.post()
+        # Validate the request using its URL, POST data,
+        # and X-TWILIO-SIGNATURE header
+        data = await request.post()
+        request_valid = self.validator.validate(
+            str(request.url),
+            data,
+            request.headers.get('X-TWILIO-SIGNATURE', ''))
+        if not request_valid:
+            raise aiohttp.web.HTTPForbidden()
         message = Message(
-            text=req_data["Body"],
-            user=req_data["From"],
-            user_id=req_data["From"],
+            text=data["Body"],
+            user=data["From"],
+            user_id=data["From"],
             connector=self,
         )
         await self.opsdroid.parse(message)
@@ -68,10 +86,15 @@ class ConnectorSMS(Connector):
             )
         else:
             await asyncio.get_running_loop().run_in_executor(
-                self.connection.messages.create,
-                from_=self.config["phone_number"],
-                to=message.user,
-                body=message.text
+                None,
+                # run_in_executor only accepts positional arguments, so
+                # partial is used here to pass in kwargs.
+                functools.partial(
+                    self.connection.messages.create,
+                    from_=self.config["phone_number"],
+                    to=message.user,
+                    body=message.text
+                )
             )
 
     async def listen(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pyyaml==5.3.1
 setuptools==46.2.0
 slackclient==2.6.2
 tailer==0.4.1
-twilio==6.39.0
+twilio==6.50.1
 ibm-watson==4.4.1
 websockets==8.1
 webexteamssdk==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pyyaml==5.3.1
 setuptools==46.2.0
 slackclient==2.6.2
 tailer==0.4.1
+twilio==6.39.0
 ibm-watson==4.4.1
 websockets==8.1
 webexteamssdk==1.3

--- a/tests/test_connector_sms.py
+++ b/tests/test_connector_sms.py
@@ -1,4 +1,3 @@
-# Based on the Facebook tests
 import unittest
 import asyncio
 
@@ -11,7 +10,7 @@ from opsdroid.cli.start import configure_lang
 
 
 class TestConnectorSMS(unittest.TestCase):
-    """Test the opsdroid Facebook connector class."""
+    """Test the opsdroid SMS connector class."""
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
@@ -19,7 +18,6 @@ class TestConnectorSMS(unittest.TestCase):
     def test_init(self):
         opsdroid = amock.CoroutineMock()
         connector = ConnectorSMS({}, opsdroid=opsdroid)
-        self.assertEqual(None, connector.default_target)
         self.assertEqual("sms", connector.name)
 
     def test_property(self):

--- a/tests/test_connector_sms.py
+++ b/tests/test_connector_sms.py
@@ -1,0 +1,68 @@
+# Based on the Facebook tests
+import unittest
+import asyncio
+
+import asynctest
+import asynctest.mock as amock
+
+from opsdroid.core import OpsDroid
+from opsdroid.connector.sms import ConnectorSMS
+from opsdroid.cli.start import configure_lang
+
+
+class TestConnectorSMS(unittest.TestCase):
+    """Test the opsdroid Facebook connector class."""
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+
+    def test_init(self):
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorSMS({}, opsdroid=opsdroid)
+        self.assertEqual(None, connector.default_target)
+        self.assertEqual("sms", connector.name)
+
+    def test_property(self):
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorSMS({}, opsdroid=opsdroid)
+        self.assertEqual("sms", connector.name)
+
+
+class TestConnectorSMSAsync(asynctest.TestCase):
+    """Test the async methods of the opsdroid SMS connector class."""
+
+    async def setUp(self):
+        configure_lang({})
+
+    async def test_connect(self):
+        """Test the connect method adds the handlers."""
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorSMS({}, opsdroid=opsdroid)
+        opsdroid.web_server = amock.CoroutineMock()
+        opsdroid.web_server.web_app = amock.CoroutineMock()
+        opsdroid.web_server.web_app.router = amock.CoroutineMock()
+        opsdroid.web_server.web_app.router.add_get = amock.CoroutineMock()
+
+        await connector.connect()
+
+        self.assertTrue(opsdroid.web_server.web_app.router.add_get.called)
+
+    async def test_message_handler(self):
+        """Test the message handler."""
+
+        opsdroid = amock.CoroutineMock()
+        connector = ConnectorSMS({}, opsdroid=opsdroid)
+        req_ob = {
+            "From": "555-555-5555",
+            "Body": "Join Earth's Mightiests Heros. Like Kevin Bacon",
+        }
+        mock_request = amock.CoroutineMock()
+        mock_request.json = amock.CoroutineMock()
+        mock_request.json.return_value = req_ob
+
+        with OpsDroid() as opsdroid:
+            connector.opsdroid = opsdroid
+            connector.opsdroid.parse = amock.CoroutineMock()
+
+            await connector.handle_messages(mock_request)
+            self.assertTrue(connector.opsdroid.parse.called)


### PR DESCRIPTION
# Description

Closes #1490 
Supersedes #1488 

This builds on @Gideon357's commits in #1488 with the following changes:

* Addressed @jacobtomlinson's review comments left on the original PR.
* Confirmed that there is no programmatic API for configuring the webhook route in Twilio, left a comment with a link.
* Fixed some things to get it working.
* Moved all synchronous calls into an executor. The Twilio Python API does not support async, per [this official post](https://www.twilio.com/blog/twilio-python-helper-library-async), and recommends several approaches. This is the most straightfoward one, IMO.
* Implemented security, such that requests not correctly signed by Twilio are rejected with `HTTP 403`.

This works for me interactively. I have branched `v0.19.0` for now just to avoid getting confused by changes since. Additional work may be need to make it work on `master`. Any hints about how best practices have evolved since `v0.19.0` would be welcome. :- )

TO DO:

- [ ] Rebase on `master` and make any necessary changes
- [ ] Revisit docs
- [ ] More tests

## Status
READY | **UNDER DEVELOPMENT** | ON HOLD


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


# How Has This Been Tested?

Needs tests

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
