### PR TITLE
Use pytest marks to add responses to the mock_api fixture

### DIFF
--- a/opsdroid/conftest.py
+++ b/opsdroid/conftest.py
@@ -1,47 +1,7 @@
 """Pytest config for all opsdroid tests."""
-import pytest
-
-import asyncio
-import contextlib
-import socket
-
-from opsdroid.testing import opsdroid, mock_api  # noqa
-from opsdroid.connector import Connector
+# All global fixtures should be defined in the fixtures file
+from opsdroid.testing.fixtures import *  # noqa
 
 from opsdroid.cli.start import configure_lang
 
-__all__ = ["opsdroid"]
-
 configure_lang({})
-
-
-@pytest.fixture(scope="session")
-def get_connector():
-    def _get_connector(config={}):
-        return Connector(config, opsdroid=opsdroid)
-
-    return _get_connector
-
-
-@pytest.yield_fixture
-def event_loop():
-    """Create an instance of the default event loop for each test case."""
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
-
-
-@pytest.fixture
-def bound_address(request):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    with contextlib.suppress(socket.error):
-        if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):  # only on windows
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
-        if hasattr(socket, "SO_REUSEPORT"):  # not on windows
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 0)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
-
-    host = request.param if hasattr(request, "param") else "0.0.0.0"
-    s.bind((host, 0))  # an ephemeral port
-    yield s.getsockname()
-    s.close()

--- a/opsdroid/conftest.py
+++ b/opsdroid/conftest.py
@@ -1,5 +1,9 @@
-"""Pytest config for all opsdroid tests."""
-# All global fixtures should be defined in the fixtures file
+"""Pytest config for all opsdroid tests.
+
+This file includes definitions for any private (opsdroid-use-only) fixtures.
+All public fixtures should be defined in ``opsdroid.testing.fixtures``
+so that sub-projects can reuse them.
+"""
 from opsdroid.testing.fixtures import *  # noqa
 
 from opsdroid.cli.start import configure_lang

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -11,9 +11,9 @@ from opsdroid.testing import call_endpoint, running_opsdroid
 
 
 @pytest.fixture
-async def connector(opsdroid, mock_api):
+async def connector(opsdroid, mock_api_obj):
     opsdroid.config["connectors"] = {
-        "github": {"token": "abc123", "api_base_url": mock_api.base_url}
+        "github": {"token": "abc123", "api_base_url": mock_api_obj.base_url}
     }
     await opsdroid.load()
     return opsdroid.get_connector("github")
@@ -68,13 +68,11 @@ async def test_connect_failure(connector, mock_api, caplog):
     assert "Bad credentials" in caplog.text
 
 
-@pytest.mark.add_response("/", "GET")
 @pytest.mark.asyncio
 async def test_disconnect(connector):
     assert await connector.disconnect() is None
 
 
-@pytest.mark.add_response("/", "GET")
 @pytest.mark.asyncio
 async def test_listen(connector):
     """Test the listen method.

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -1,8 +1,7 @@
 """Tests for the GitHub class."""
 import pytest
 from asynctest.mock import CoroutineMock
-
-import os.path
+from pathlib import Path
 
 
 from opsdroid.connector.github import ConnectorGitHub
@@ -21,7 +20,7 @@ async def connector(opsdroid, mock_api):
 
 
 def get_response_path(response):
-    return os.path.join(os.path.dirname(__file__), "responses", response)
+    return Path(__file__).parent / "responses" / response
 
 
 def get_webhook_payload(path):

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -42,49 +42,40 @@ def test_missing_token(caplog):
     assert "Missing auth token!" in caplog.text
 
 
+@pytest.mark.add_response(
+    "/user", "GET", get_response_path("github_user.json"), status=200
+)
 @pytest.mark.asyncio
 async def test_connect(connector, mock_api):
-    mock_api.add_response(
-        "/user", "GET", get_response_path("github_user.json"), status=200
-    )
+    await connector.connect()
 
-    async def test():
-        await connector.connect()
+    assert mock_api.called("/user")
+    assert mock_api.call_count("/user") == 1
 
-        assert mock_api.called("/user")
-        assert mock_api.call_count("/user") == 1
+    request = mock_api.get_request("/user")
+    assert "Authorization" in request.headers
+    assert "abc123" in request.headers["Authorization"]
 
-        request = mock_api.get_request("/user")
-        assert "Authorization" in request.headers
-        assert "abc123" in request.headers["Authorization"]
-
-        # Populated by the call to /user
-        assert connector.github_username == "opsdroid"
-
-    await mock_api.run_test(test)
+    # Populated by the call to /user
+    assert connector.github_username == "opsdroid"
 
 
+@pytest.mark.add_response(
+    "/user", "GET", get_response_path("github_user_bad_credentials.json"), status=401
+)
 @pytest.mark.asyncio
 async def test_connect_failure(connector, mock_api, caplog):
-    mock_api.add_response(
-        "/user",
-        "GET",
-        get_response_path("github_user_bad_credentials.json"),
-        status=401,
-    )
-
-    async def test():
-        await connector.connect()
-        assert "Bad credentials" in caplog.text
-
-    await mock_api.run_test(test)
+    await connector.connect()
+    assert "Bad credentials" in caplog.text
 
 
+@pytest.mark.add_response("/", "GET")
 @pytest.mark.asyncio
 async def test_disconnect(connector):
     assert await connector.disconnect() is None
 
 
+@pytest.mark.add_response("/", "GET")
 @pytest.mark.asyncio
 async def test_listen(connector):
     """Test the listen method.
@@ -97,76 +88,69 @@ async def test_listen(connector):
     assert await connector.listen() is None
 
 
+@pytest.mark.add_response(
+    "/repos/opsdroid/opsdroid/issues/1/comments", "POST", None, status=201
+)
 @pytest.mark.asyncio
 async def test_send(opsdroid, connector, mock_api):
     org, repo, issue = "opsdroid", "opsdroid", "1"
-    api_url = f"/repos/{org}/{repo}/issues/{issue}/comments"
-    mock_api.add_response(api_url, "POST", None, status=201)
-
-    async def test():
-        await opsdroid.send(
-            Message(
-                text="test",
-                user="jacobtomlinson",
-                target=f"{org}/{repo}#{issue}",
-                connector=connector,
-            )
+    await opsdroid.send(
+        Message(
+            text="test",
+            user="jacobtomlinson",
+            target=f"{org}/{repo}#{issue}",
+            connector=connector,
         )
-        assert mock_api.called(api_url)
+    )
+    assert mock_api.called("/repos/opsdroid/opsdroid/issues/1/comments")
 
-    await mock_api.run_test(test)
 
-
+@pytest.mark.add_response(
+    "/repos/opsdroid/opsdroid/issues/1/comments",
+    "POST",
+    get_response_path("github_send_failure.json"),
+    status=400,
+)
 @pytest.mark.asyncio
 async def test_send_failure(opsdroid, connector, mock_api, caplog):
     org, repo, issue = "opsdroid", "opsdroid", "1"
-    api_url = f"/repos/{org}/{repo}/issues/{issue}/comments"
-    mock_api.add_response(
-        api_url, "POST", get_response_path("github_send_failure.json"), status=400
-    )
-
-    async def test():
-        await opsdroid.send(
-            Message(
-                text="test",
-                user="jacobtomlinson",
-                target=f"{org}/{repo}#{issue}",
-                connector=connector,
-            )
+    await opsdroid.send(
+        Message(
+            text="test",
+            user="jacobtomlinson",
+            target=f"{org}/{repo}#{issue}",
+            connector=connector,
         )
-        assert mock_api.called(api_url)
-        assert "some error" in caplog.text
+    )
+    assert mock_api.called("/repos/opsdroid/opsdroid/issues/1/comments")
+    assert "some error" in caplog.text
 
-    await mock_api.run_test(test)
 
-
+@pytest.mark.add_response(
+    "/repos/opsdroid/opsdroid/issues/1/comments", "POST", status=201
+)
 @pytest.mark.asyncio
 async def test_do_not_send_to_self(opsdroid, connector, mock_api):
     org, repo, issue = "opsdroid", "opsdroid", "1"
-    api_url = f"/repos/{org}/{repo}/issues/{issue}/comments"
-    mock_api.add_response(api_url, "POST", None, status=201)
     connector.github_username = "opsdroid-bot"
 
-    async def test():
-        await opsdroid.send(
-            Message(
-                text="test",
-                user="opsdroid-bot",
-                target=f"{org}/{repo}#{issue}",
-                connector=connector,
-            )
+    await opsdroid.send(
+        Message(
+            text="test",
+            user="opsdroid-bot",
+            target=f"{org}/{repo}#{issue}",
+            connector=connector,
         )
-        assert not mock_api.called(api_url)
+    )
+    assert not mock_api.called("/repos/opsdroid/opsdroid/issues/1/comments")
 
-    await mock_api.run_test(test)
 
-
+@pytest.mark.add_response(
+    "/user", "GET", get_response_path("github_user.json"), status=200
+)
 @pytest.mark.asyncio
 async def test_receive_comment(opsdroid, connector, mock_api):
     """Test a comment create event creates a message and parses it."""
-    mock_api.add_response(
-        "/user", "GET", get_response_path("github_user.json"), status=200
-    )
 
     @match_event(Message)
     async def test_skill(opsdroid, config, event):
@@ -185,15 +169,15 @@ async def test_receive_comment(opsdroid, connector, mock_api):
         )
         assert resp.status == 201
 
-    await mock_api.run_test(run_unit_test, opsdroid, test)
+    await run_unit_test(opsdroid, test)
 
 
+@pytest.mark.add_response(
+    "/user", "GET", get_response_path("github_user.json"), status=200
+)
 @pytest.mark.asyncio
 async def test_receive_pr(opsdroid, connector, mock_api):
     """Test a PR create event creates a message and parses it."""
-    mock_api.add_response(
-        "/user", "GET", get_response_path("github_user.json"), status=200
-    )
 
     @match_event(Message)
     async def test_skill(opsdroid, config, event):
@@ -212,15 +196,15 @@ async def test_receive_pr(opsdroid, connector, mock_api):
         )
         assert resp.status == 201
 
-    await mock_api.run_test(run_unit_test, opsdroid, test)
+    await run_unit_test(opsdroid, test)
 
 
+@pytest.mark.add_response(
+    "/user", "GET", get_response_path("github_user.json"), status=200
+)
 @pytest.mark.asyncio
 async def test_receive_issue(opsdroid, connector, mock_api):
     """Test a PR create event creates a message and parses it."""
-    mock_api.add_response(
-        "/user", "GET", get_response_path("github_user.json"), status=200
-    )
 
     @match_event(Message)
     async def test_skill(opsdroid, config, event):
@@ -239,15 +223,15 @@ async def test_receive_issue(opsdroid, connector, mock_api):
         )
         assert resp.status == 201
 
-    await mock_api.run_test(run_unit_test, opsdroid, test)
+    await run_unit_test(opsdroid, test)
 
 
+@pytest.mark.add_response(
+    "/user", "GET", get_response_path("github_user.json"), status=200
+)
 @pytest.mark.asyncio
 async def test_receive_label(opsdroid, connector, mock_api):
     """Test a PR create event creates a message and parses it."""
-    mock_api.add_response(
-        "/user", "GET", get_response_path("github_user.json"), status=200
-    )
 
     test_skill = match_event(Message)(CoroutineMock())
     opsdroid.register_skill(test_skill, config={"name": "test"})
@@ -261,16 +245,16 @@ async def test_receive_label(opsdroid, connector, mock_api):
         )
         assert resp.status == 200
 
-    await mock_api.run_test(run_unit_test, opsdroid, test)
+    await run_unit_test(opsdroid, test)
     assert not test_skill.called
 
 
+@pytest.mark.add_response(
+    "/user", "GET", get_response_path("github_user.json"), status=200
+)
 @pytest.mark.asyncio
 async def test_receive_status(opsdroid, connector, mock_api):
     """Test a PR create event creates a message and parses it."""
-    mock_api.add_response(
-        "/user", "GET", get_response_path("github_user.json"), status=200
-    )
 
     test_skill = match_event(Message)(CoroutineMock())
     opsdroid.register_skill(test_skill, config={"name": "test"})
@@ -284,5 +268,5 @@ async def test_receive_status(opsdroid, connector, mock_api):
         )
         assert resp.status == 201
 
-    await mock_api.run_test(run_unit_test, opsdroid, test)
+    await run_unit_test(opsdroid, test)
     assert not test_skill.called

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from opsdroid.connector.github import ConnectorGitHub
 from opsdroid.events import Message
 from opsdroid.matchers import match_event
-from opsdroid.testing import call_endpoint, run_unit_test
+from opsdroid.testing import call_endpoint, running_opsdroid
 
 
 @pytest.fixture
@@ -159,7 +159,7 @@ async def test_receive_comment(opsdroid, connector, mock_api):
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
-    async def test():
+    async with running_opsdroid(opsdroid):
         resp = await call_endpoint(
             opsdroid,
             "/connector/github",
@@ -167,8 +167,6 @@ async def test_receive_comment(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_comment_payload.json"),
         )
         assert resp.status == 201
-
-    await run_unit_test(opsdroid, test)
 
 
 @pytest.mark.add_response(
@@ -186,7 +184,7 @@ async def test_receive_pr(opsdroid, connector, mock_api):
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
-    async def test():
+    async with running_opsdroid(opsdroid):
         resp = await call_endpoint(
             opsdroid,
             "/connector/github",
@@ -194,8 +192,6 @@ async def test_receive_pr(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_pr_payload.json"),
         )
         assert resp.status == 201
-
-    await run_unit_test(opsdroid, test)
 
 
 @pytest.mark.add_response(
@@ -213,7 +209,7 @@ async def test_receive_issue(opsdroid, connector, mock_api):
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
-    async def test():
+    async with running_opsdroid(opsdroid):
         resp = await call_endpoint(
             opsdroid,
             "/connector/github",
@@ -221,8 +217,6 @@ async def test_receive_issue(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_issue_payload.json"),
         )
         assert resp.status == 201
-
-    await run_unit_test(opsdroid, test)
 
 
 @pytest.mark.add_response(
@@ -235,7 +229,7 @@ async def test_receive_label(opsdroid, connector, mock_api):
     test_skill = match_event(Message)(CoroutineMock())
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
-    async def test():
+    async with running_opsdroid(opsdroid):
         resp = await call_endpoint(
             opsdroid,
             "/connector/github",
@@ -244,7 +238,6 @@ async def test_receive_label(opsdroid, connector, mock_api):
         )
         assert resp.status == 200
 
-    await run_unit_test(opsdroid, test)
     assert not test_skill.called
 
 
@@ -258,7 +251,7 @@ async def test_receive_status(opsdroid, connector, mock_api):
     test_skill = match_event(Message)(CoroutineMock())
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
-    async def test():
+    async with running_opsdroid(opsdroid):
         resp = await call_endpoint(
             opsdroid,
             "/connector/github",
@@ -267,5 +260,4 @@ async def test_receive_status(opsdroid, connector, mock_api):
         )
         assert resp.status == 201
 
-    await run_unit_test(opsdroid, test)
     assert not test_skill.called

--- a/opsdroid/testing/__init__.py
+++ b/opsdroid/testing/__init__.py
@@ -3,4 +3,4 @@
 from .fixtures import *  # noqa
 from .external_api import ExternalAPIMockServer  # noqa
 from .const import *  # noqa
-from .utils import run_unit_test, call_endpoint  # noqa
+from .utils import run_unit_test, call_endpoint, running_opsdroid  # noqa

--- a/opsdroid/testing/external_api.py
+++ b/opsdroid/testing/external_api.py
@@ -4,12 +4,12 @@ Testing helpers for opsdroid.
 opsdroid provides a set of pytest fixtures and other helpers for writing tests
 for both opsdroid core and skills.
 """
-
 import asyncio
-from aiohttp import web
 import json
-from typing import Any, Awaitable, List, Dict
+from os import PathLike
+from typing import Any, Awaitable, Dict, List, Union
 
+from aiohttp import web
 from opsdroid.helper import Timeout
 
 
@@ -125,16 +125,19 @@ class ExternalAPIMockServer:
         self,
         route: str,
         method: str,
-        response_path: str = None,
-        response_data: dict = None,
+        response: Union[dict, PathLike] = None,
         status: int = 200,
     ) -> None:
         """Push a mocked response onto a route."""
-        if response_path is not None:
-            with open(response_path) as json_file:
+        if isinstance(response, PathLike):
+            with open(response) as json_file:
                 response = json.load(json_file)
+        elif response is None or isinstance(response, dict):
+            response = response
         else:
-            response = response_data
+            raise ValueError(
+                "response should be either a path like object or a dictionary."
+            )
 
         if route in self.responses:
             self.responses[route].append((status, response))

--- a/opsdroid/testing/external_api.py
+++ b/opsdroid/testing/external_api.py
@@ -125,19 +125,15 @@ class ExternalAPIMockServer:
         self,
         route: str,
         method: str,
-        response: Union[dict, PathLike] = None,
+        response: Union[Any, PathLike] = None,
         status: int = 200,
     ) -> None:
         """Push a mocked response onto a route."""
         if isinstance(response, PathLike):
             with open(response) as json_file:
                 response = json.load(json_file)
-        elif response is None or isinstance(response, dict):
-            response = response
         else:
-            raise ValueError(
-                "response should be either a path like object or a dictionary."
-            )
+            response = response
 
         if route in self.responses:
             self.responses[route].append((status, response))

--- a/opsdroid/testing/external_api.py
+++ b/opsdroid/testing/external_api.py
@@ -122,14 +122,19 @@ class ExternalAPIMockServer:
         return f"http://{self.host}:{self.port}"
 
     def add_response(
-        self, route: str, method: str, response_path: str, status: int = 200
+        self,
+        route: str,
+        method: str,
+        response_path: str = None,
+        response_data: dict = None,
+        status: int = 200,
     ) -> None:
         """Push a mocked response onto a route."""
         if response_path is not None:
             with open(response_path) as json_file:
                 response = json.load(json_file)
         else:
-            response = None
+            response = response_data
 
         if route in self.responses:
             self.responses[route].append((status, response))

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -113,9 +113,9 @@ async def mock_api(request, mock_api_obj) -> ExternalAPIMockServer:
 
     """
     mock_api = mock_api_obj
-    markers = list(
-        filter(lambda marker: marker.name == "add_response", request.node.own_markers)
-    )
+    markers = [
+        marker for marker in request.node.own_markers if marker.name == "add_response"
+    ]
 
     for marker in markers:
         mock_api.add_response(*marker.args, **marker.kwargs)

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -13,10 +13,10 @@ __all__ = ["mock_api_obj", "bound_address", "get_connector", "opsdroid", "mock_a
 
 
 @pytest.fixture(scope="session")
-def get_connector(opsdroid):
+def get_connector():
     """Pytest fixture which is a factory to generate a connector."""
 
-    def _get_connector(config={}):
+    def _get_connector(config={}, opsdroid=None):
         return Connector(config, opsdroid=opsdroid)
 
     return _get_connector

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -13,8 +13,8 @@ __all__ = ["bound_address", "get_connector", "opsdroid", "mock_api"]
 
 
 @pytest.fixture(scope="session")
-def get_connector():
-    """Factory fixture to get a connector instance."""
+def get_connector(opsdroid):
+    """Pytest fixture which is a factory to generate a connector."""
 
     def _get_connector(config={}):
         return Connector(config, opsdroid=opsdroid)

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -1,4 +1,7 @@
-"""Core fixtures for testing opsdroid and skills."""
+"""Core fixtures for testing opsdroid and skills.
+
+These are not in conftest.py so that they can be imported in sub-projects.
+"""
 import contextlib
 import socket
 

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -14,6 +14,8 @@ __all__ = ["bound_address", "get_connector", "opsdroid", "mock_api"]
 
 @pytest.fixture(scope="session")
 def get_connector():
+    """Factory fixture to get a connector instance."""
+
     def _get_connector(config={}):
         return Connector(config, opsdroid=opsdroid)
 
@@ -22,6 +24,7 @@ def get_connector():
 
 @pytest.fixture
 def bound_address(request):
+    """I have no idea what this does but must have a docstring."""
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     with contextlib.suppress(socket.error):
         if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):  # only on windows

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -77,8 +77,9 @@ def opsdroid() -> OpsDroid:
 
 @pytest.fixture
 def mock_api_obj():
-    """
-    Returns a non-running instance of :class:`opsdroid.testing.ExternalAPIMockServer`.
+    """Initialize instance of :class:`opsdroid.testing.ExternalAPIMockServer`.
+
+    Any tests or fixtures that use this need to handle running _start() and _stop().
     """
     return ExternalAPIMockServer()
 
@@ -120,6 +121,8 @@ async def mock_api(request, mock_api_obj) -> ExternalAPIMockServer:
     for marker in markers:
         mock_api.add_response(*marker.args, **marker.kwargs)
 
+    # noinspection PyProtectedMember
     await mock_api._start()
     yield mock_api
+    # noinspection PyProtectedMember
     await mock_api._stop()

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -79,15 +79,36 @@ def opsdroid() -> OpsDroid:
 def mock_api_obj():
     """Initialize instance of :class:`opsdroid.testing.ExternalAPIMockServer`.
 
-    Any tests or fixtures that use this need to handle running _start() and _stop().
+    This fixture returns an instance that hasn't been started, allowing you to
+    add routes to the server before it is started.
+    There are a few options of how to start the server once this fixture has
+    been used:
+
+        * Use `:meth:opsdroid.testing.ExternalAPIMockServer.run_test`
+        * Use the ``mock_api`` fixture in the test *after* this fixture has
+          been called to setup a route.
+        * Manually start and stop the server.
+
+    An example of the second method is to define a fixture which adds a
+    response, and then use the ``mock_api`` fixture in the test to start the
+    server::
+
+        @pytest.fixture
+        def canned_response(mock_api_obj):
+            mock_api_obj.add_response("/test", "GET")
+
+        # Note here mock_api MUST come after canned_response for the route to
+        # be added before the server is started.
+        def test_my_endpoint(canned_response, mock_api):
+            ...
+
     """
     return ExternalAPIMockServer()
 
 
 @pytest.fixture
 async def mock_api(request, mock_api_obj) -> ExternalAPIMockServer:
-    """
-    Fixture for mocking API calls to a web service.
+    """Fixture for mocking API calls to a web service.
 
     Will yield a running instance of
     :class:`opsdroid.testing.ExternalAPIMockServer`, which has been configured

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -19,10 +19,45 @@ def opsdroid() -> OpsDroid:
 
 
 @pytest.fixture
-async def mock_api() -> ExternalAPIMockServer:
-    """Fixture for making a mock API server.
+async def mock_api(request) -> ExternalAPIMockServer:
+    """
+    Fixture for mocking API calls to a web service.
 
-    Will give an instance of :class:`opsdroid.testing.ExternalAPIMockServer`.
+    Will give an instance of :class:`opsdroid.testing.ExternalAPIMockServer`,
+    which has been configured with any routes specified through
+    ``@pytest.mark.add_response()`` decorators.
+
+    All arguments and keyword arguments passed to ``pytest.mark.add_response``
+    are passed through to `.ExternalAPIMockServer.add_response`.
+
+    An example test would look like::
+
+        @pytest.mark.add_response("/test", "GET")
+        @pytest.mark.add_response("/test2", "GET", status=500)
+        @pytest.mark.asyncio
+        async def test_hello(mock_api):
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{mock_api.base_url}/test") as resp:
+                    assert resp.status == 200
+                    assert mock_api.called("/test")
+
+                async with session.get(f"{mock_api.base_url}/test2") as resp:
+                    assert resp.status == 500
+                    assert mock_api.called("/test2")
 
     """
-    return ExternalAPIMockServer()
+    mock_api = ExternalAPIMockServer()
+    markers = list(
+        filter(lambda marker: marker.name == "add_response", request.node.own_markers)
+    )
+    if not markers:
+        raise ValueError(
+            "Tests using the mock_api fixture must provide request info with at least one @pytest.mark.add_response"
+        )
+
+    for marker in markers:
+        mock_api.add_response(*marker.args, **marker.kwargs)
+
+    await mock_api._start()
+    yield mock_api
+    await mock_api._stop()

--- a/opsdroid/testing/tests/test_testing.py
+++ b/opsdroid/testing/tests/test_testing.py
@@ -149,12 +149,11 @@ async def test_mock_skill_and_connector(opsdroid):
 @pytest.mark.add_response("/test", "GET")
 @pytest.mark.add_response("/test2", "GET", status=500)
 @pytest.mark.asyncio
-async def test_mock_api_with_pytest_marks(mock_api):
-    async with aiohttp.ClientSession() as session:
-        async with session.get(f"{mock_api.base_url}/test") as resp:
-            assert resp.status == 200
-            assert mock_api.called("/test")
+async def test_mock_api_with_pytest_marks(mock_api, session):
+    async with session.get(f"{mock_api.base_url}/test") as resp:
+        assert resp.status == 200
+        assert mock_api.called("/test")
 
-        async with session.get(f"{mock_api.base_url}/test2") as resp:
-            assert resp.status == 500
-            assert mock_api.called("/test2")
+    async with session.get(f"{mock_api.base_url}/test2") as resp:
+        assert resp.status == 500
+        assert mock_api.called("/test2")

--- a/opsdroid/testing/tests/test_testing.py
+++ b/opsdroid/testing/tests/test_testing.py
@@ -11,6 +11,7 @@ from opsdroid.testing import (
     ExternalAPIMockServer,
     call_endpoint,
     run_unit_test,
+    running_opsdroid,
 )
 
 
@@ -118,7 +119,19 @@ async def test_run_unit_test(opsdroid):
     async def test():
         assert opsdroid.is_running()
 
+    assert not opsdroid.is_running()
+
     await run_unit_test(opsdroid, test)
+
+
+@pytest.mark.asyncio
+async def test_with_running_opsdroid(opsdroid):
+    await opsdroid.load(config=MINIMAL_CONFIG)
+
+    assert not opsdroid.is_running()
+
+    async with running_opsdroid(opsdroid):
+        assert opsdroid.is_running()
 
 
 @pytest.mark.asyncio

--- a/opsdroid/testing/tests/test_testing.py
+++ b/opsdroid/testing/tests/test_testing.py
@@ -131,3 +131,17 @@ async def test_mock_skill_and_connector(opsdroid):
         assert skill.called
 
     await run_unit_test(opsdroid, test)
+
+
+@pytest.mark.add_response("/test", "GET")
+@pytest.mark.add_response("/test2", "GET", status=500)
+@pytest.mark.asyncio
+async def test_mock_api_with_pytest_marks(mock_api):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{mock_api.base_url}/test") as resp:
+            assert resp.status == 200
+            assert mock_api.called("/test")
+
+        async with session.get(f"{mock_api.base_url}/test2") as resp:
+            assert resp.status == 500
+            assert mock_api.called("/test2")

--- a/opsdroid/testing/utils.py
+++ b/opsdroid/testing/utils.py
@@ -1,13 +1,34 @@
 """Utilities for testing opsdroid."""
 
 import asyncio
-import aiohttp
-from aiohttp import web
 import json
 import time
-from typing import Any, Awaitable, List, Dict
+from typing import Any, Awaitable, Dict, List
+from contextlib import asynccontextmanager
 
+import aiohttp
+from aiohttp import web
 from opsdroid.core import OpsDroid
+
+
+@asynccontextmanager
+async def running_opsdroid(opsdroid, start_timeout=1):
+    """Context manager to control when opsdroid is running.
+
+    This async context manager will start opsdroid running for its duration.
+    It can be used like this::
+
+        @pytest.mark.asyncio
+        async def test_with_running_opsdroid(opsdroid):
+            async with running_opsdroid(opsdroid):
+                assert opsdroid.is_running()
+    """
+    start = time.time()
+    asyncio.create_task(opsdroid.start())
+    while not opsdroid.is_running() and start + start_timeout > time.time():
+        await asyncio.sleep(0.1)
+    yield
+    await opsdroid.stop()
 
 
 async def run_unit_test(

--- a/opsdroid/testing/utils.py
+++ b/opsdroid/testing/utils.py
@@ -22,6 +22,7 @@ async def running_opsdroid(opsdroid, start_timeout=1):
         async def test_with_running_opsdroid(opsdroid):
             async with running_opsdroid(opsdroid):
                 assert opsdroid.is_running()
+                
     """
     start = time.time()
     asyncio.create_task(opsdroid.start())

--- a/opsdroid/testing/utils.py
+++ b/opsdroid/testing/utils.py
@@ -22,7 +22,7 @@ async def running_opsdroid(opsdroid, start_timeout=1):
         async def test_with_running_opsdroid(opsdroid):
             async with running_opsdroid(opsdroid):
                 assert opsdroid.is_running()
-                
+
     """
     start = time.time()
     asyncio.create_task(opsdroid.start())

--- a/setup.cfg
+++ b/setup.cfg
@@ -141,6 +141,8 @@ testpaths = opsdroid tests
 norecursedirs = .git testing_config
 addopts = -v
 mock_use_standalone_module = true
+markers =
+    add_response: adds a response to the ExternalAPIMockServer
 
 [flake8]
 max-line-length = 80


### PR DESCRIPTION
# Description

This solves the pytest puzzle of how to use `ExternalAPIMockServer` in the most pytest way possible.