### PR TITLE
Fix handle_stop_signal to actually call stop()

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -56,7 +56,7 @@ class OpsDroid:
         if os.name != "nt":
             for sig in (signal.SIGINT, signal.SIGTERM):
                 self.eventloop.add_signal_handler(
-                    sig, lambda: asyncio.ensure_future(self.handle_signal())
+                    sig, lambda: asyncio.ensure_future(self.handle_stop_signal())
                 )
             self.eventloop.add_signal_handler(
                 signal.SIGHUP, lambda: asyncio.ensure_future(self.reload())
@@ -155,9 +155,10 @@ class OpsDroid:
         """Check whether opsdroid is running."""
         return self._running
 
-    async def handle_signal(self):
+    async def handle_stop_signal(self):
         """Handle signals."""
         self._running = False
+        await self.stop()
         await self.unload()
 
     def run(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -221,9 +221,11 @@ class TestCoreAsync(asynctest.TestCase):
         with OpsDroid() as opsdroid:
             opsdroid._running = True
             self.assertTrue(opsdroid.is_running())
+            opsdroid.stop = amock.CoroutineMock()
             opsdroid.unload = amock.CoroutineMock()
             await opsdroid.handle_stop_signal()
             self.assertFalse(opsdroid.is_running())
+            self.assertTrue(opsdroid.stop.called)
             self.assertTrue(opsdroid.unload.called)
 
     async def test_unload_and_stop(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -217,12 +217,12 @@ class TestCoreAsync(asynctest.TestCase):
         mockedskill.config = {}
         return mockedskill
 
-    async def test_handle_signal(self):
+    async def test_handle_stop_signal(self):
         with OpsDroid() as opsdroid:
             opsdroid._running = True
             self.assertTrue(opsdroid.is_running())
             opsdroid.unload = amock.CoroutineMock()
-            await opsdroid.handle_signal()
+            await opsdroid.handle_stop_signal()
             self.assertFalse(opsdroid.is_running())
             self.assertTrue(opsdroid.unload.called)
 


### PR DESCRIPTION
# Description

This was only calling unload() on ctrl-c, but it needs to call stop() first.

Fixes #1704


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Test manually with pycharm debugger hooked up.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
