### PR TITLE
Move most of the magic to the mock_api_obj fixture

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2%

--- a/opsdroid/testing/external_api.py
+++ b/opsdroid/testing/external_api.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 from os import PathLike
 from typing import Any, Awaitable, Dict, List, Union
+from contextlib import asynccontextmanager
 
 from aiohttp import web
 from opsdroid.helper import Timeout
@@ -176,6 +177,13 @@ class ExternalAPIMockServer:
 
         _, run_output = await asyncio.gather(self._start(), _run_test_then_stop())
         return run_output
+
+    @asynccontextmanager
+    async def running_mock_api(self) -> "ExternalAPIMockServer":
+        """Start the External API server within a context manager."""
+        await self._start()
+        yield self
+        await self._stop()
 
     def reset(self) -> None:
         """Reset the mock back to a clean state."""

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -86,9 +86,8 @@ def mock_api_obj(request) -> ExternalAPIMockServer:
 
         * Use the ``mock_api`` fixture in the test *after* this fixture has
           been called to setup a route.
-        * Use :meth:`opsdroid.testing.ExternalAPIMockServer.run_test`
         * Use the
-          :meth:`opsdroid.testing.ExternalAPIMockServer.running_mock_api`
+          :meth:`opsdroid.testing.ExternalAPIMockServer.running`
           context manager.
         * Manually start and stop the server.
 
@@ -149,5 +148,5 @@ async def mock_api(mock_api_obj) -> ExternalAPIMockServer:
                     assert mock_api.called("/test2")
 
     """
-    async with mock_api_obj.running_mock_api() as mock_api:
+    async with mock_api_obj.running() as mock_api:
         yield mock_api

--- a/opsdroid/testing/fixtures.py
+++ b/opsdroid/testing/fixtures.py
@@ -108,15 +108,15 @@ def mock_api_obj(request) -> ExternalAPIMockServer:
     Routes can be specified with ``pytest.mark.add_response`` on tests using
     this fixture, as described in :func:`~opsdroid.testing.fixtures.mock_api`
     """
-    mock_api = ExternalAPIMockServer()
+    mock_api_obj = ExternalAPIMockServer()
     markers = [
         marker for marker in request.node.own_markers if marker.name == "add_response"
     ]
 
     for marker in markers:
-        mock_api.add_response(*marker.args, **marker.kwargs)
+        mock_api_obj.add_response(*marker.args, **marker.kwargs)
 
-    return mock_api
+    return mock_api_obj
 
 
 @pytest.fixture
@@ -149,8 +149,5 @@ async def mock_api(mock_api_obj) -> ExternalAPIMockServer:
                     assert mock_api.called("/test2")
 
     """
-    # noinspection PyProtectedMember
-    await mock_api._start()
-    yield mock_api
-    # noinspection PyProtectedMember
-    await mock_api._stop()
+    async with mock_api_obj.running_mock_api() as mock_api:
+        yield mock_api

--- a/opsdroid/testing/tests/test_testing.py
+++ b/opsdroid/testing/tests/test_testing.py
@@ -168,6 +168,6 @@ async def test_mock_api_obj_with_pytest_marks(mock_api_obj, session):
             assert resp.status == 200
             assert mock_api_obj.called("/test")
 
-            async with session.get(f"{mock_api_obj.base_url}/test2") as resp:
-                assert resp.status == 500
-                assert mock_api_obj.called("/test2")
+        async with session.get(f"{mock_api_obj.base_url}/test2") as resp:
+            assert resp.status == 500
+            assert mock_api_obj.called("/test2")

--- a/opsdroid/testing/tests/test_testing.py
+++ b/opsdroid/testing/tests/test_testing.py
@@ -157,3 +157,17 @@ async def test_mock_api_with_pytest_marks(mock_api, session):
     async with session.get(f"{mock_api.base_url}/test2") as resp:
         assert resp.status == 500
         assert mock_api.called("/test2")
+
+
+@pytest.mark.add_response("/test", "GET")
+@pytest.mark.add_response("/test2", "GET", status=500)
+@pytest.mark.asyncio
+async def test_mock_api_obj_with_pytest_marks(mock_api_obj, session):
+    async with mock_api_obj.running_mock_api():
+        async with session.get(f"{mock_api_obj.base_url}/test") as resp:
+            assert resp.status == 200
+            assert mock_api_obj.called("/test")
+
+            async with session.get(f"{mock_api_obj.base_url}/test2") as resp:
+                assert resp.status == 500
+                assert mock_api_obj.called("/test2")


### PR DESCRIPTION
# Description

This is a few small improvements to the ExternalAPIMockServer fixtures.

* Move all the setup into the non-running fixture 
* Add a context manager to run the server (as an alternative to `run_test`).

## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes