### PR TITLE
Adjust tests for matrix-nio==0.16.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ console_scripts =
 # connectors
 connector_matrix =
   bleach>=3.1.5
-  matrix-nio>=0.14.1
+  matrix-nio>=0.16.0
 connector_matrix_e2e =
   bleach>=3.1.5
   matrix-nio[e2e]

--- a/tests/test_database_matrix.py
+++ b/tests/test_database_matrix.py
@@ -50,6 +50,7 @@ def matrix_call(method, path, content=None):
             path += "enceventid?access_token=arbitrarytoken"
             return call(nio.RoomGetEventResponse, method, path)
         else:
+            path = path.rstrip("/")
             path += "?access_token=arbitrarytoken"
             return call(
                 nio.RoomGetStateEventResponse,
@@ -67,6 +68,7 @@ def matrix_call(method, path, content=None):
             ("!notaroomid",),
         )
     else:
+        path = path.rstrip("/")
         path += "?access_token=arbitrarytoken"
         return call(
             nio.RoomPutStateResponse,
@@ -779,7 +781,7 @@ async def test_get_single_state_key(patched_send, opsdroid_matrix):
     patched_send.assert_called_once_with(
         nio.RoomGetStateEventResponse,
         "GET",
-        "/_matrix/client/r0/rooms/%21notaroomid/state/dev.opsdroid.database/?access_token=arbitrarytoken",
+        "/_matrix/client/r0/rooms/%21notaroomid/state/dev.opsdroid.database?access_token=arbitrarytoken",
         response_data=("dev.opsdroid.database", "", "!notaroomid"),
     )
 
@@ -1074,7 +1076,7 @@ async def test_room_switch(patched_send, opsdroid_matrix):
     patched_send.assert_called_once_with(
         nio.RoomGetStateEventResponse,
         "GET",
-        "/_matrix/client/r0/rooms/%21notanotherroom/state/dev.opsdroid.database/?access_token=arbitrarytoken",
+        "/_matrix/client/r0/rooms/%21notanotherroom/state/dev.opsdroid.database?access_token=arbitrarytoken",
         response_data=("dev.opsdroid.database", "", "!notanotherroom"),
     )
 


### PR DESCRIPTION
# Description

matrix-nio is stripping "/" from the end of URLs now probably due to:
https://github.com/poljar/matrix-nio/commit/574a2ee7276ee88f8d61e4d33561810031c7cc50

But, it looks like that was their intention all along, so this is a bugfix.

This PR adjusts our tests to not expect the final "/" anymore.

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally in pytest.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
