### PR TITLE
Fix decryption of events and default end to end encryption to off in the matrix connector

### DIFF
--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -49,6 +49,7 @@ connectors:
     nick: "Botty McBotface"  # The nick will be set on startup
     room_specific_nicks: False  # Look up room specific nicknames of senders (expensive in large rooms)
     device_name: "opsdroid"
+    encryption_enabled: False
     device_id: "opsdroid" # A unique string to use as an ID for a persistent opsdroid device
     store_path: "path/to/store/" # Path to the directory where the matrix store will be saved
 ```
@@ -56,7 +57,8 @@ connectors:
 
 ## End to End Encryption
 
-The connector supports interacting with end to end encrypted rooms for which it will create a sqlite database to store the encryption keys into, where this database is kept can be configured with ``store_path``.
 To be able to use E2EE you need to have the 'olm' library installed, this is currently not available through pip, you can find it [here](https://gitlab.matrix.org/matrix-org/olm/), in most linux distributions or by using the opsdroid docker images.
 Once olm is installed you need to install opsdroid with the ``connector_matrix_e2e`` extra (by running ``pip install opsdroid[connector_matrix_e2e]``, this is not done by default as it required you to have already installed the olm library.
+You also need to set the `encryption_enabled: True` configuration option to enable encryption.
+The connector supports interacting with end to end encrypted rooms for which it will create a sqlite database to store the encryption keys into, where this database is kept can be configured with ``store_path``.
 Currently there is no device verification implemented which means messages will be sent regardless of whether encrypted rooms have users with unverified devices.

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -109,7 +109,7 @@ class ConnectorMatrix(Connector):
         if self._allow_encryption and not nio.crypto.ENCRYPTION_ENABLED:
             _LOGGER.warning(
                 "enable_encryption is True but encryption support is not available."
-            )
+            )  # pragma: no cover
             self._allow_encryption = False
 
         self._event_creator = MatrixEventCreator(self)

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -29,6 +29,7 @@ CONFIG_SCHEMA = {
     "device_name": str,
     "device_id": str,
     "store_path": str,
+    "enable_encryption": bool,
 }
 
 __all__ = ["ConnectorMatrix"]
@@ -103,7 +104,12 @@ class ConnectorMatrix(Connector):
             "store_path", str(Path(const.DEFAULT_ROOT_PATH, "matrix"))
         )
         self._ignore_unverified = True
-        self._allow_encryption = nio.crypto.ENCRYPTION_ENABLED
+        self._allow_encryption = config.get("enable_encryption", False)
+        if self._allow_encryption and not nio.crypto.ENCRYPTION_ENABLED:
+            _LOGGER.warning(
+                "enable_encryption is True but encryption support is not available."
+            )
+            self._allow_encryption = False
 
         self._event_creator = MatrixEventCreator(self)
 

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -106,10 +106,12 @@ class ConnectorMatrix(Connector):
         )
         self._ignore_unverified = True
         self._allow_encryption = config.get("enable_encryption", False)
-        if self._allow_encryption and not nio.crypto.ENCRYPTION_ENABLED:
+        if (
+            self._allow_encryption and not nio.crypto.ENCRYPTION_ENABLED
+        ):  # pragma: no cover
             _LOGGER.warning(
                 "enable_encryption is True but encryption support is not available."
-            )  # pragma: no cover
+            )
             self._allow_encryption = False
 
         self._event_creator = MatrixEventCreator(self)
@@ -285,14 +287,10 @@ class ConnectorMatrix(Connector):
                         if event.source["type"] == "m.room.member":
                             event.source["content"] = event.content
                         if isinstance(event, nio.MegolmEvent):
-                            try:
-                                event = self.connection.decrypt_event(
-                                    event
-                                )  # pragma: nocover
-                            except nio.exceptions.EncryptionError:
-                                _LOGGER.exception(
-                                    f"Failed to decrypt event {event}"
-                                )  # pragma: nocover
+                            try:  # pragma: no cover
+                                event = self.connection.decrypt_event(event)
+                            except nio.exceptions.EncryptionError:  # pragma: no cover
+                                _LOGGER.exception(f"Failed to decrypt event {event}")
                         return await self._event_creator.create_event(
                             event.source, roomid
                         )

--- a/tests/test_connector_matrix.py
+++ b/tests/test_connector_matrix.py
@@ -28,6 +28,7 @@ def connector():
             "mxid": "@opsdroid:localhost",
             "password": "hello",
             "homeserver": "http://localhost:8008",
+            "enable_encryption": True,
         }
     )
     api = nio.AsyncClient("https://notaurl.com", None)

--- a/tests/test_database_matrix.py
+++ b/tests/test_database_matrix.py
@@ -29,6 +29,7 @@ def opsdroid_matrix(mocker):
             "mxid": "@opsdroid:localhost",
             "password": "hello",
             "homeserver": "http://localhost:8008",
+            "enable_encryption": True,
         }
     )
     connector.room_ids = {"main": "!notaroomid"}


### PR DESCRIPTION
# Description

This adds a configuration option to enable end to end encryption in the matrix connector. Defaulting this to off means that an encryption enabled device will not be added to the matrix account, having an encryption enabled device means some clients, most notably, Element will automatically enable e2ee when creating rooms.

Also fixes #1713 

## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes