### PR TITLE
Fix get from database when content is empty

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,6 +45,6 @@ installation/packaging:
   - .github/**/*
 
 tests:
-  - tests/**/*
-  - **/tests/**/*
-  - **/conftest.py
+  - "tests/**/*"
+  - "**/tests/**/*"
+  - "**/conftest.py"

--- a/opsdroid/database/matrix/__init__.py
+++ b/opsdroid/database/matrix/__init__.py
@@ -182,6 +182,9 @@ class DatabaseMatrix(Database):
 
         data = ori_data.content
 
+        if not data:
+            return
+
         _LOGGER.debug(f"Got {data} from state in room {self.room_id}")
 
         if self._single_state_key:

--- a/tests/test_database_matrix.py
+++ b/tests/test_database_matrix.py
@@ -996,6 +996,16 @@ async def test_delete_single_state_key_false(patched_send, opsdroid_matrix):
 
 
 @pytest.mark.asyncio
+async def test_get_empty(patched_send, opsdroid_matrix):
+    patched_send.return_value = nio.RoomGetStateEventResponse({}, "", "", "")
+
+    db = DatabaseMatrix({"single_state_key": False}, opsdroid=opsdroid_matrix)
+    db.should_migrate = False
+
+    assert await db.get("test") is None
+
+
+@pytest.mark.asyncio
 async def test_delete_multiple_keys(patched_send, opsdroid_matrix):
     patched_send.return_value = nio.RoomGetStateEventResponse(
         {"hello": "world", "twim": "hello", "pill": "red"}, "", "", ""


### PR DESCRIPTION
-------

# Description

Prevents raising KeyError when the content in the state event is empty.

## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes