### PR TITLE
Update mentions of Riot to Element

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -7,7 +7,7 @@ assignees: ""
 
 ---
 
-<!-- Before you post an issue or if you are unsure about something join our matrix channel https://riot.im/app/#/room/#opsdroid-general:matrix.org and ask away! We are more than happy to help you. -->
+<!-- Before you post an issue or if you are unsure about something join our matrix channel https://app.element.io/#/room/#opsdroid-general:matrix.org and ask away! We are more than happy to help you. -->
 # Description
 Please include a summary of the issue.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <a href="https://hub.docker.com/r/opsdroid/opsdroid/builds/"><img src="https://img.shields.io/docker/build/opsdroid/opsdroid.svg" alt="Docker Build" /></a>
 <a href="https://hub.docker.com/r/opsdroid/opsdroid/builds/"><img alt="Docker Image Size (latest by date)" src="https://img.shields.io/docker/image-size/opsdroid/opsdroid?label=image%20size"></a><a href="https://microbadger.com/#/images/opsdroid/opsdroid"><img src="https://img.shields.io/microbadger/layers/opsdroid/opsdroid.svg" alt="Docker Layers" /></a>
 <a href="http://opsdroid.readthedocs.io/en/stable/?badge=stable"><img src="https://img.shields.io/readthedocs/opsdroid/latest.svg" alt="Documentation Status" /></a>
-<a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org"><img src="https://img.shields.io/matrix/opsdroid-general:matrix.org.svg?logo=matrix" alt="Matrix Chat" /></a>
+<a href="https://app.element.io/#/room/#opsdroid-general:matrix.org"><img src="https://img.shields.io/matrix/opsdroid-general:matrix.org.svg?logo=matrix" alt="Matrix Chat" /></a>
 <a href="#backers"><img src="https://opencollective.com/opsdroid/backers/badge.svg" alt="Backers on Open Collective" /></a>
 <a href="#sponsors"><img src="https://opencollective.com/opsdroid/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
 <a href="https://www.codetriage.com/opsdroid/opsdroid"><img src="https://www.codetriage.com/opsdroid/opsdroid/badges/users.svg" alt="Open Source Helpers" /></a>
@@ -25,7 +25,7 @@
   <a href="https://docs.opsdroid.dev">Documentation</a> •
   <a href="https://playground.opsdroid.dev">Playground</a> •
   <a href="https://medium.com/opsdroid">Blog</a> •
-  <a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org">Community</a>
+  <a href="https://app.element.io/#/room/#opsdroid-general:matrix.org">Community</a>
 </p>
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -616,4 +616,4 @@ Which would be represented in a dictionary format like this:
 
 You can have a look at the [example configuration file](https://github.com/opsdroid/opsdroid/blob/master/opsdroid/configuration/example_configuration.yaml) for a better grasp of the new layout.
 
-If you need help migrating your configuration to the new layout please get in touch with us on the [official matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org).
+If you need help migrating your configuration to the new layout please get in touch with us on the [official matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org).

--- a/docs/connectors/custom.md
+++ b/docs/connectors/custom.md
@@ -94,4 +94,4 @@ class MyConnector(Connector):
 
 ---
 You might also be interested in reading the [configuration reference - Connector Modules](../configuration.html#connector-modules) in the documentation.
-*If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
+*If you need help or if you are unsure about something join our* [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -43,7 +43,7 @@ connectors:
     # One of these have to be named 'main'
     rooms:
       'main': '#matrix:matrix.org'
-      'other': '#riot:matrix.org'
+      'other': '#element-web:matrix.org'
     # Optional
     homeserver: "https://matrix.org"
     nick: "Botty McBotface"  # The nick will be set on startup

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -18,7 +18,7 @@ web:
   base-url: <secure url/ngrok url>
 ```
 
-> If you need any help migrating, please asks on our [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org).
+> If you need any help migrating, please asks on our [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org).
 
 ## Requirements
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -28,7 +28,7 @@ Check out the following guides for specific contribution suggestions.
 
 ```
 
-*If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
+*If you need help or if you are unsure about something join our* [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
 
 ## Credits
 

--- a/docs/contributing/new_modules.md
+++ b/docs/contributing/new_modules.md
@@ -3,7 +3,7 @@ Opsdroid is an open source chatbot framework. It is designed to be extendable, s
 
  If you love a particular platform and wish to use opsdroid with it or if you want opsdroid to interact with something in a certain way, you can create your own modules and extend the functionality of opsdroid.
 
- If you don't know where to start, make sure to check the overview and read the [documentation](http://opsdroid.readthedocs.io/en/latest/?badge=latest).  Remember that you can also ask for help in our [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org)
+ If you don't know where to start, make sure to check the overview and read the [documentation](http://opsdroid.readthedocs.io/en/latest/?badge=latest).  Remember that you can also ask for help in our [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org)
 
 ## Creating Consistent Logging Messages
 

--- a/docs/databases/custom.md
+++ b/docs/databases/custom.md
@@ -48,4 +48,4 @@ class MyDatabase(Database):
 
 ```
 
-*If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
+*If you need help or if you are unsure about something join our* [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*

--- a/docs/examples/how-are-you.md
+++ b/docs/examples/how-are-you.md
@@ -3,7 +3,7 @@
 We will create a basic skill that makes opsdroid respond to the text "how are you".
 The video tutorial for creating your own skill is also available [here](https://www.youtube.com/watch?v=gk7JN4e5l_4&index=3&list=PLViQCHlMbEq5nZL6VNrUxu--Of1uCpflq).
 
-*If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
+*If you need help or if you are unsure about something join our* [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
 
 ## The Skill folder
 Opsdroid skills are located inside a folder with the name `skill-<skillname>`. Inside this folder you should have at least these files:

--- a/docs/examples/stocks-portfolio.md
+++ b/docs/examples/stocks-portfolio.md
@@ -4,7 +4,7 @@ We will create a skill that will allow opsdroid to return info of specific stock
 
 This example will use [YFinace](https://github.com/ranaroussi/yfinance) to get the information of the stocks and [SQLite3](https://www.sqlite.org/index.html) to keep our portfolio when we close the bot.
 
-*If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
+*If you need help or if you are unsure about something join our* [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
 
 ## Building the Skill
 

--- a/docs/examples/weather.md
+++ b/docs/examples/weather.md
@@ -4,7 +4,7 @@ We will create a skill, that will make opsdroid tell us the current weather in a
 
 This tutorial will use the  [OpenWeatherMap](https://openweathermap.org) API to get the weather information from a city. We will only need the free version of the API, so register and get your key from the [API](https://openweathermap.org/price) menu.
 
-*If you need help or if you are unsure about something join our* [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
+*If you need help or if you are unsure about something join our* [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org) *and ask away! We are more than happy to help you.*
 
 ## Setting Up
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 <a href="https://hub.docker.com/r/opsdroid/opsdroid/builds/"><img src="https://img.shields.io/docker/build/opsdroid/opsdroid.svg" alt="Docker Build" /></a>
 <a href="https://hub.docker.com/r/opsdroid/opsdroid/builds/"><img alt="Docker Image Size (latest by date)" src="https://img.shields.io/docker/image-size/opsdroid/opsdroid?label=image%20size"></a><a href="https://microbadger.com/#/images/opsdroid/opsdroid"><img src="https://img.shields.io/microbadger/layers/opsdroid/opsdroid.svg" alt="Docker Layers" /></a>
 <a href="http://opsdroid.readthedocs.io/en/stable/?badge=stable"><img src="https://img.shields.io/readthedocs/opsdroid/latest.svg" alt="Documentation Status" /></a>
-<a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org"><img src="https://img.shields.io/matrix/opsdroid-general:matrix.org.svg?logo=matrix" alt="Matrix Chat" /></a>
+<a href="https://app.element.io/#/room/#opsdroid-general:matrix.org"><img src="https://img.shields.io/matrix/opsdroid-general:matrix.org.svg?logo=matrix" alt="Matrix Chat" /></a>
 <a href="#backers"><img src="https://opencollective.com/opsdroid/backers/badge.svg" alt="Backers on Open Collective" /></a>
 <a href="#sponsors"><img src="https://opencollective.com/opsdroid/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
 <a href="https://www.codetriage.com/opsdroid/opsdroid"><img src="https://www.codetriage.com/opsdroid/opsdroid/badges/users.svg" alt="Open Source Helpers" /></a>
@@ -25,7 +25,7 @@
   <a href="https://docs.opsdroid.dev">Documentation</a> •
   <a href="https://playground.opsdroid.dev">Playground</a> •
   <a href="https://medium.com/opsdroid">Blog</a> •
-  <a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org">Community</a>
+  <a href="https://app.element.io/#/room/#opsdroid-general:matrix.org">Community</a>
 </p>
 
 ---

--- a/docs/maintaining/overview.md
+++ b/docs/maintaining/overview.md
@@ -6,7 +6,7 @@ A maintainer should be polite and respectful towards every member of the communi
 - **Responsibilities**
   - Responding to issues and PRs (even just to say thanks and we'll look into it)
   - Reviewing and merging Pull Requests
-  - Providing support on [matrix](https://riot.im/app/#/room/#opsdroid-general:matrix.org)
+  - Providing support on [matrix](https://app.element.io/#/room/#opsdroid-general:matrix.org)
   - Engaging in discussions on how to grow and shape opsdroid
   - Promote the project (blogging, tweeting, speaking at events, etc)
   - Make regular contributions and tackle old issues
@@ -28,7 +28,7 @@ As a maintainer one of the tasks that you have to take on will be reviewing pull
 
 Depending on the pull request, coverage might drop a bit. If that is the case, as a maintainer you should ask that a test is created to bump the coverage back up. You might need to give some guidance as to how to properly test the code in the PR.
 
-If a PR is not related to an open issue, then it's a proposal for the project. Jacob, the creator of opsdroid, and the community should give feedback and discuss the Pull Request either in the PR itself, an issue or in the [Matrix](https://riot.im/app/#/room/#opsdroid-general:matrix.org) channel.
+If a PR is not related to an open issue, then it's a proposal for the project. Jacob, the creator of opsdroid, and the community should give feedback and discuss the Pull Request either in the PR itself, an issue or in the [Matrix](https://app.element.io/#/room/#opsdroid-general:matrix.org) channel.
 
 When merging a PR into opsdroid main branch you should take a few things into consideration.
 - Use Squash and Merge option when merging a PR into opsdroid's master branch

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -131,4 +131,4 @@ If you try to access a connector or database which has not been configured these
 
 For examples of the kind of skills you can build in opsdroid see the [examples section](../examples/index). Or continue reading about more of the features you can use to create your skills.
 
-_If you need help or if you are unsure about something join our_ [matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org) _and ask away! We are more than happy to help you._
+_If you need help or if you are unsure about something join our_ [matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org) _and ask away! We are more than happy to help you._

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -156,7 +156,7 @@ connectors:
 #    # One of these should be named 'main'
 #    rooms:
 #      'main': '#matrix:matrix.org'
-#      'other': '#riot:matrix.org'
+#      'other': '#element-web:matrix.org'
 #    # Optional
 #    homeserver: "https://matrix.org"
 #    nick: "Botty McBotface"  # The nick will be set on startup

--- a/opsdroid/connector/matrix/html_cleaner.py
+++ b/opsdroid/connector/matrix/html_cleaner.py
@@ -6,7 +6,7 @@ __all__ = ["clean"]
 
 
 """
-Take the list of allowed tags and attributes from Riot for consistency:
+Take the list of allowed tags and attributes from Element for consistency:
 https://github.com/matrix-org/matrix-react-sdk/blob/master/src/HtmlUtils.js#L180-L195
 """
 
@@ -63,7 +63,7 @@ def clean(html, **kwargs):
     """
     Sanitise HTML fragments.
 
-    A version of `bleach.clean` but with Riot's allowed tags and ``strip=True``
+    A version of `bleach.clean` but with Element's allowed tags and ``strip=True``
     by default.
     """
     defaults = {


### PR DESCRIPTION
# Description

Riot has rebranded to [Element](https://element.io). At some point links to riot.im will probably stop working. This PR updates `riot.im/app` to instead point to `app.element.io`.


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Checked the links, they seem to work.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
