### PR TITLE
Twitch webhook lease time

### DIFF
--- a/docs/connectors/twitch.md
+++ b/docs/connectors/twitch.md
@@ -21,6 +21,7 @@ connectors:
     redirect: http://localhost # Url to be passed to get oath token - defaults to localhost
     forward-url: 'http://94jfsd9ff.ngrok.io' # Either an URL provided by a forwarding service or an exposed ip address
     # optional
+    webhook-lease-seconds: 86400 # how long for webhooks to expire
     always-listening: false # Turn on to connect to the chat server even if stream is offline.
 ```
 

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -131,6 +131,7 @@ connectors:
 #   redirect: http://localhost # Url to be passed to get oath token - defaults to localhost
 #   forward-url: 'http://94jfsd9ff.ngrok.io' # Either an URL provided by a forwarding service or an exposed ip address
 #   # optional
+#   webhook-lease-seconds: 86400 # how long for webhooks to expire
 #   always-listening: false # Turn on to connect to the chat server even if stream is offline.
 #
 #  ## Webexteams (core)

--- a/opsdroid/connector/twitch/__init__.py
+++ b/opsdroid/connector/twitch/__init__.py
@@ -56,6 +56,7 @@ class ConnectorTwitch(Connector):
         self.redirect = config.get("redirect", "http://localhost")
         self.bot_name = config.get("bot-name", "opsdroid")
         self.websocket = None
+        self.webhook_lease_seconds = config.get("webhook-lease-seconds", 60 * 60 * 24) # default 1 day
         self.user_id = None
         self.webhook_secret = secrets.token_urlsafe(18)
         # TODO: Allow usage of SSL connection
@@ -328,7 +329,7 @@ class ConnectorTwitch(Connector):
                 "hub.callback": f"{self.base_url}/connector/{self.name}",
                 "hub.mode": mode,
                 "hub.topic": topic,
-                "hub.lease_seconds": 60 * 60 * 24 * 9,  # Expire after 9 days
+                "hub.lease_seconds": self.webhook_lease_seconds,
                 "hub.secret": self.webhook_secret,
             }
 

--- a/opsdroid/connector/twitch/__init__.py
+++ b/opsdroid/connector/twitch/__init__.py
@@ -56,7 +56,9 @@ class ConnectorTwitch(Connector):
         self.redirect = config.get("redirect", "http://localhost")
         self.bot_name = config.get("bot-name", "opsdroid")
         self.websocket = None
-        self.webhook_lease_seconds = config.get("webhook-lease-seconds", 60 * 60 * 24) # default 1 day
+        self.webhook_lease_seconds = config.get(
+            "webhook-lease-seconds", 60 * 60 * 24
+        )  # default 1 day
         self.user_id = None
         self.webhook_secret = secrets.token_urlsafe(18)
         # TODO: Allow usage of SSL connection


### PR DESCRIPTION
# Description

The Twitch Connector docs mention that the default webhook lease time is 1 day, but the actual code uses 9 days. 

This PR makes the webhook lease time a configuration option, and also changes the default to 1 day. 



## Status
**READY** 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

I think this is closest to a bug fix. 

# How Has This Been Tested?

I've only run this locally without issue. 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
