### PR TITLE
s/encryption_enabled/enable_encryption in matrix documentation

### DIFF
--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -49,7 +49,7 @@ connectors:
     nick: "Botty McBotface"  # The nick will be set on startup
     room_specific_nicks: False  # Look up room specific nicknames of senders (expensive in large rooms)
     device_name: "opsdroid"
-    encryption_enabled: False
+    enable_encryption: False
     device_id: "opsdroid" # A unique string to use as an ID for a persistent opsdroid device
     store_path: "path/to/store/" # Path to the directory where the matrix store will be saved
 ```
@@ -59,6 +59,6 @@ connectors:
 
 To be able to use E2EE you need to have the 'olm' library installed, this is currently not available through pip, you can find it [here](https://gitlab.matrix.org/matrix-org/olm/), in most linux distributions or by using the opsdroid docker images.
 Once olm is installed you need to install opsdroid with the ``connector_matrix_e2e`` extra (by running ``pip install opsdroid[connector_matrix_e2e]``, this is not done by default as it required you to have already installed the olm library.
-You also need to set the `encryption_enabled: True` configuration option to enable encryption.
+You also need to set the `enable_encryption: True` configuration option to enable encryption.
 The connector supports interacting with end to end encrypted rooms for which it will create a sqlite database to store the encryption keys into, where this database is kept can be configured with ``store_path``.
 Currently there is no device verification implemented which means messages will be sent regardless of whether encrypted rooms have users with unverified devices.


### PR DESCRIPTION
# Description

[The matrix connector configuration documentation](https://docs.opsdroid.dev/en/stable/connectors/matrix.html) shows:
```yaml
encryption_enabled: False
```
As the desired variable to enable encryption. The actual variable sought by the matrix connector is `enable_encryption`:
* https://github.com/opsdroid/opsdroid/blob/fa0a863e024e5c35e108b0ff1bcfdf3975d40c64/opsdroid/connector/matrix/connector.py#L34
* https://github.com/opsdroid/opsdroid/blob/fa0a863e024e5c35e108b0ff1bcfdf3975d40c64/opsdroid/connector/matrix/connector.py#L114

## Status
**READY**


## Type of change

- Documentation (fix or adds documentation)


# How Has This Been Tested?

Checked config with `enable_encryption: True` - works. Otherwise just a change to documentation.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (as much as they did before - just doc change)
