### PR TITLE
Fix matrix connector sync_token book keeping and log on successful connect

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -234,8 +234,6 @@ class ConnectorMatrix(Connector):
                 "Configuration for the matrix connector should specify mxid and password or access_token."
             )  # pragma: no cover
 
-        self.connection.sync_token = None
-
         for roomname, room in self.rooms.items():
             response = await self.connection.join(room["alias"])
             if isinstance(response, nio.JoinError):
@@ -263,8 +261,6 @@ class ConnectorMatrix(Connector):
             )
             return
 
-        self.connection.sync_token = response.next_batch
-
         await self.exchange_keys(initial_sync=True)
 
         if self.nick:
@@ -284,13 +280,13 @@ class ConnectorMatrix(Connector):
                         f"Error setting display_name: {display_name_resp.message} (status code {display_name_resp.status_code})"
                     )
 
+        _LOGGER.info("Successfully connected to matrix.")
+
     async def disconnect(self):
         """Close the matrix session."""
         await self.connection.close()
 
     async def _parse_sync_response(self, response):
-        self.connection.sync_token = response.next_batch
-
         # Emit Invite events for every room in the invite list.
         for roomid, roomInfo in response.rooms.invite.items():
             # Process the invite list to extract the person who invited us.
@@ -330,7 +326,6 @@ class ConnectorMatrix(Connector):
             response = await self.connection.sync(
                 timeout=int(60 * 1e3),  # 1m in ms
                 sync_filter=self.filter_id,
-                since=self.connection.sync_token,
             )
             if isinstance(response, nio.SyncError):
                 _LOGGER.error(


### PR DESCRIPTION
# Description

This makes the matrix connector error out cleaner if it can't connect to the HS


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)