### PR TITLE
Fixed a Broken Link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ html_theme_options = {
 
 # -- Recommonmark ------------------------------------------------------------
 
-github_doc_root = "https://github.com/rtfd/recommonmark/tree/master/doc/"
+github_doc_root = "https://github.com/readthedocs/recommonmark/tree/master/docs"
 
 
 def setup(app):


### PR DESCRIPTION
Since rtfd shifted to another github repository named readthedocs, the link to the docs got broken, fixed that 