### PR TITLE
Update docs and unit test after PR #1776

### DIFF
--- a/docs/connectors/mattermost.md
+++ b/docs/connectors/mattermost.md
@@ -44,3 +44,5 @@ hi
 opsdroid APP [9:06 PM]
 Hi daniccan
 ```
+
+The connector doesn't parse messages that have been posted by the bot itself.

--- a/opsdroid/connector/mattermost/__init__.py
+++ b/opsdroid/connector/mattermost/__init__.py
@@ -93,8 +93,8 @@ class ConnectorMattermost(Connector):
         if "event" in message and message["event"] == "posted":
             data = message["data"]
             post = json.loads(data["post"])
-            # don't parse our own messages (https://github.com/opsdroid/opsdroid/issues/1775)
-            # (but also parse if somehow our bot_id is unknown, like in the unit tests)
+            # if connected to Mattermost, don't parse our own messages
+            # (https://github.com/opsdroid/opsdroid/issues/1775)
             if self.bot_id is None or self.bot_id != post["user_id"]:
                 await self.opsdroid.parse(
                     Message(

--- a/tests/test_connector_mattermost.py
+++ b/tests/test_connector_mattermost.py
@@ -153,6 +153,75 @@ class TestConnectorMattermostAsync(asynctest.TestCase):
         await connector.process_message(message)
         self.assertTrue(connector.opsdroid.parse.called)
 
+    async def test_do_not_process_own_message(self):
+        """Test that we do not process our own messages when connected to Mattermost."""
+        connector = ConnectorMattermost(
+            {
+                "token": "abc123",
+                "url": "localhost",
+                "team-name": "opsdroid",
+                "scheme": "http",
+            },
+            opsdroid=OpsDroid(),
+        )
+        opsdroid = amock.CoroutineMock()
+        opsdroid.eventloop = self.loop
+        connector.mm_driver.login = mock.MagicMock()
+        connector.mm_driver.login.return_value = {"id": "1", "username": "opsdroid_bot"}
+        await connector.connect()
+        self.assertEqual("1", connector.bot_id)
+        self.assertEqual("opsdroid_bot", connector.bot_name)
+
+        connector.opsdroid = amock.CoroutineMock()
+        connector.opsdroid.eventloop = self.loop
+        connector.opsdroid.parse = amock.CoroutineMock()
+
+        post = json.dumps(
+            {
+                "id": "wr9wetwc87bgdcx6opkjaxwb7b",
+                "create_at": 1574001673420,
+                "update_at": 1574001673420,
+                "edit_at": 0,
+                "delete_at": 0,
+                "is_pinned": False,
+                "user_id": "1",
+                "channel_id": "hdnm8gbxfp8bmcns7oswmwur4r",
+                "root_id": "",
+                "parent_id": "",
+                "original_id": "",
+                "message": "hello",
+                "type": "",
+                "props": {},
+                "hashtags": "",
+                "pending_post_id": "mrtopue9oigr8poa3bgfq4if4a:1574001673372",
+                "metadata": {},
+            }
+        )
+
+        message = json.dumps(
+            {
+                "event": "posted",
+                "data": {
+                    "channel_display_name": "@daniccan",
+                    "channel_name": "546qd6zsyffcfcafd77a3kdadr__mrtopue9oigr8poa3bgfq4if4a",
+                    "channel_type": "D",
+                    "mentions": '["546qd6zsyffcfcafd77a3kdadr"]',
+                    "post": post,
+                    "sender_name": "@opsdroid_bot",
+                    "team_id": "",
+                },
+                "broadcast": {
+                    "omit_users": "",
+                    "user_id": "",
+                    "channel_id": "hdnm8gbxfp8bmcns7oswmwur4r",
+                    "team_id": "",
+                },
+                "seq": 4,
+            }
+        )
+        await connector.process_message(message)
+        self.assertFalse(connector.opsdroid.parse.called)
+
     async def test_send_message(self):
         connector = ConnectorMattermost(
             {


### PR DESCRIPTION
# Description

This PR complements merged PR #1776.

It slightly updates the docs, and most importantly adds a unit test that verifies that the bot's own messages are indeed /not/ parsed.

As intended, the unit test fails on revision 638e3a85e6a557a18097d06ef6d5f4d1c50bd0a1 (master without PR #1776) but passes with PR #1776 applied.

## Status
**READY**


## Type of change

- New unit test
- Documentation update


# How Has This Been Tested?

- Unit tests pass locally


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes