### PR TITLE
rasanlu matcher fixes, regex intent matching and extended example

### DIFF
--- a/docs/skills/matchers/rasanlu.md
+++ b/docs/skills/matchers/rasanlu.md
@@ -94,6 +94,8 @@ nlu:
 
 > **Note** - Rasa NLU requires an intent to have at least three training examples in the list. There must also be a minimum of two intents in your file for Rasa to train.
 
+> **Note** - The intent matching (`@match_rasanlu('greetings')` will perform a case-sentitive RegEx search on the intent returned by Rasa.
+
 The above skill would be called on any intent which has a name of `'greetings'` and `'bye'`.
 
 ## Example 2

--- a/docs/skills/matchers/rasanlu.md
+++ b/docs/skills/matchers/rasanlu.md
@@ -156,7 +156,7 @@ import random
 _LOGGER = logging.getLogger(__name__)
 
 class MySkill(Skill):
-    @match_rasanlu("ask_weather")
+    @match_rasanlu("^ask_weather$")
     async def ask_weather(self, message):
         _LOGGER.info(_("Rasa result data - %s"), json.dumps(message.rasanlu))
         _LOGGER.info(_("Entities got from Rasa - %s"), json.dumps(message.entities))
@@ -168,7 +168,7 @@ class MySkill(Skill):
         else:
             await message.respond("I don't know this city. :(")
 
-    @match_rasanlu(".")  # Matches all
+    @match_rasanlu("^.*$")  # Matches all
     async def passthrough(self, message):
         _LOGGER.info(_("Rasa result data - %s"), json.dumps(message.rasanlu))
         if (

--- a/docs/skills/matchers/rasanlu.md
+++ b/docs/skills/matchers/rasanlu.md
@@ -156,7 +156,7 @@ import random
 _LOGGER = logging.getLogger(__name__)
 
 class MySkill(Skill):
-    @match_rasanlu("^ask_weather$")
+    @match_rasanlu("ask_weather")
     async def ask_weather(self, message):
         _LOGGER.info(_("Rasa result data - %s"), json.dumps(message.rasanlu))
         _LOGGER.info(_("Entities got from Rasa - %s"), json.dumps(message.entities))
@@ -168,7 +168,7 @@ class MySkill(Skill):
         else:
             await message.respond("I don't know this city. :(")
 
-    @match_rasanlu("^.*$")  # Matches all
+    @match_rasanlu(".")  # Matches all
     async def passthrough(self, message):
         _LOGGER.info(_("Rasa result data - %s"), json.dumps(message.rasanlu))
         if (

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -291,11 +291,18 @@ async def parse_rasanlu(opsdroid, skills, message, config):
                     if matched_regex:
                         message.rasanlu = result
                         for entity in result["entities"]:
-                            message.update_entity(
-                                entity["entity"],
-                                entity["value"],
-                                entity["confidence_entity"],
-                            )
+                            if "confidence_entity" in entity:
+                                message.update_entity(
+                                    entity["entity"],
+                                    entity["value"],
+                                    entity["confidence_entity"],
+                                )
+                            elif "extractor" in entity:
+                                message.update_entity(
+                                    entity["entity"],
+                                    entity["value"],
+                                    entity["extractor"],
+                                )
                         matched_skills.append(
                             {
                                 "score": confidence,

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -265,7 +265,12 @@ async def parse_rasanlu(opsdroid, skills, message, config):
         _LOGGER.error(_("Rasa NLU error - Unauthorised request. Check your 'token'."))
         return matched_skills
 
-    if result is None or "intent" not in result or result["intent"] is None:
+    if (
+        result is None
+        or "intent" not in result
+        or result["intent"] is None
+        or result["intent"]["name"] is None
+    ):
         _LOGGER.error(
             _("Rasa NLU error - No intent found. Did you forget to create one?")
         )

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -287,7 +287,9 @@ async def parse_rasanlu(opsdroid, skills, message, config):
                         message.rasanlu = result
                         for entity in result["entities"]:
                             message.update_entity(
-                                entity["entity"], entity["value"], entity["confidence"]
+                                entity["entity"],
+                                entity["value"],
+                                entity["confidence_entity"],
                             )
                         matched_skills.append(
                             {

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -116,6 +116,8 @@ async def _load_model(config):
                 config["model_filename"],
             ),
         }
+        _LOGGER.info(_("Loading Rasa NLU model from %s."), data["model_file"])
+        training_start = arrow.now()
         url = config.get("url", RASANLU_DEFAULT_URL) + "/model"
         if "token" in config:
             url += "?token={}".format(config["token"])
@@ -130,6 +132,10 @@ async def _load_model(config):
             result = await resp.text()
             _LOGGER.error(_("Bad Rasa NLU response - %s."), result)
 
+        time_taken = (arrow.now() - training_start).total_seconds()
+        _LOGGER.info(
+            _("Rasa NLU model load is completed in %s seconds."), int(time_taken)
+        )
         return result
 
 

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -8,6 +8,7 @@ from hashlib import sha256
 
 import aiohttp
 import arrow
+import regex
 
 from opsdroid.const import RASANLU_DEFAULT_URL, RASANLU_DEFAULT_MODELS_PATH
 
@@ -273,7 +274,10 @@ async def parse_rasanlu(opsdroid, skills, message, config):
         for skill in skills:
             for matcher in skill.matchers:
                 if "rasanlu_intent" in matcher:
-                    if matcher["rasanlu_intent"] == result["intent"]["name"]:
+                    matched_regex = regex.search(
+                        matcher["rasanlu_intent"], result["intent"]["name"]
+                    )
+                    if matched_regex:
                         message.rasanlu = result
                         for entity in result["entities"]:
                             message.update_entity(

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -189,6 +189,29 @@ class TestParserRasaNLU(asynctest.TestCase):
                 self.assertEqual(
                     skill["message"].entities["cuisine"]["value"], "chinese"
                 )
+            with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
+                mocked_call_rasanlu.return_value = {
+                    "text": "show me chinese restaurants",
+                    "intent": {"name": "restaurant_search", "confidence": 0.98343},
+                    "entities": [
+                        {
+                            "start": 8,
+                            "end": 15,
+                            "value": "chinese",
+                            "entity": "cuisine",
+                            "extractor": "RegexEntityExtractor",
+                        }
+                    ],
+                }
+                [skill] = await rasanlu.parse_rasanlu(
+                    opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
+                )
+
+                self.assertEqual(len(skill["message"].entities.keys()), 1)
+                self.assertTrue("cuisine" in skill["message"].entities.keys())
+                self.assertEqual(
+                    skill["message"].entities["cuisine"]["value"], "chinese"
+                )
 
     async def test_parse_rasanlu_raises(self):
         with OpsDroid() as opsdroid:

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -131,7 +131,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                             "end": 32,
                             "entity": "state",
                             "extractor": "ner_crf",
-                            "confidence": 0.854,
+                            "confidence_entity": 0.854,
                             "start": 25,
                             "value": "running",
                         }
@@ -175,7 +175,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                             "value": "chinese",
                             "entity": "cuisine",
                             "extractor": "CRFEntityExtractor",
-                            "confidence": 0.854,
+                            "confidence_entity": 0.854,
                             "processors": [],
                         }
                     ],
@@ -215,7 +215,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                             "end": 32,
                             "entity": "state",
                             "extractor": "ner_crf",
-                            "confidence": 0.854,
+                            "confidence_entity": 0.854,
                             "start": 25,
                             "value": "running",
                         }


### PR DESCRIPTION
# Description

* Add RegEx for matching rasanlu intents
  * Enables to more flexible intent matching in opsdroid
  * Enables to use "passthrough" function in opsdroid skill to pass the responses proposed by Rasa (using Rasa's ResponseSelector)
* Add log message: time spend for loading the model
* Fix for entity matching. Rasa 2.x uses `confidence_entity` instead of `confidence`
* Handle exception if no intent was matched (intent is None)
* Enable entity extractors without confidence property (like RegexEntityExtractor)
* Add a more extensive Rasa example

Fixes #1756

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Unit test
- Skill used in the documentation


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
