### PR TITLE
Implement multi-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,64 @@
-FROM python:3.8-alpine
+FROM python:3.9.6-alpine3.14 as builder
 LABEL maintainer="Jacob Tomlinson <jacob@tomlinson.email>"
+LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
 WORKDIR /usr/src/app
-ARG EXTRAS=.[all,connector_matrix_e2e]
+
+ARG EXTRAS=[all,connector_matrix_e2e]
+ENV DEPS_DIR=/usr/src/app/deps
 
 # Copy source
 COPY . .
 
+# Install build tools and libraries to build OpsDroid and its dependencies.
 RUN apk update \
-    && apk add --no-cache build-base linux-headers musl-dev python3-dev libzmq zeromq-dev git openssh-client olm olm-dev libffi-dev \
-    && pip3 install --upgrade pip \
-    && pip3 install --no-cache-dir $EXTRAS \
-    && apk del build-base linux-headers musl-dev python3-dev zeromq-dev
+  && apk add \
+  build-base \
+  gcc \
+  g++ \
+  libffi-dev \
+  linux-headers \
+  musl-dev \
+  olm-dev \
+  openssh-client \
+  openssl-dev \
+  python3-dev \
+  zeromq-dev \
+  && pip install --upgrade \
+  build \
+  pip \
+  setuptools \
+  setuptools-scm \
+  wheel \
+  && mkdir -p "${DEPS_DIR}" \
+  && pip download --prefer-binary -d ${DEPS_DIR} .${EXTRAS} \
+  && pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.tar.gz \
+  && python -m build --wheel --outdir ${DEPS_DIR}
+
+FROM python:3.9.6-alpine3.14 as runtime
+LABEL maintainer="Jacob Tomlinson <jacob@tomlinson.email>"
+LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
+
+WORKDIR /usr/src/app
+
+ARG EXTRAS=[all,connector_matrix_e2e]
+ENV DEPS_DIR=/usr/src/app/deps
+
+# Copy the pre-built dependencies.
+COPY --from=builder ${DEPS_DIR}/*.whl ${DEPS_DIR}/
+
+# Install Opsdroid using only pre-built dependencies.
+RUN apk add --no-cache \
+  git \
+  libzmq \
+  && pip install --no-cache-dir --no-index -f ${DEPS_DIR} \
+  ${DEPS_DIR}/opsdroid-0+unknown-py3-none-any.whl${EXTRAS} \
+  && rm -rf /tmp/* /var/tmp/* ${DEPS_DIR}/* \
+  && adduser -u 1001 -S -G root opsdroid
 
 EXPOSE 8080
 
-CMD ["opsdroid", "start"]
+# Ensure the service runs as an unprivileged user.
+USER opsdroid
+ENTRYPOINT ["opsdroid"]
+CMD ["start"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -135,7 +135,7 @@ docs =
   docutils==0.16
 
 [wheel]
-universal = 1
+universal = 0
 
 [tool:pytest]
 testpaths = opsdroid tests


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Updates the Dockerfile to leverage multi-stage build and ensure that the
runtime contains only the dependencies required to run OpsDroid.

The final image was updated to run as an unprivileged user.

The concepts used to build this new version of the Docker image mostly
come from Bitnami's recommendations:
https://engineering.bitnami.com/articles/best-practices-writing-a-dockerfile.html

The wheel `unversal` flag was removed since the project does not have C
extensions, nor supports Python 2 (see
https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
for reference).

## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->
- New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Building and running the image locally.

```
$ docker run --rm -it opsdroid/opsdroid:snapshot
INFO opsdroid.logging: ========================================
INFO opsdroid.logging: Started opsdroid 0+unknown.
INFO opsdroid: ========================================
INFO opsdroid: You can customise your opsdroid by modifying your configuration.yaml.
INFO opsdroid: Read more at: http://opsdroid.readthedocs.io/#configuration
INFO opsdroid: Watch the Get Started Videos at: http://bit.ly/2fnC0Fh
INFO opsdroid: Install Opsdroid Desktop at:
https://github.com/opsdroid/opsdroid-desktop/releases
INFO opsdroid: ========================================
WARNING opsdroid.loader: No databases in configuration. This will cause skills which store things in memory to lose data when opsdroid is restarted.
INFO opsdroid.loader: Cloning dance from remote repository.
INFO opsdroid.loader: Cloning hello from remote repository.
INFO opsdroid.loader: Cloning loudnoises from remote repository.
INFO opsdroid.loader: Cloning seen from remote repository.
INFO opsdroid.core: Opsdroid is now running, press ctrl+c to exit.
INFO opsdroid.web: Started web server on http://0.0.0.0:8080
^CINFO opsdroid.core: Received stop signal, exiting.
INFO opsdroid.core: Stopping connector websocket...
INFO opsdroid.core: Stopped connector websocket.
INFO opsdroid.core: Stopping database inmem...
INFO opsdroid.core: Stopped database inmem.
INFO opsdroid.core: Stopping web server...
INFO opsdroid.core: Stopped web server.
INFO opsdroid.core: Stopping pending tasks...
INFO opsdroid.core: Stopped pending tasks.
INFO opsdroid.core: Bye!
INFO opsdroid.core: Exiting application with return code 0.
```


# Checklist:

- [ X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
