### PR TITLE
make opsdroid dynamic module actually importable

### DIFF
--- a/opsdroid/const.py
+++ b/opsdroid/const.py
@@ -7,7 +7,7 @@ from opsdroid import __version__  # noqa # pylint: disable=unused-import
 NAME = "opsdroid"
 MODULE_ROOT = os.path.dirname(os.path.abspath(opsdroid.__file__))
 DEFAULT_GIT_URL = "https://github.com/opsdroid/"
-MODULES_DIRECTORY = "opsdroid-modules"
+MODULES_DIRECTORY = "opsdroid_modules"
 DEFAULT_ROOT_PATH = user_data_dir(NAME)
 DEFAULT_LOG_FILENAME = os.path.join(user_log_dir(NAME, appauthor=False), "output.log")
 DEFAULT_MODULES_PATH = user_data_dir(NAME, MODULES_DIRECTORY)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -116,7 +116,7 @@ class TestMessage(asynctest.TestCase):
                     "name": "shell",
                     "thinking-delay": 3,
                     "type": "connector",
-                    "module_path": "opsdroid-modules.connector.shell",
+                    "module_path": "opsdroid_modules.connector.shell",
                 },
                 opsdroid=opsdroid,
             )
@@ -137,7 +137,7 @@ class TestMessage(asynctest.TestCase):
                     "name": "shell",
                     "thinking-delay": 3,
                     "type": "connector",
-                    "module_path": "opsdroid-modules.connector.shell",
+                    "module_path": "opsdroid_modules.connector.shell",
                 },
                 opsdroid=opsdroid,
             )
@@ -158,7 +158,7 @@ class TestMessage(asynctest.TestCase):
                     "name": "shell",
                     "thinking-delay": [1, 4],
                     "type": "connector",
-                    "module_path": "opsdroid-modules.connector.shell",
+                    "module_path": "opsdroid_modules.connector.shell",
                 },
                 opsdroid=opsdroid,
             )
@@ -179,7 +179,7 @@ class TestMessage(asynctest.TestCase):
                     "name": "shell",
                     "typing-delay": 0.3,
                     "type": "connector",
-                    "module_path": "opsdroid-modules.connector.shell",
+                    "module_path": "opsdroid_modules.connector.shell",
                 },
                 opsdroid=opsdroid,
             )
@@ -201,7 +201,7 @@ class TestMessage(asynctest.TestCase):
                     "name": "shell",
                     "typing-delay": [1, 4],
                     "type": "connector",
-                    "module_path": "opsdroid-modules.connector.shell",
+                    "module_path": "opsdroid_modules.connector.shell",
                 },
                 opsdroid=opsdroid,
             )
@@ -222,7 +222,7 @@ class TestMessage(asynctest.TestCase):
                     "name": "shell",
                     "typing-delay": 6,
                     "type": "connector",
-                    "module_path": "opsdroid-modules.connector.shell",
+                    "module_path": "opsdroid_modules.connector.shell",
                 },
                 opsdroid=opsdroid,
             )


### PR DESCRIPTION
When loading skills via `path` and `repo` opsdroid smushes them into a dynamically created and loaded module. That module is then loaded with `importlib`.

However that module has been named `opsdroid-modules` which isn't actually importable from within code. I'm surprised that `importlib` is happy with it to be honest.

This PR renames it to `opsdroid_modules` which would allow skills to import each other.

```yaml
...

skills:
  foo:
    path: ~/foo.py

  bar:
    path:  ~/bar.py
```

```python
# foo.py
from opsdroid.matchers import match_regex
from opsdroid.skill import Skill


class FooSkill(Skill):
    @match_regex(r"foo")
    async def foo_method(self, event):
        await event.respond("fooooo")
```

```python
# bar.py
from opsdroid.matchers import match_regex
from opsdroid.skill import Skill


class BarSkill(Skill):
    @match_regex(r"bar")
    async def bar_method(self, event):
        from opsdroid_modules.skill.foo import FooSkill
        # Do things with `FooSkill`, just remember this is the base class not the instance loaded into opsdroid
```