### PR TITLE
Fix GitHub event creation

### DIFF
--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -113,7 +113,7 @@ class ConnectorGitHub(Connector):
                 sender=user,
             )
 
-        if payload["action"] == "completed":
+        elif payload["action"] == "completed":
             if payload["check_run"]["conclusion"] == "success":
                 event = github_events.CheckPassed(
                     action=payload["action"],
@@ -153,7 +153,7 @@ class ConnectorGitHub(Connector):
                 connector=self,
                 raw_event=payload,
             )
-        if payload["action"] == "closed":
+        elif payload["action"] == "closed":
             event = github_events.IssueClosed(
                 title=payload["issue"]["title"],
                 user=user,
@@ -162,7 +162,7 @@ class ConnectorGitHub(Connector):
                 connector=self,
                 raw_event=payload,
             )
-        if "comment" in payload:
+        elif "comment" in payload:
             event = github_events.IssueCommented(
                 comment=payload["comment"]["body"],
                 user=payload["comment"]["user"]["login"],
@@ -187,7 +187,7 @@ class ConnectorGitHub(Connector):
                 connector=self,
                 raw_event=payload,
             )
-        if payload["action"] == "closed" and payload["pull_request"]["merged"]:
+        elif payload["action"] == "closed" and payload["pull_request"]["merged"]:
             event = github_events.PRMerged(
                 title=payload["pull_request"]["title"],
                 description=payload["pull_request"]["body"],
@@ -197,7 +197,7 @@ class ConnectorGitHub(Connector):
                 connector=self,
                 raw_event=payload,
             )
-        if payload["action"] == "closed":
+        elif payload["action"] == "closed":
             event = github_events.PRClosed(
                 title=payload["pull_request"]["title"],
                 user=payload["pull_request"]["user"]["login"],

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -224,7 +224,6 @@ async def test_close_pr(opsdroid, connector, mock_api):
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-@pytest.mark.timeout(120)
 async def test_pr_merged(opsdroid, connector, mock_api, caplog):
     """Test a PR merge event creates an event and parses it."""
     caplog.set_level(logging.INFO)

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -197,7 +197,7 @@ async def test_receive_pr(opsdroid, connector, mock_api):
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_close_pr(opsdroid, connector, mock_api):
+async def test_close_pr(opsdroid, connector, mock_api, caplog):
     """Test a PR close event creates an event and parses it."""
 
     @match_event(github_event.PRClosed)
@@ -218,6 +218,7 @@ async def test_close_pr(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_pr_closed_payload.json"),
         )
         assert resp.status == 201
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -1,5 +1,4 @@
 """Tests for the GitHub class."""
-import asyncio
 import logging
 from pathlib import Path
 
@@ -250,8 +249,7 @@ async def test_pr_merged(opsdroid, connector, mock_api, caplog):
             data=get_webhook_payload("github_pr_merged_payload.json"),
         )
         assert resp.status == 201
-        while "Test skill complete" not in caplog.text:
-            await asyncio.sleep(0.1)
+        assert "Test skill complete" in caplog.text
         assert "Exception when running skill" not in caplog.text
 
 


### PR DESCRIPTION
When parsing payloads from the GitHub webhook there are a few series of if statements. In the case of a PR Merged event the if was passing and creating the event, but then the next if was also passing and replacing it with a PR Closed event.

This PR updates it to use `elif` instead which fixes this issue.

I've also expanded the test to ensure that the skill gets called, cc @ajitdsa.