### PR TITLE
GitHub fix labels

### DIFF
--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -220,6 +220,7 @@ class ConnectorGitHub(Connector):
                 user = payload["sender"]["login"]
                 if payload["action"] == "labeled":
                     event = github_events.Labeled(
+                        label_added=payload["label"]["name"],
                         labels=payload["issue"]["labels"],
                         state=payload["issue"]["state"],
                         user=user,
@@ -229,7 +230,8 @@ class ConnectorGitHub(Connector):
                     )
                 elif payload["action"] == "unlabeled":
                     event = github_events.Unlabeled(
-                        labels=payload["label"]["name"],
+                        label_removed=payload["label"]["name"],
+                        labels=payload["issue"]["labels"],
                         state=payload["issue"]["state"],
                         user=user,
                         target=f"{repo}{payload['issue']['number']}",

--- a/opsdroid/connector/github/events.py
+++ b/opsdroid/connector/github/events.py
@@ -119,7 +119,7 @@ class PRClosed(events.Event):
 class Labeled(events.Event):
     """Event class that triggers when an issue/PR is labeled.."""
 
-    def __init__(self, labels, state, *args, **kwargs):
+    def __init__(self, label_added, labels, state, *args, **kwargs):
         """Event that is triggered when a user adds a label.
 
         Note that if a user creates a new issue/PR and labels it at the same time,
@@ -133,6 +133,7 @@ class Labeled(events.Event):
         multiple labels. This allows you to iterate over the list of ``labels`` and
         do actions on it.
 
+        * ``label_added`` - Name of the label that was added during labeling
         * ``labels`` - A list of dicts, containing all the labels. Each label contains
             an ``id``, ``url``, `name``, ``color``, ``description``, ``default`` and
             ``node_id`` key.
@@ -140,6 +141,7 @@ class Labeled(events.Event):
 
         """
         super().__init__(*args, **kwargs)
+        self.label_added = label_added
         self.labels = labels
         self.state = state
 
@@ -147,7 +149,7 @@ class Labeled(events.Event):
 class Unlabeled(events.Event):
     """Event class that triggers when a label is removed from an issue/PR."""
 
-    def __init__(self, labels, state, *args, **kwargs):
+    def __init__(self, label_removed, labels, state, *args, **kwargs):
         """Event that is triggered when a user removes a label.
 
         If you have an issue/PR with multiple labels, you need to do some checking to
@@ -160,6 +162,7 @@ class Unlabeled(events.Event):
 
         Note that the labels list can be empty if we remove all the labels!
 
+        * ``label_removed`` - Name of the label that was removed during unlabeling
         * ``labels`` - A list of dicts, containing all the labels. Each label contains
             an ``id``, ``url``, `name``, ``color``, ``description``, ``default`` and
             ``node_id`` key.
@@ -167,6 +170,7 @@ class Unlabeled(events.Event):
 
         """
         super().__init__(*args, **kwargs)
+        self.label_removed = label_removed
         self.labels = labels
         self.state = state
 

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -458,6 +458,7 @@ async def test_receive_label(opsdroid, connector, mock_api, caplog):
 
     @match_event(github_event.Labeled)
     async def test_skill(opsdroid, config, event):
+        assert event.label_added == "bug"
         assert len(event.labels) == 1 and event.labels[0]["name"] == "bug"
         assert event.state == "open"
         logging.getLogger(__name__).info("Test skill complete")
@@ -486,7 +487,8 @@ async def test_receive_unlabel(opsdroid, connector, mock_api, caplog):
 
     @match_event(github_event.Unlabeled)
     async def test_skill(opsdroid, config, event):
-        assert event.labels == "bug"
+        assert event.label_removed == "bug"
+        assert len(event.labels) == 0
         assert event.state == "open"
         logging.getLogger(__name__).info("Test skill complete")
 

--- a/opsdroid/connector/github/tests/test_connector_github.py
+++ b/opsdroid/connector/github/tests/test_connector_github.py
@@ -140,8 +140,9 @@ async def test_do_not_send_to_self(opsdroid, connector, mock_api):
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_receive_comment(opsdroid, connector, mock_api):
+async def test_receive_comment(opsdroid, connector, mock_api, caplog):
     """Test a comment create event creates a message and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.IssueCommented)
     async def test_skill(opsdroid, config, event):
@@ -154,6 +155,7 @@ async def test_receive_comment(opsdroid, connector, mock_api):
             == "https://api.github.com/repos/opsdroid/opsdroid/issues/comments/439318644"
         )
         assert event.user == "jacobtomlinson"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -165,14 +167,17 @@ async def test_receive_comment(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_comment_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_receive_pr(opsdroid, connector, mock_api):
+async def test_receive_pr(opsdroid, connector, mock_api, caplog):
     """Test a PR create event creates a message and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.PROpened)
     async def test_skill(opsdroid, config, event):
@@ -180,6 +185,7 @@ async def test_receive_pr(opsdroid, connector, mock_api):
         assert event.target == "opsdroid/opsdroid-audio#175"
         assert event.title == "Update pytest-timeout to 1.3.3"
         assert event.description == "hello world"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -191,6 +197,8 @@ async def test_receive_pr(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_pr_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
@@ -199,6 +207,7 @@ async def test_receive_pr(opsdroid, connector, mock_api):
 @pytest.mark.asyncio
 async def test_close_pr(opsdroid, connector, mock_api, caplog):
     """Test a PR close event creates an event and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.PRClosed)
     async def test_skill(opsdroid, config, event):
@@ -207,6 +216,7 @@ async def test_close_pr(opsdroid, connector, mock_api, caplog):
         assert event.title == "Update pytest-timeout to 1.3.3"
         assert event.closed_by == "pyup-bot"
         assert event.user == "pyup-bot"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -218,6 +228,7 @@ async def test_close_pr(opsdroid, connector, mock_api, caplog):
             data=get_webhook_payload("github_pr_closed_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
         assert "Exception when running skill" not in caplog.text
 
 
@@ -257,8 +268,9 @@ async def test_pr_merged(opsdroid, connector, mock_api, caplog):
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_check_started(opsdroid, connector, mock_api):
+async def test_check_started(opsdroid, connector, mock_api, caplog):
     """Test a check started event creates an event and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.CheckStarted)
     async def test_skill(opsdroid, config, event):
@@ -267,6 +279,7 @@ async def test_check_started(opsdroid, connector, mock_api):
         assert not event.conclusion
         assert event.repository == "Hello-World"
         assert event.sender == "Codertocat"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -278,14 +291,17 @@ async def test_check_started(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_check_created_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_check_failed(opsdroid, connector, mock_api):
+async def test_check_failed(opsdroid, connector, mock_api, caplog):
     """Test a check failed event creates an event and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.CheckFailed)
     async def test_skill(opsdroid, config, event):
@@ -294,6 +310,7 @@ async def test_check_failed(opsdroid, connector, mock_api):
         assert event.conclusion == "failure"
         assert event.repository == "Hello-World"
         assert event.sender == "Codertocat"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -305,14 +322,17 @@ async def test_check_failed(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_check_failed_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_check_passed(opsdroid, connector, mock_api):
+async def test_check_passed(opsdroid, connector, mock_api, caplog):
     """Test a check passed event creates an event and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.CheckPassed)
     async def test_skill(opsdroid, config, event):
@@ -321,6 +341,7 @@ async def test_check_passed(opsdroid, connector, mock_api):
         assert event.conclusion == "success"
         assert event.repository == "Hello-World"
         assert event.sender == "Codertocat"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -332,14 +353,17 @@ async def test_check_passed(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_check_passed_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_check_completed(opsdroid, connector, mock_api):
+async def test_check_completed(opsdroid, connector, mock_api, caplog):
     """Test a check completed event creates an event and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.CheckCompleted)
     async def test_skill(opsdroid, config, event):
@@ -348,6 +372,7 @@ async def test_check_completed(opsdroid, connector, mock_api):
         assert event.conclusion == "timed_out"
         assert event.repository == "Hello-World"
         assert event.sender == "Codertocat"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -359,20 +384,24 @@ async def test_check_completed(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_check_completed_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_receive_issue(opsdroid, connector, mock_api):
+async def test_receive_issue(opsdroid, connector, mock_api, caplog):
     """Test a issue create event creates a message and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.IssueCreated)
     async def test_skill(opsdroid, config, event):
         assert event.user == "jacobtomlinson"
         assert event.title == "A test please ignore"
         assert event.description == "test"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -384,14 +413,17 @@ async def test_receive_issue(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_issue_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_received_issue_close(opsdroid, connector, mock_api):
+async def test_received_issue_close(opsdroid, connector, mock_api, caplog):
     """Test a issue close event creates an event and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.IssueClosed)
     async def test_skill(opsdroid, config, event):
@@ -400,6 +432,7 @@ async def test_received_issue_close(opsdroid, connector, mock_api):
         assert event.title == "Test integration"
         assert event.description == "this is a test for the integration"
         assert event.user == "FabioRosado"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -411,19 +444,23 @@ async def test_received_issue_close(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_issue_close_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_receive_label(opsdroid, connector, mock_api):
+async def test_receive_label(opsdroid, connector, mock_api, caplog):
     """Test a receive label event creates a message and parses it."""
+    caplog.set_level(logging.INFO)
 
-    @match_event(github_event.Unlabeled)
+    @match_event(github_event.Labeled)
     async def test_skill(opsdroid, config, event):
-        assert event.labels == "bug"
+        assert len(event.labels) == 1 and event.labels[0]["name"] == "bug"
         assert event.state == "open"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -435,19 +472,23 @@ async def test_receive_label(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_label_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(
     "/user", "GET", get_response_path("github_user.json"), status=200
 )
 @pytest.mark.asyncio
-async def test_receive_unlabel_event(opsdroid, connector, mock_api):
+async def test_receive_unlabel(opsdroid, connector, mock_api, caplog):
     """Test a unlabel event creates a message and parses it."""
+    caplog.set_level(logging.INFO)
 
     @match_event(github_event.Unlabeled)
     async def test_skill(opsdroid, config, event):
         assert event.labels == "bug"
         assert event.state == "open"
+        logging.getLogger(__name__).info("Test skill complete")
 
     opsdroid.register_skill(test_skill, config={"name": "test"})
 
@@ -459,6 +500,8 @@ async def test_receive_unlabel_event(opsdroid, connector, mock_api):
             data=get_webhook_payload("github_unlabel_payload.json"),
         )
         assert resp.status == 201
+        assert "Test skill complete" in caplog.text
+        assert "Exception when running skill" not in caplog.text
 
 
 @pytest.mark.add_response(


### PR DESCRIPTION
# Description

The labels field behaved differently (and inconsistent with documentation) depending on whether a `Label` or `Unlabel` event was being called. I made the `labels` field behave the same between the two events, and then added `label_added` and `label_removed` respectively in order to make this consistent.

Issue first mentioned in #1811 


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Updated the tests for this functionality in `test_connector_github.py`.


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
