### PR TITLE
Multistage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
 WORKDIR /usr/src/app
 
-ARG EXTRAS=.[all,connector_matrix_e2e]
+ARG EXTRAS=[all,connector_matrix_e2e]
 ENV DEPS_DIR=/usr/src/app/deps
 
 # Copy source
@@ -14,6 +14,7 @@ COPY . .
 RUN apk update \
     && apk add \
     build-base \
+    cargo \
     gcc \
     g++ \
     libffi-dev \
@@ -31,7 +32,7 @@ RUN apk update \
     setuptools-scm \
     wheel \
     && mkdir -p "${DEPS_DIR}" \
-    && pip download --use-feature=in-tree-build --prefer-binary -d ${DEPS_DIR} ${EXTRAS} \
+    && pip download --use-feature=in-tree-build --prefer-binary -d ${DEPS_DIR} .${EXTRAS} \
     && pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.tar.gz \
     && python -m build --wheel --outdir ${DEPS_DIR}
 
@@ -41,7 +42,7 @@ LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
 WORKDIR /usr/src/app
 
-ARG EXTRAS=.[all,connector_matrix_e2e]
+ARG EXTRAS=[all,connector_matrix_e2e]
 ENV DEPS_DIR=/usr/src/app/deps
 
 # Copy the pre-built dependencies.
@@ -52,7 +53,7 @@ RUN apk add --no-cache \
     git \
     libzmq \
     && pip install --no-cache-dir --no-index -f ${DEPS_DIR} \
-    ${DEPS_DIR}/opsdroid-0+unknown-py3-none-any.whl${EXTRAS} \
+    $(find ${DEPS_DIR} -type f -name opsdroid-*-any.whl)${EXTRAS} \
     && rm -rf /tmp/* /var/tmp/* ${DEPS_DIR}/* \
     && adduser -u 1001 -S -G root opsdroid
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,64 @@
-FROM python:3.8-alpine
+FROM python:3.9.6-alpine3.14 as builder
 LABEL maintainer="Jacob Tomlinson <jacob@tomlinson.email>"
+LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
 WORKDIR /usr/src/app
-ARG EXTRAS=.[all,connector_matrix_e2e]
+
+ARG EXTRAS=[all,connector_matrix_e2e]
+ENV DEPS_DIR=/usr/src/app/deps
 
 # Copy source
 COPY . .
 
+# Install build tools and libraries to build OpsDroid and its dependencies.
 RUN apk update \
-    && apk add --no-cache build-base linux-headers musl-dev python3-dev libzmq zeromq-dev git openssh-client olm olm-dev libffi-dev openssl-dev cargo \
-    && pip3 install --upgrade pip \
-    && pip3 install --no-cache-dir $EXTRAS \
-    && apk del build-base linux-headers musl-dev python3-dev zeromq-dev
+    && apk add \
+    build-base \
+    gcc \
+    g++ \
+    libffi-dev \
+    linux-headers \
+    musl-dev \
+    olm-dev \
+    openssh-client \
+    openssl-dev \
+    python3-dev \
+    zeromq-dev \
+    && pip install --upgrade \
+    build \
+    pip \
+    setuptools \
+    setuptools-scm \
+    wheel \
+    && mkdir -p "${DEPS_DIR}" \
+    && pip download --prefer-binary -d ${DEPS_DIR} .${EXTRAS} \
+    && pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.tar.gz \
+    && python -m build --wheel --outdir ${DEPS_DIR}
+
+FROM python:3.9.6-alpine3.14 as runtime
+LABEL maintainer="Jacob Tomlinson <jacob@tomlinson.email>"
+LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
+
+WORKDIR /usr/src/app
+
+ARG EXTRAS=[all,connector_matrix_e2e]
+ENV DEPS_DIR=/usr/src/app/deps
+
+# Copy the pre-built dependencies.
+COPY --from=builder ${DEPS_DIR}/*.whl ${DEPS_DIR}/
+
+# Install Opsdroid using only pre-built dependencies.
+RUN apk add --no-cache \
+    git \
+    libzmq \
+    && pip install --no-cache-dir --no-index -f ${DEPS_DIR} \
+    ${DEPS_DIR}/opsdroid-0+unknown-py3-none-any.whl${EXTRAS} \
+    && rm -rf /tmp/* /var/tmp/* ${DEPS_DIR}/* \
+    && adduser -u 1001 -S -G root opsdroid
 
 EXPOSE 8080
 
-CMD ["opsdroid", "start"]
+# Ensure the service runs as an unprivileged user.
+USER opsdroid
+ENTRYPOINT ["opsdroid"]
+CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.9.6-alpine3.14 as builder
 LABEL maintainer="Jacob Tomlinson <jacob@tomlinson.email>"
-LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update \
     build-base \
     cargo \
     gcc \
+    git \
     g++ \
     libffi-dev \
     linux-headers \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
 WORKDIR /usr/src/app
 
-ARG EXTRAS=[all,connector_matrix_e2e]
+ARG EXTRAS=.[all,connector_matrix_e2e]
 ENV DEPS_DIR=/usr/src/app/deps
 
 # Copy source
@@ -31,7 +31,7 @@ RUN apk update \
     setuptools-scm \
     wheel \
     && mkdir -p "${DEPS_DIR}" \
-    && pip download --prefer-binary -d ${DEPS_DIR} .${EXTRAS} \
+    && pip download --use-feature=in-tree-build --prefer-binary -d ${DEPS_DIR} ${EXTRAS} \
     && pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.tar.gz \
     && python -m build --wheel --outdir ${DEPS_DIR}
 
@@ -41,7 +41,7 @@ LABEL maintainer="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
 WORKDIR /usr/src/app
 
-ARG EXTRAS=[all,connector_matrix_e2e]
+ARG EXTRAS=.[all,connector_matrix_e2e]
 ENV DEPS_DIR=/usr/src/app/deps
 
 # Copy the pre-built dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ COPY --from=builder ${DEPS_DIR}/*.whl ${DEPS_DIR}/
 # Install Opsdroid using only pre-built dependencies.
 RUN apk add --no-cache \
     git \
+    olm \
     libzmq \
     && pip install --no-cache-dir --no-index -f ${DEPS_DIR} \
     $(find ${DEPS_DIR} -type f -name opsdroid-*-any.whl)${EXTRAS} \

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,9 +145,6 @@ docs =
   deadlinks>=0.3.2
   docutils==0.16
 
-[wheel]
-universal = 0
-
 [tool:pytest]
 testpaths = opsdroid tests
 norecursedirs = .git testing_config

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,7 +146,7 @@ docs =
   docutils==0.16
 
 [wheel]
-universal = 1
+universal = 0
 
 [tool:pytest]
 testpaths = opsdroid tests

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
      full: docker build -t opsdroid-image:tmp .
      docker run -it -d --name opsdroid-container opsdroid-image:tmp
      sleep 10
-     docker exec opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"
+     docker exec --user root opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"
      docker logs opsdroid-container
      docker stop opsdroid-container
      docker rm opsdroid-container

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ whitelist_externals =
     bash
     sleep
 commands =
-     min: docker build --build-arg EXTRAS=. -t opsdroid-image:tmp .
+     min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
      full: docker build -t opsdroid-image:tmp .
      docker run -it -d --name opsdroid-container opsdroid-image:tmp
      sleep 10


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #950

Updates the Dockerfile to leverage multi-stage build and ensure that the
runtime contains only the dependencies required to run OpsDroid.

The final image was updated to run as an unprivileged user.

The concepts used to build this new version of the Docker image mostly
come from Bitnami's recommendations:
https://engineering.bitnami.com/articles/best-practices-writing-a-dockerfile.html

The wheel unversal flag was removed since the project does not have C
extensions, nor supports Python 2 (see
https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
for reference).


## Status
**UNDER DEVELOPMENT**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->


Building and running the image locally.



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
