### PR TITLE
Add Push event for GitHub connector

### DIFF
--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -59,6 +59,11 @@ connectors:
 ```
 
 ```eval_rst
+.. autoclass:: opsdroid.connector.github.events.Push
+  :members:
+```
+
+```eval_rst
 .. autoclass:: opsdroid.connector.github.events.PROpened
   :members:
 ```

--- a/opsdroid/connector/github/events.py
+++ b/opsdroid/connector/github/events.py
@@ -254,6 +254,21 @@ class PRClosed(events.Event):
         self.closed_by = closed_by
 
 
+class Push(events.Event):
+    """Event class that triggers when one or more commits is pushed."""
+
+    def __init__(self, user, pushed_by, *args, **kwargs):
+        """Event that is triggered when commits are pushed.
+
+        * ``user`` - The user who created the event
+        * ``pushed_by`` - The user who pushed the commits
+
+        """
+        super().__init__(*args, **kwargs)
+        self.user = user
+        self.pushed_by = pushed_by
+
+
 class Labeled(events.Event):
     """Event class that triggers when an issue/PR is labeled.."""
 

--- a/opsdroid/connector/github/tests/github_response_payloads/push.json
+++ b/opsdroid/connector/github/tests/github_response_payloads/push.json
@@ -1,0 +1,203 @@
+{
+    "ref": "refs/heads/readme-change",
+    "before": "7978638dfbd41fb4523e94cb59391d4d3d2b5e70",
+    "after": "4ac7661c00d4395919efe6432e52a7d273c26ea2",
+    "repository": {
+        "id": 383694677,
+        "node_id": "MDEwOlJlcG9zaXRvcnkzODM2OTQ2Nzc=",
+        "name": "test-repo",
+        "full_name": "test-org/test-repo",
+        "private": false,
+        "owner": {
+            "name": "test-org",
+            "email": null,
+            "login": "test-org",
+            "id": 8030416,
+            "node_id": "MDEyOk9yZ2FuaXphdGlvbjgwMzA0MTY=",
+            "avatar_url": "https://avatars.githubusercontent.com/u/8030416?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/test-org",
+            "html_url": "https://github.com/test-org",
+            "followers_url": "https://api.github.com/users/test-org/followers",
+            "following_url": "https://api.github.com/users/test-org/following{/other_user}",
+            "gists_url": "https://api.github.com/users/test-org/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/test-org/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/test-org/subscriptions",
+            "organizations_url": "https://api.github.com/users/test-org/orgs",
+            "repos_url": "https://api.github.com/users/test-org/repos",
+            "events_url": "https://api.github.com/users/test-org/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/test-org/received_events",
+            "type": "Organization",
+            "site_admin": false
+        },
+        "html_url": "https://github.com/test-org/test-repo",
+        "description": "a test-repo repo",
+        "fork": false,
+        "url": "https://github.com/test-org/test-repo",
+        "forks_url": "https://api.github.com/repos/test-org/test-repo/forks",
+        "keys_url": "https://api.github.com/repos/test-org/test-repo/keys{/key_id}",
+        "collaborators_url": "https://api.github.com/repos/test-org/test-repo/collaborators{/collaborator}",
+        "teams_url": "https://api.github.com/repos/test-org/test-repo/teams",
+        "hooks_url": "https://api.github.com/repos/test-org/test-repo/hooks",
+        "issue_events_url": "https://api.github.com/repos/test-org/test-repo/issues/events{/number}",
+        "events_url": "https://api.github.com/repos/test-org/test-repo/events",
+        "assignees_url": "https://api.github.com/repos/test-org/test-repo/assignees{/user}",
+        "branches_url": "https://api.github.com/repos/test-org/test-repo/branches{/branch}",
+        "tags_url": "https://api.github.com/repos/test-org/test-repo/tags",
+        "blobs_url": "https://api.github.com/repos/test-org/test-repo/git/blobs{/sha}",
+        "git_tags_url": "https://api.github.com/repos/test-org/test-repo/git/tags{/sha}",
+        "git_refs_url": "https://api.github.com/repos/test-org/test-repo/git/refs{/sha}",
+        "trees_url": "https://api.github.com/repos/test-org/test-repo/git/trees{/sha}",
+        "statuses_url": "https://api.github.com/repos/test-org/test-repo/statuses/{sha}",
+        "languages_url": "https://api.github.com/repos/test-org/test-repo/languages",
+        "stargazers_url": "https://api.github.com/repos/test-org/test-repo/stargazers",
+        "contributors_url": "https://api.github.com/repos/test-org/test-repo/contributors",
+        "subscribers_url": "https://api.github.com/repos/test-org/test-repo/subscribers",
+        "subscription_url": "https://api.github.com/repos/test-org/test-repo/subscription",
+        "commits_url": "https://api.github.com/repos/test-org/test-repo/commits{/sha}",
+        "git_commits_url": "https://api.github.com/repos/test-org/test-repo/git/commits{/sha}",
+        "comments_url": "https://api.github.com/repos/test-org/test-repo/comments{/number}",
+        "issue_comment_url": "https://api.github.com/repos/test-org/test-repo/issues/comments{/number}",
+        "contents_url": "https://api.github.com/repos/test-org/test-repo/contents/{+path}",
+        "compare_url": "https://api.github.com/repos/test-org/test-repo/compare/{base}...{head}",
+        "merges_url": "https://api.github.com/repos/test-org/test-repo/merges",
+        "archive_url": "https://api.github.com/repos/test-org/test-repo/{archive_format}{/ref}",
+        "downloads_url": "https://api.github.com/repos/test-org/test-repo/downloads",
+        "issues_url": "https://api.github.com/repos/test-org/test-repo/issues{/number}",
+        "pulls_url": "https://api.github.com/repos/test-org/test-repo/pulls{/number}",
+        "milestones_url": "https://api.github.com/repos/test-org/test-repo/milestones{/number}",
+        "notifications_url": "https://api.github.com/repos/test-org/test-repo/notifications{?since,all,participating}",
+        "labels_url": "https://api.github.com/repos/test-org/test-repo/labels{/name}",
+        "releases_url": "https://api.github.com/repos/test-org/test-repo/releases{/id}",
+        "deployments_url": "https://api.github.com/repos/test-org/test-repo/deployments",
+        "created_at": 1625638821,
+        "updated_at": "2021-07-07T06:34:51Z",
+        "pushed_at": 1628961498,
+        "git_url": "git://github.com/test-org/test-repo.git",
+        "ssh_url": "git@github.com:test-org/test-repo.git",
+        "clone_url": "https://github.com/test-org/test-repo.git",
+        "svn_url": "https://github.com/test-org/test-repo",
+        "homepage": null,
+        "size": 2,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": null,
+        "has_issues": true,
+        "has_projects": true,
+        "has_downloads": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "forks_count": 0,
+        "mirror_url": null,
+        "archived": false,
+        "disabled": false,
+        "open_issues_count": 3,
+        "license": null,
+        "forks": 0,
+        "open_issues": 3,
+        "watchers": 0,
+        "default_branch": "main",
+        "stargazers": 0,
+        "master_branch": "main",
+        "organization": "test-org"
+    },
+    "pusher": {
+        "name": "test-user",
+        "email": "test-user@gmail.com"
+    },
+    "organization": {
+        "login": "test-org",
+        "id": 8030416,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjgwMzA0MTY=",
+        "url": "https://api.github.com/orgs/test-org",
+        "repos_url": "https://api.github.com/orgs/test-org/repos",
+        "events_url": "https://api.github.com/orgs/test-org/events",
+        "hooks_url": "https://api.github.com/orgs/test-org/hooks",
+        "issues_url": "https://api.github.com/orgs/test-org/issues",
+        "members_url": "https://api.github.com/orgs/test-org/members{/member}",
+        "public_members_url": "https://api.github.com/orgs/test-org/public_members{/member}",
+        "avatar_url": "https://avatars.githubusercontent.com/u/8030416?v=4",
+        "description": "A Loannister always pays his debts"
+    },
+    "sender": {
+        "login": "test-user",
+        "id": 34076,
+        "node_id": "MDQ6VXNlcjM0MDc2",
+        "avatar_url": "https://avatars.githubusercontent.com/u/34076?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/test-user",
+        "html_url": "https://github.com/test-user",
+        "followers_url": "https://api.github.com/users/test-user/followers",
+        "following_url": "https://api.github.com/users/test-user/following{/other_user}",
+        "gists_url": "https://api.github.com/users/test-user/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/test-user/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/test-user/subscriptions",
+        "organizations_url": "https://api.github.com/users/test-user/orgs",
+        "repos_url": "https://api.github.com/users/test-user/repos",
+        "events_url": "https://api.github.com/users/test-user/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/test-user/received_events",
+        "type": "User",
+        "site_admin": false
+    },
+    "created": false,
+    "deleted": false,
+    "forced": false,
+    "base_ref": null,
+    "compare": "https://github.com/test-org/test-repo/compare/7978638dfbd4...4ac7661c00d4",
+    "commits": [
+        {
+            "id": "4ac7661c00d4395919efe6432e52a7d273c26ea2",
+            "tree_id": "b618e2427d1292a8e1838ec40fe0673d595eccce",
+            "distinct": true,
+            "message": "Readme change 3",
+            "timestamp": "2021-08-14T12:18:10-05:00",
+            "url": "https://github.com/test-org/test-repo/commit/4ac7661c00d4395919efe6432e52a7d273c26ea2",
+            "author": {
+                "name": "Ajit D'Sa",
+                "email": "adsa@planview.com",
+                "username": "test-user"
+            },
+            "committer": {
+                "name": "Ajit D'Sa",
+                "email": "adsa@planview.com",
+                "username": "test-user"
+            },
+            "added": [
+
+            ],
+            "removed": [
+
+            ],
+            "modified": [
+                "README.md"
+            ]
+        }
+    ],
+    "head_commit": {
+        "id": "4ac7661c00d4395919efe6432e52a7d273c26ea2",
+        "tree_id": "b618e2427d1292a8e1838ec40fe0673d595eccce",
+        "distinct": true,
+        "message": "Readme change 3",
+        "timestamp": "2021-08-14T12:18:10-05:00",
+        "url": "https://github.com/test-org/test-repo/commit/4ac7661c00d4395919efe6432e52a7d273c26ea2",
+        "author": {
+            "name": "Ajit D'Sa",
+            "email": "adsa@planview.com",
+            "username": "test-user"
+        },
+        "committer": {
+            "name": "Ajit D'Sa",
+            "email": "adsa@planview.com",
+            "username": "test-user"
+        },
+        "added": [
+
+        ],
+        "removed": [
+
+        ],
+        "modified": [
+            "README.md"
+        ]
+    }
+}


### PR DESCRIPTION
# Description

Adding an event that triggers when a user pushes commits to a branch in Github.


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

Added a test in `test_connector_github.py` for this functionality. Also tested manually with my own github account.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
