### PR TITLE
Update the docs/conf.py file to fix the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,10 +12,10 @@ from recommonmark.transform import AutoStructify
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../opsdroid'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ html_theme_options = {
     "code_font_family": "'Fira Code', monospace",
 }
 
-autodoc_mock_imports = ['jwt', 'motor']
+autodoc_mock_imports = ["jwt", "motor"]
 
 # -- Recommonmark ------------------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,10 +12,10 @@ from recommonmark.transform import AutoStructify
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../opsdroid'))
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -71,6 +71,8 @@ html_theme_options = {
     "font_family": "'Montserrat', sans-serif",
     "code_font_family": "'Fira Code', monospace",
 }
+
+autodoc_mock_imports = ['jwt', 'motor']
 
 # -- Recommonmark ------------------------------------------------------------
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The docs build is broken in opsdroid workflows.
See here: https://readthedocs.org/projects/opsdroid/builds/14715423/

I used the following to fix the issue:
https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports

## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

This has been tested in the ci and succeeds now:
https://readthedocs.org/projects/opsdroid/builds/14716702/

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
