### PR TITLE
Fixed an errant entry into the MongoDB documentation

### DIFF
--- a/docs/databases/mongo.md
+++ b/docs/databases/mongo.md
@@ -22,13 +22,13 @@ databases:
 ## Usage
 This module helps opsdroid to persist memory using a MongoDB database.
 
-If desired, you can specify a default collection in the database configuration, but specify a different collection per call. Code that doesn't specify a collection name will be placed into the collection specified in the mongo database configuration.
 ```python
-await opsdroid.memory.put(key, value, collection_name='example_collection')
-await opsdroid.memory.get(key, collection_name='example_collection')
+await opsdroid.memory.put(key, value)
+await opsdroid.memory.get(key)
+await opsdroid.memory.delete(key)
 ```
 
-An addition to the usual use of memory, the mongo database provides a context manager `memory_in_collection` to perform some operations in a collection other than the one specified in the configuration.
+In addition to the usual use of memory, the mongo database provides a context manager `memory_in_collection` to perform some operations in a collection other than the one specified in the configuration.
 
 ```
 async with opsdroid.get_database("mongo").memory_in_colection("new_collection") as new_db:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When I was originally working on the Mongo functionality, I had proposed a change for the "default_collection_name" in the main configuration, as well as the ability to specify a "collection_name" per call. However, upon discussion with opsdroid devs, we decided instead to implement a context manager similar to another database such as not to change the API. I made the required changes, but it looks as though I missed removing one of the documentation changes related to this. So I'm correcting that now.

## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

n/a

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
