### PR TITLE
Use aioredis 2.0 for redis database

### DIFF
--- a/opsdroid/database/redis/tests/test_redis.py
+++ b/opsdroid/database/redis/tests/test_redis.py
@@ -31,7 +31,9 @@ def test_init(caplog):
 async def test_connect(mocker, caplog):
     caplog.set_level(logging.DEBUG)
     database = RedisDatabase({})
-    mocked_connection = mocker.patch("aioredis.create_pool")
+    mocked_connection = mocker.patch(
+        "aioredis.Redis.ping", return_value=return_async_value(True)
+    )
 
     await database.connect()
 
@@ -43,7 +45,7 @@ async def test_connect(mocker, caplog):
 async def test_connect_failure(mocker, caplog):
     caplog.set_level(logging.DEBUG)
     database = RedisDatabase({})
-    mocked_connection = mocker.patch("aioredis.create_pool", side_effect=OSError)
+    mocked_connection = mocker.patch("aioredis.Redis.ping", side_effect=OSError)
 
     with suppress(OSError):
         await database.connect()
@@ -57,13 +59,15 @@ async def test_get(mocker, caplog):
     caplog.set_level(logging.DEBUG)
     database = RedisDatabase({})
     database.client = mocker.Mock()
-    attrs = {"execute.return_value": return_async_value('{"data_key":"data_value"}')}
+    attrs = {
+        "execute_command.return_value": return_async_value('{"data_key":"data_value"}')
+    }
     database.client.configure_mock(**attrs)
 
     result = await database.get("key")
 
     assert result == dict(data_key="data_value")
-    database.client.execute.assert_called_with("GET", "key")
+    database.client.execute_command.assert_called_with("GET", "key")
     assert "Getting" in caplog.text
 
 
@@ -72,7 +76,7 @@ async def test_get_return_none(mocker, caplog):
     caplog.set_level(logging.DEBUG)
     database = RedisDatabase({})
     database.client = mocker.Mock()
-    attrs = {"execute.return_value": return_async_value(None)}
+    attrs = {"execute_command.return_value": return_async_value(None)}
     database.client.configure_mock(**attrs)
 
     result = await database.get("key")
@@ -86,12 +90,12 @@ async def test_put(mocker, caplog):
     caplog.set_level(logging.DEBUG)
     database = RedisDatabase({})
     database.client = mocker.Mock()
-    attrs = {"execute.return_value": return_async_value("None")}
+    attrs = {"execute_command.return_value": return_async_value("None")}
     database.client.configure_mock(**attrs)
 
     await database.put("key", dict(data_key="data_value"))
 
-    database.client.execute.assert_called_with(
+    database.client.execute_command.assert_called_with(
         "SET", "key", json.dumps(dict(data_key="data_value"), cls=JSONEncoder)
     )
     assert "Putting" in caplog.text
@@ -102,12 +106,12 @@ async def test_delete(mocker, caplog):
     caplog.set_level(logging.DEBUG)
     database = RedisDatabase({})
     database.client = mocker.Mock()
-    attrs = {"execute.return_value": return_async_value("None")}
+    attrs = {"execute_command.return_value": return_async_value("None")}
     database.client.configure_mock(**attrs)
 
     await database.delete("key")
 
-    database.client.execute.assert_called_with("DEL", "key")
+    database.client.execute_command.assert_called_with("DEL", "key")
     assert "Deleting" in caplog.text
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,7 @@ parser_watson =
   ibm-watson>=4.4.1
 # databases
 database_redis =
-  aioredis>=1.3.1,<2
+  aioredis>=2
 database_sqlite =
   aiosqlite>=0.15.0
 database_mongo =


### PR DESCRIPTION
# Description

This pull request makes use of aioredis 2.0 I decided to keep disconnect function even though it is not required anymore, see [aioredis docs](https://aioredis.readthedocs.io/en/latest/migration/#cleaning-up)
I removed setting the parser as aioredis will fall back to pure-python implementation if hiredis is not installed.
Also creating the instance no longer connects, so to keep existing behaviour I added ping command

Fixes #1810 

Also, I am glad to annually return to contribute to opsdroid this hacktoberfest! The best project, really :tada: 

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With sample skill `skill.py`

```
import random

from opsdroid.matchers import match_regex
from opsdroid.skill import Skill


class HelloSkill(Skill):
    @match_regex(r"hi|hello")
    async def hello(self, message):
        await message.respond("Hey")
        await self.opsdroid.memory.put(random.randint(1, 10), "test")
```

![изображение](https://user-images.githubusercontent.com/39452697/135505325-6d63fe2c-bf98-4cc7-829c-f547f091e2bd.png)
![изображение](https://user-images.githubusercontent.com/39452697/135505351-f298e741-39f8-4a7c-bd06-34be3baa0e5d.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
