### PR TITLE
Deploy docker images to github container registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,7 @@ jobs:
         images: |
           ghcr.io/${{ github.repository_owner }}/opsdroid
         tags: |
-          type=semver,pattern={{version}}
-          type=raw,value=latest
+          type=semver,pattern={{raw}}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to GitHub Container Registry

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish python package
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist
-        twine upload dist/*
+    # - name: Build and publish python package
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: |
+    #     python setup.py sdist
+    #     twine upload dist/*
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1 
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,11 +29,17 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
+          ${{ secrets.DOCKERHUB_REPO }}
           ghcr.io/${{ github.repository_owner }}/opsdroid
         tags: |
           type=semver,pattern={{raw}}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+    - name: Login to Dockerhub
+      uses: docker/login-action@v1 
+      with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1 
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,23 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
+    - name: Build and publish python package
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist
         twine upload dist/*
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1 
+      with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/opsdroid:latest
+          ghcr.io/${{ github.repository_owner }}/opsdroid:${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,17 @@ jobs:
     #   run: |
     #     python setup.py sdist
     #     twine upload dist/*
+    - name: Docker meta
+      id: docker_meta
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/opsdroid
+        tags: |
+          type=semver,pattern={{version}}
+          type=raw,value=latest
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1 
       with:
@@ -34,6 +45,4 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: |
-          ghcr.io/${{ github.repository_owner }}/opsdroid:latest
-          ghcr.io/${{ github.repository_owner }}/opsdroid:${{ github.event.release.tag_name }}
+        tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,3 +45,4 @@ jobs:
       with:
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    # - name: Build and publish python package
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     python setup.py sdist
-    #     twine upload dist/*
+    - name: Build and publish python package
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist
+        twine upload dist/*
     - name: Docker meta
       id: docker_meta
       uses: docker/metadata-action@v3

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,10 +68,10 @@ for a list of all the modules you can install this way.
 
 ```bash
 # Pull the container image
-$ docker pull opsdroid/opsdroid:latest
+$ docker pull ghcr.io/opsdroid/opsdroid:latest
 
 # Run the container
-$ docker run --rm -it -v /path/to/config_folder:/root/.config/opsdroid opsdroid/opsdroid:latest
+$ docker run --rm -it -v /path/to/config_folder:/root/.config/opsdroid ghcr.io/opsdroid/opsdroid:latest
 ```
 
 The default docker image on Docker Hub contains all the module dependencies. To
@@ -88,7 +88,7 @@ $ docker build --build-arg EXTRAS=.[common] .
 $ docker config create OpsdroidConfig /path/to/configuration.yaml
 
 # Create the service
-$ docker service create --name opsdroid --config source=OpsdroidConfig,target=/root/.config/opsdroid/configuration.yaml --mount 'type=volume,src=OpsdroidData,dst=/root/.config/opsdroid' opsdroid/opsdroid:latest
+$ docker service create --name opsdroid --config source=OpsdroidConfig,target=/root/.config/opsdroid/configuration.yaml --mount 'type=volume,src=OpsdroidData,dst=/root/.config/opsdroid' ghcr.io/opsdroid/opsdroid:latest
 ```
 
 ### Docker Swarm
@@ -107,7 +107,7 @@ version: "3.5"
 services:
 
   opsdroid:
-    image: opsdroid/opsdroid:latest
+    image: ghcr.io/opsdroid/opsdroid:latest
     networks:
       - opsdroid
     volumes:

--- a/docs/maintaining/making-a-release.md
+++ b/docs/maintaining/making-a-release.md
@@ -11,7 +11,7 @@ Currently opsdroid builds:
 
 - A Python distribution on [pypi](https://pypi.org/project/opsdroid/)
 - A Python distribution on [Conda Forge](https://github.com/conda-forge/opsdroid-feedstock)
-- A container image on [Docker Hub](https://hub.docker.com/r/opsdroid/opsdroid/)
+- A container image on [Docker Hub](https://hub.docker.com/r/opsdroid/opsdroid/) and [Github container registry](https://github.com/opsdroid/opsdroid/pkgs/container/opsdroid)
 
 The building and distributing is automated by Travis CI and run when a [release is created](https://help.github.com/articles/creating-releases/) on GitHub.
 
@@ -52,7 +52,7 @@ This will result in a number of automated actions:
 
 - The new [release tag](https://github.com/opsdroid/opsdroid/tags) will be created on GitHub.
 - [Travis CI](https://travis-ci.org/opsdroid/opsdroid) will build the [pypi distribution](https://pypi.python.org/pypi/opsdroid) and upload it.
-- [Docker Hub](https://hub.docker.com/r/opsdroid/opsdroid/) will build a new container image, create the [new release tag](https://hub.docker.com/r/opsdroid/opsdroid/tags/) and also update `latest` to point to this release.
+- [Docker Hub](https://hub.docker.com/r/opsdroid/opsdroid/) and [Github container registry](https://github.com/opsdroid/opsdroid/pkgs/container/opsdroid) will build a new container image, create the [new release tag](https://hub.docker.com/r/opsdroid/opsdroid/tags/) and also update `latest` to point to this release.
 - The @opsdroid [twitter account](https://twitter.com/opsdroid) will tweet that the release has been generated (via [IFTTT](https://ifttt.com)).
 
 There are also the following manual actions which need to be performed:


### PR DESCRIPTION
# Description

Fixes #1723

By the way dockerhub pushes can be also done by this CI easily (with no additional time spent), should I add it too?
Not sure about `dev` tag or how is it got, only modified the `deploy` workflow
I didn't pass any additional build args to docker build
Metadata action is used for username normalization (always lowercase) and creation of opencontainers labels


## Status
**READY**

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)

# How Has This Been Tested?

Created a sample release on my repo with tag `v0.24.0`, github actions run:
https://github.com/MrNaif2018/opsdroid/actions/runs/1296702637
It successfully created `latest` and `v0.24.0` tags on container registry:
https://github.com/MrNaif2018/opsdroid/pkgs/container/opsdroid

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
