### PR TITLE
Add label configs for the new teams connector

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,8 @@ connector/webexteams:
   - opsdroid/connector/webexteams/**/*
 connector/websocket:
   - opsdroid/connector/websocket/**/*
+connector/teams:
+  - opsdroid/connector/teams/**/*
 
 database:
   - opsdroid/database/**/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,9 @@ categories:
   - title: 'Slack Connector Changes'
     labels:
       - 'connector/slack'
+  - title: 'Teams Connector Changes'
+    labels:
+      - 'connector/teams'
   - title: 'Telegram Connector Changes'
     labels:
       - 'connector/telegram'


### PR DESCRIPTION
We added and new connector but none of the labels or changelog stuff.