### PR TITLE
changing conf dir in installation.md from root to home/opsdroid

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ for a list of all the modules you can install this way.
 $ docker pull ghcr.io/opsdroid/opsdroid:latest
 
 # Run the container
-$ docker run --rm -it -v /path/to/config_folder:/root/.config/opsdroid ghcr.io/opsdroid/opsdroid:latest
+$ docker run --rm -it -v /path/to/config_folder:/home/opsdroid/.config/opsdroid ghcr.io/opsdroid/opsdroid:latest
 ```
 
 The default docker image on Docker Hub contains all the module dependencies. To
@@ -88,7 +88,7 @@ $ docker build --build-arg EXTRAS=.[common] .
 $ docker config create OpsdroidConfig /path/to/configuration.yaml
 
 # Create the service
-$ docker service create --name opsdroid --config source=OpsdroidConfig,target=/root/.config/opsdroid/configuration.yaml --mount 'type=volume,src=OpsdroidData,dst=/root/.config/opsdroid' ghcr.io/opsdroid/opsdroid:latest
+$ docker service create --name opsdroid --config source=OpsdroidConfig,target=/home/opsdroid/.config/opsdroid/configuration.yaml --mount 'type=volume,src=OpsdroidData,dst=/home/opsdroid/.config/opsdroid' ghcr.io/opsdroid/opsdroid:latest
 ```
 
 ### Docker Swarm
@@ -111,10 +111,10 @@ services:
     networks:
       - opsdroid
     volumes:
-      -  opsdroid:/root/.config/opsdroid
+      -  opsdroid:/home/opsdroid/.config/opsdroid
     configs:
       -  source: opsdroid_conf
-         target: /root/.config/opsdroid/configuration.yaml
+         target: /home/opsdroid/.config/opsdroid/configuration.yaml
     deploy:
       restart_policy:
         condition: any


### PR DESCRIPTION
# Description

Currently, https://github.com/opsdroid/opsdroid/blob/e8dd6b099b3756acc79eb65aa56689f4f111bcab/docs/installation.md states `/root/.config/opsdroid` as the directory to sore `configuration.yaml` for docker instances. Now that docker images have been updated to no longer run as root, rather a user, `opsdroid`, this updates the documentation for that reason.

I see no issue about this (yet).

## Status
**READY**


## Type of change

- Documentation (fix or adds documentation)


# How Has This Been Tested?

It has not.


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] New and existing unit tests pass locally with my changes
