### PR TITLE
Update example config and slack docs

### DIFF
--- a/docs/connectors/gitter.md
+++ b/docs/connectors/gitter.md
@@ -32,5 +32,9 @@ To use the Gitter connector you will need a user for the bot to use and generate
 ```yaml
 connectors:
   gitter:
-    room-id: "to be added" #required
-    token: "to be added" #required
+    # Required
+    room-id: "to be added"
+    token: "to be added"
+    # optional
+    bot-name: opsdroid # default 'opsdroid'
+```

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -44,7 +44,7 @@ connectors:
     bot-name: "mybot" # default "opsdroid" **
     icon-emoji: ":smile:" # default ":robot_face:" **
     default-room: "#random" # default "#general"
-    start_thread: false # default false. if true, opsdroid will start a thread when replying to a message
+    start-thread: false # default false. if true, opsdroid will start a thread when replying to a message
 ```
 
 \* when `socket-mode` is true, you need to set also an `app-token` (more info: [app level tokens](https://api.slack.com/authentication/token-types#app))
@@ -57,21 +57,32 @@ You need to choose between two backends. The [Events API](https://api.slack.com/
 
 If you are unsure which one is the best for you, [Slack Faq](https://api.slack.com/faq#events_api) provide differences between those two.
 
-**Socket Mode**
+```eval_rst
+.. note::
+  You should follow the instructions for the Event API first when configuring your slack connector, even if you are planning
+  on using slack in Socket Mode.
+```
 
-_Note:_ Due to a Slack inconsistency, you will need to complete the *Events API* instructions below first before setting up Socket Mode. The reason for this is that the Request URL verification step is needed and is only available via the *Events API*.
-* Go to your [Slack App](https://api.slack.com/apps)
-* On the left column go to "Socket Mode" and set the "Enable Socket Mode" toggle to enabled.
-* Make sure to set `socket-mode` to `true` in your Opsdroid configuration.
-* Copy your new token add add it to your Opsdroid configuration file as your `app-token`. (the `app-token` will start with `xapp-abcdef-1233`)
+
 
 **Events API**
+
 * Make sure to set `socket-mode` to `false` in your Opsdroid configuration.
 * You will need an **endpoint** which exposes your Opsdroid to the **internet**. [Exposing Opsdroid via tunnels](https://docs.opsdroid.dev/en/latest/exposing.html) might help out.
 * Go to your [Slack App](https://api.slack.com/apps)
 * On the left column go to "Socket Mode" and make sure the "Enable Socket Mode" toggle is set to disabled.
 * On the left column go to "Event Subscriptions" and set the "Enable Events" toggle to enabled.
 * Under "Request URL" add the `/connector/slack` uri to your endpoint: https://slackbot.example.com/connector/slack. Note that you will have to have your Opsdroid instance running so Slack can verify the endpoint.
+
+**Socket Mode**
+
+ Mode. The reason for this is that the Request URL verification step is needed and is only available via the *Events API*.
+* Go to your [Slack App](https://api.slack.com/apps)
+* On the left column go to "Socket Mode" and set the "Enable Socket Mode" toggle to enabled.
+* Make sure to set `socket-mode` to `true` in your Opsdroid configuration.
+* Copy your new token add add it to your Opsdroid configuration file as your `app-token`. (the `app-token` will start with `xapp-abcdef-1233`)
+
+
 
 ### Subscribe to events
 You will need to subscribe to events in your new Slack App, so Opsdroid can receive those events. 

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -166,7 +166,7 @@ connectors:
 #  ## Mattermost (core)
 #  mattermost:
 #    # Required
-#    api-token: "zyxw-abdcefghi-12345"
+#    token: "zyxw-abdcefghi-12345"
 #    url: "mattermost.server.com"
 #    team-name: "myteam"
 #    # Optional
@@ -200,16 +200,24 @@ connectors:
 #      - user1
 #      - user2
 #
+#  ## Teams (core)
+#  teams:
+#    # Required
+#    app-id: "yourappid"
+#    password: "yourpassword"
+#    # Optional
+#    bot-name: "mybot" # default "opsdroid"
 #  ## Slack (core)
 #  slack:
 #    # required
-#    token: "zyxw-abdcefghi-12345"
+#    bot-token: "zyxw-abdcefghi-12345"
 #    # optional
+#    socket-mode: false # default true
+#    app-token: "xapp-abdcfkje-12345" # socket-mode needs to be true
+#    start-thread: true # default false, if true opsdroid will reply in a thread
 #    bot-name: "mybot" # default "opsdroid"
 #    default-room: "#random" # default "#general"
 #    icon-emoji: ":smile:" # default ":robot_face:"
-#    connect-timeout: 10 # default 10 seconds
-#    chat-as-user: true # default false
 #
 #  ## Rocketchat (core)
 #  rocketchat:

--- a/opsdroid/connector/slack/connector.py
+++ b/opsdroid/connector/slack/connector.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = {
     "bot-name": str,
     "default-room": str,
     "icon-emoji": str,
-    "start_thread": bool,
+    "start-thread": bool,
 }
 
 
@@ -51,7 +51,7 @@ class ConnectorSlack(Connector):
         self.bot_name = config.get("bot-name", "opsdroid")
         self.default_target = config.get("default-room", "#general")
         self.icon_emoji = config.get("icon-emoji", ":robot_face:")
-        self.start_thread = config.get("start_thread", False)
+        self.start_thread = config.get("start-thread", False)
         self.socket_mode = config.get("socket-mode", True)
         self.app_token = config.get("app-token")
         self.ssl_context = ssl.create_default_context(cafile=certifi.where())
@@ -109,7 +109,7 @@ class ConnectorSlack(Connector):
                 _LOGGER.info(_("Connected successfully with socket mode"))
             else:
                 self.opsdroid.web_server.web_app.router.add_post(
-                    f"/connector/{self.name}".format(),
+                    f"/connector/{self.name}",
                     self.web_event_handler,
                 )
                 _LOGGER.info(_("Connected successfully with events api"))


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

While working on a skill for slack I've noticed that our example configuration was out of date and I had to look into the docs to figure out what was missing from the configuration. I've also noticed a small inconsistency on getting slack to work since I had to set `socket-mode` to false before I was able to start anything since slack was failing with an unhelpful message (it only mentioned that the configuration had changed).

This PR updates the example configuration so new users will have the right configuration params and moves the `Event mode` first in the slack docs and adds a note saying: HEY do this first!


## Status
**READY**

## Type of change

<!-- Please delete options that are not relevant. -->

- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Test A
- Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
