### PR TITLE
Add support for mongodb+srv:// urls in MongoDB backend

### DIFF
--- a/docs/databases/mongo.md
+++ b/docs/databases/mongo.md
@@ -11,12 +11,13 @@ An accessible MongoDB server with the database that you provide already created.
 ```yaml
 databases:
   mongo:
-    host:                       "my_host"       # (optional) default "localhost"
-    port:                       "12345"         # (optional) default "27017"
-    database:                   "my_database"   # (optional) default "opsdroid"
-    collection:                 "my_collection" # (optional) default "opsdroid"
-    user:                       "my_user"       # (optional)
-    password:                   "pwd123!"       # (optional)
+    host:                       "my_host"         # (optional) default "localhost"
+    port:                       "12345"           # (optional) default "27017"
+    database:                   "my_database"     # (optional) default "opsdroid"
+    protocol:                   "mongodb://"      # (optional) default "mongodb://"
+    collection:                 "my_collection"   # (optional) default "opsdroid"
+    user:                       "my_user"         # (optional)
+    password:                   "pwd123!"         # (optional)
 ```
 
 ## Usage

--- a/opsdroid/database/mongo/__init__.py
+++ b/opsdroid/database/mongo/__init__.py
@@ -44,17 +44,18 @@ class DatabaseMongo(Database):
     async def connect(self):
         """Connect to the database."""
         host = self.config.get("host", "localhost")
+        protocol = self.config.get("protocol", "mongodb").replace("://", "")
         port = self.config.get("port", "27017")
+        if port != "27017":
+            host = f"{host}:{port}"
         database = self.config.get("database", "opsdroid")
         user = self.config.get("user")
         pwd = self.config.get("password")
         if user and pwd:
-            path = "mongodb://{user}:{pwd}@{host}:{port}".format(
-                user=user, pwd=pwd, host=host, port=port
-            )
+            self.db_url = f"{protocol}://{user}:{pwd}@{host}"
         else:
-            path = "mongodb://{host}:{port}".format(host=host, port=port)
-        self.client = AsyncIOMotorClient(path)
+            self.db_url = f"{protocol}://{host}"
+        self.client = AsyncIOMotorClient(self.db_url)
         self.database = self.client[database]
         _LOGGER.info("Connected to MongoDB.")
 

--- a/opsdroid/database/mongo/tests/test_mongo.py
+++ b/opsdroid/database/mongo/tests/test_mongo.py
@@ -45,6 +45,7 @@ def test_init(database):
             "database": "test_db",
             "collection": "test_collection",
             "protocol": "mongodb://",
+            "port": "1234",
             "user": "root",
             "password": "mongo",
         },

--- a/opsdroid/database/mongo/tests/test_mongo.py
+++ b/opsdroid/database/mongo/tests/test_mongo.py
@@ -44,6 +44,7 @@ def test_init(database):
         {
             "database": "test_db",
             "collection": "test_collection",
+            "protocol": "mongodb://",
             "user": "root",
             "password": "mongo",
         },
@@ -53,6 +54,7 @@ async def test_connect(database):
     """Test that the mongo database has implemented connect function properly"""
     try:
         await database.connect()
+        assert "mongodb://" in database.db_url
     except NotImplementedError:
         raise Exception
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,7 @@ database_sqlite =
   aiosqlite>=0.15.0
 database_mongo =
   motor>=2.1.0
+  dnspython>=2.1.0
 database_matrix =
   wrapt>=1.12.1
 # testing


### PR DESCRIPTION
# Description

Added a new `protocol` configuration option to the MongoDB backend to support using `mongodb+srv://` URLs.

As that protocol doesn't support port numbers I also shuffled things a little so that if the default `27017` port is used it is omitted from the URL altogether. This protocol also requires the `dnspython` package so added that to the mongo extras install.

Fixes #1859


## Status
**READY** 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
