### PR TITLE
Start connectors before databases

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -184,8 +184,8 @@ class OpsDroid:
         if len(self.skills) == 0:
             self.critical(_("No skills in configuration, at least 1 required"), 1)
 
+        await self.start_databases()
         await self.start_connectors()
-        self.create_task(self.start_databases())
         self.create_task(self.watch_paths())
         self.create_task(parse_crontab(self))
         self.create_task(self.web_server.start())


### PR DESCRIPTION
Fixes #1863 

Some connectors like Teams use the database during the connect. Currently databases are started after connectors though. This doesn't seem to be a problem for the `sqlite` database as it creates a cursor during the `get` operation, but for others the database connection is not initialized correctly yet.

This PR runs the database connections before the connectors.