### PR TITLE
Pin dialogflow package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ connector_telegram =
   emoji>=0.6.0
 # parsers
 parser_dialogflow =
-  google-cloud-dialogflow>=0.8.0
+  dialogflow>=0.8.0,<=1.1.1
 parser_watson =
   ibm-watson>=4.4.1
 # databases

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ connector_telegram =
   emoji>=0.6.0
 # parsers
 parser_dialogflow =
-  dialogflow>=0.8.0
+  google-cloud-dialogflow>=0.8.0
 parser_watson =
   ibm-watson>=4.4.1
 # databases


### PR DESCRIPTION
Pin `dialogflow` as the latest release raises a `RuntimeError` to force folks to migrate to `v2`.

xref #1865 