### PR TITLE
Fix a typo in the Typing event

### DIFF
--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -319,7 +319,7 @@ class Typing(Event):  # pragma: nocover
         """Create the object."""
         self.timeout = timeout
         self.trigger = trigger
-        super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class Reaction(Event):


### PR DESCRIPTION
# Description

This is a simple typo fix for the `opsdroid.events.Typing` class. The `Typing.__init__` method was passing `self` to `super().__init__()` call, which is an error.

`self` would get passed to `Event.__init__` as the first argument, `user_id`.

## Status
**READY**

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I'm able to send typing events with that change.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
