### PR TITLE
Resolve docker image build - failing dep pycryptodome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apk update \
     && mkdir -p "${DEPS_DIR}" \
     && pip download --use-feature=in-tree-build --prefer-binary -d ${DEPS_DIR} .${EXTRAS} \
     && pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.tar.gz \
+    && count=$(ls -1 ${DEPS_DIR}/*.zip 2>/dev/null | wc -l) && if [ $count != 0 ]; then pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.zip ; fi \
     && python -m build --wheel --outdir ${DEPS_DIR}
 
 FROM python:3.9.6-alpine3.14 as runtime


### PR DESCRIPTION
# Description

This is to resolve the issue with the failing dependency pycryptodome on the docker image build.
The issue is that the docker build pulls down the pycryptodome dependency as a zip file rather than a whl or tar.gz (where tar.gz is correctly converted to a whl file). 
The simple fix is to convert the zip to a whl file so it is installed during the later stage of th build

Fixes #1874

## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested locally by running the docker build command: `docker build .` and the tox build command in the CI: `tox -vv -e docker-full`


# Checklist:

- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
