### PR TITLE
Rasanlu: Fix entiry extraction

### DIFF
--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -289,9 +289,18 @@ async def parse_rasanlu(opsdroid, skills, message, config):
                     if matcher["rasanlu_intent"] == result["intent"]["name"]:
                         message.rasanlu = result
                         for entity in result["entities"]:
-                            message.update_entity(
-                                entity["entity"], entity["value"], entity["confidence"]
-                            )
+                            if "confidence_entity" in entity:
+                                message.update_entity(
+                                    entity["entity"],
+                                    entity["value"],
+                                    entity["confidence_entity"],
+                                )
+                            elif "extractor" in entity:
+                                message.update_entity(
+                                    entity["entity"],
+                                    entity["value"],
+                                    entity["extractor"],
+                                )
                         matched_skills.append(
                             {
                                 "score": confidence,

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -131,7 +131,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                             "end": 32,
                             "entity": "state",
                             "extractor": "ner_crf",
-                            "confidence": 0.854,
+                            "confidence_entity": 0.854,
                             "start": 25,
                             "value": "running",
                         }
@@ -175,8 +175,32 @@ class TestParserRasaNLU(asynctest.TestCase):
                             "value": "chinese",
                             "entity": "cuisine",
                             "extractor": "CRFEntityExtractor",
-                            "confidence": 0.854,
+                            "confidence_entity": 0.854,
                             "processors": [],
+                        }
+                    ],
+                }
+                [skill] = await rasanlu.parse_rasanlu(
+                    opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
+                )
+
+                self.assertEqual(len(skill["message"].entities.keys()), 1)
+                self.assertTrue("cuisine" in skill["message"].entities.keys())
+                self.assertEqual(
+                    skill["message"].entities["cuisine"]["value"], "chinese"
+                )
+
+            with amock.patch.object(rasanlu, "call_rasanlu") as mocked_call_rasanlu:
+                mocked_call_rasanlu.return_value = {
+                    "text": "show me chinese restaurants",
+                    "intent": {"name": "restaurant_search", "confidence": 0.98343},
+                    "entities": [
+                        {
+                            "start": 8,
+                            "end": 15,
+                            "value": "chinese",
+                            "entity": "cuisine",
+                            "extractor": "RegexEntityExtractor",
                         }
                     ],
                 }
@@ -215,7 +239,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                             "end": 32,
                             "entity": "state",
                             "extractor": "ner_crf",
-                            "confidence": 0.854,
+                            "confidence_entity": 0.854,
                             "start": 25,
                             "value": "running",
                         }


### PR DESCRIPTION
# Description

The Rasa API states the key is 'confidence' but the fact is … the key is 'confidence_entity' for the entity extraction.

https://rasa.com/docs/rasa/pages/http-api#operation/parseModelMessage

Fixes #1887


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Run the following skill on the latest master branch of Opsdroid and Rasa-v2.8.19
`__init__.py`:
```
from opsdroid.matchers import match_rasanlu
from opsdroid.skill import Skill

import logging
import json

_LOGGER = logging.getLogger(__name__)

class MySkill(Skill):
    @match_rasanlu('price')
    async def price(self, message):
        ticker = message.get_entity('ticker')
        if ticker != None:
            await message.respond("Sure I can get you the price for {}".format(ticker))
        else:
            _LOGGER.error("Couldn't extract entity from: {}".format(message.text))
```
`configuration.yaml`:
```
welcome-message: false
logging:
  level: debug
connectors:
  websocket:
parsers:
  rasanlu:
    url: http://XXXXXXX:5005
    token: XXXXXXX
    min-score: 0.8

skills:
  rasa-test:
    path: /some-path/rasa_entity_extraction_skill
```
`intents.yml`:
```
version: "2.0"

intents:
  - greetings
  - add
  - bye
  - price:
      use_entities:
        - ticker
  - add stock

entities:
  - ticker

nlu:
- intent: greetings
  examples: |
    - Hii
    - hi
    - hey
    - Hello
    - Heya
    - wassup

- intent: add
  examples: |
    - add stock AAPL for 9 days
    - add stock MSFT 12 to monitor list
    - add my stock GOOG 19
    - add TSLA 14  days

- intent: Bye
  examples: |
    - Bye
    - bie
    - by
    - see you
    - see ya


- intent: this_is_funny
  examples: |
    - This is funny
    - That's a funny one
    - Hahaha
    - That's a good one

- intent: price
  examples: |
    - current price of [TSLA]{"entity":"ticker"}
    - tell me current price of [AMZN]{"entity":"ticker"}
    - I want to know the current price of [NSRGY]{"entity":"ticker"}
    - tell me about the current price of [AAPL]{"entity":"ticker"}
    - Can you tell me the current price of [HDB]{"entity":"ticker"}
    - current price of [KOTAKBANK.NS]{"entity":"ticker"}
    - Please tell me the current price of [ZM]{"entity":"ticker"}
    - current price of [RELIANCE.NS]{"entity":"ticker"}
```

# Checklist:

- [x] I have performed a self-review of my own code
- ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
