### PR TITLE
Docker: opsdroid should not be a member of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apk add --no-cache \
     && pip install --no-cache-dir --no-index -f ${DEPS_DIR} \
     $(find ${DEPS_DIR} -type f -name opsdroid-*-any.whl)${EXTRAS} \
     && rm -rf /tmp/* /var/tmp/* ${DEPS_DIR}/* \
-    && adduser -u 1001 -S -G root opsdroid
+    && adduser -u 1001 -D opsdroid
 
 EXPOSE 8080
 


### PR DESCRIPTION
There is no need that the user opsdroid is member
of the group root. It is also not an system account since
it has an uid > 999. Instead set no password.

# Description

Changes the usergroup of the opsdroid user.

## Status

**READY**


## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

For people using the container this might be a breaking change depending on how they use volumes/binds for the container.
If they rely on the current group it will break.

# How Has This Been Tested?

Running tox.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
