### PR TITLE
Handle wit.ai api response when multiple values are returned

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/opsdroid/parsers/witai.py
+++ b/opsdroid/parsers/witai.py
@@ -68,10 +68,12 @@ async def parse_witai(opsdroid, skills, message, config):
                             message.witai = result
                             for key, entity in result["entities"].items():
                                 if key != "intent":
-                                    witai_entity_value = ''
-                                    if 'value' in entity[0]:
+                                    witai_entity_value = ""
+                                    if "value" in entity[0]:
                                         witai_entity_value = entity[0]["value"]
-                                    elif 'values' in entity[0]:
+                                    elif "values" in entity[0]:
+                                        # we never know which data are important for user,
+                                        # so we return list with all values
                                         witai_entity_value = entity[0]["values"]
 
                                     message.update_entity(

--- a/opsdroid/parsers/witai.py
+++ b/opsdroid/parsers/witai.py
@@ -68,8 +68,14 @@ async def parse_witai(opsdroid, skills, message, config):
                             message.witai = result
                             for key, entity in result["entities"].items():
                                 if key != "intent":
+                                    witai_entity_value = ''
+                                    if 'value' in entity[0]:
+                                        witai_entity_value = entity[0]["value"]
+                                    elif 'values' in entity[0]:
+                                        witai_entity_value = entity[0]["values"]
+
                                     message.update_entity(
-                                        key, entity[0]["value"], entity[0]["confidence"]
+                                        key, witai_entity_value, entity[0]["confidence"]
                                     )
                             matched_skills.append(
                                 {


### PR DESCRIPTION
# Description

Handle wit.ai api response that includes `values` field instead of `value`.

In tests I've renamed old test with single `value` and added new test with `values`

```dif
-    async def test_parse_witai_entities(self):
+    async def test_parse_witai_entities_single_value(self):
...
+    async def test_parse_witai_entities_multiple_values(self):
```

Payload examples and issue description - #1900 

Fixes #1900 


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- sent message to wit.ai with time range that returns `values` field using `aws cost since december` message

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
