### PR TITLE
fix: Remove obsolete in-tree-build are from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk update \
     setuptools-scm \
     wheel \
     && mkdir -p "${DEPS_DIR}" \
-    && pip download --use-feature=in-tree-build --prefer-binary -d ${DEPS_DIR} .${EXTRAS} \
+    && pip download --prefer-binary -d ${DEPS_DIR} .${EXTRAS} \
     && pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.tar.gz \
     && count=$(ls -1 ${DEPS_DIR}/*.zip 2>/dev/null | wc -l) && if [ $count != 0 ]; then pip wheel -w ${DEPS_DIR} ${DEPS_DIR}/*.zip ; fi \
     && python -m build --wheel --outdir ${DEPS_DIR}


### PR DESCRIPTION
As of pip 21.3[^1] the in-tree-build feature has been the default.

We're now getting pip 22 and it seems in-tree-build is no longer being handled and causes builds to fail.  Removing it solves the issue.

[^1]: https://pip.pypa.io/en/stable/news/#v21-3

# Description

When building the docker container we're getting pip 22.1 and fail the build with  the following:

```
#0 61.35 option --use-feature: invalid choice: 'in-tree-build' (choose from '2020-resolver', 'fast-deps')
```

## Status

READY

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Try a docker build before the change and see it fail.
- Try a docker build after the change and see it pass.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
