### PR TITLE
Fixing KeyErrors on messages without text

### DIFF
--- a/opsdroid/connector/telegram/__init__.py
+++ b/opsdroid/connector/telegram/__init__.py
@@ -305,7 +305,7 @@ class ConnectorTelegram(Connector):
 
         if message.get("reply_to_message"):
             event = Reply(
-                text=emoji.demojize(message["text"]),
+                text=emoji.demojize(message.get("text", "")),
                 user=user,
                 user_id=user_id,
                 event_id=message["message_id"],
@@ -317,7 +317,7 @@ class ConnectorTelegram(Connector):
 
         if message.get("text"):
             event = Message(
-                text=emoji.demojize(message["text"]),
+                text=emoji.demojize(message.get("text", "")),
                 user=user,
                 user_id=user_id,
                 target=message["chat"]["id"],


### PR DESCRIPTION
This may occur if messages consist only of media elements. A message
that consists just a gif for example

Fixes #1909


## Status
**READY**

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- not tested


# Checklist:

- [x] I have performed a self-review of my own code
- [n/a] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
