### PR TITLE
Use simple logging when running in a non-interactive shell

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,6 +194,17 @@ When using rich logging, opsdroid will use the [RichHandler](https://rich.readth
 - set `timestamp: false` to disable timestamps
 - set `extended: false` to disable log location
 
+##### Automatic fallback
+
+Opsdroid will fall back to simple console logging when running in a non-interactive shell (example: Docker container).
+
+If this is the case then you will see the following message in the log upon Opsdroid start:
+```
+WARNING opsdroid.logging Running in non-interactive shell - falling back to simple logging. You can override this using 'logging.config: false'
+```
+
+Specifying `logging.console` in the configuration will override this.
+
 #### Optional logging arguments
 
 You can pass optional arguments to the logging configuration to extend the opsdroid logging.

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -18,7 +18,7 @@
 #   level: info
 #   path: opsdroid.log
 #   rich: false
-#   console: true
+#   console: false
 #   extended: false
 #   timestamp: true
 #   formatter: "%(levelname)s: %(message)s"

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -1,7 +1,7 @@
 """Class for Filter logs and logging logic."""
 
 import logging
-import os
+import os,sys
 from logging.handlers import RotatingFileHandler
 
 from rich.logging import RichHandler
@@ -129,7 +129,9 @@ def configure_logging(config):
         file_handler.setFormatter(formatter)
         rootlogger.addHandler(file_handler)
 
-    if config.get("console"):
+    # If we are running in a non-interactive shell then use simple logging
+    # If config value is specified then it always overrides this
+    if config.get("console") or (config.get("console") is None and not sys.stdout.isatty()):
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
 

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -1,7 +1,8 @@
 """Class for Filter logs and logging logic."""
 
 import logging
-import os,sys
+import os
+import sys
 from logging.handlers import RotatingFileHandler
 
 from rich.logging import RichHandler
@@ -132,7 +133,7 @@ def configure_logging(config):
     # If we are running in a non-interactive shell (without a tty)
     # then use simple logging instead of rich logging
     # Config value always overrides
-    running_in_non_interactive_shell = False;
+    running_in_non_interactive_shell = False
     if config.get("console") is True:
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
@@ -159,7 +160,9 @@ def configure_logging(config):
     _LOGGER.info("=" * 40)
     _LOGGER.info(_("Started opsdroid %s."), __version__)
     if running_in_non_interactive_shell:
-        _LOGGER.warning("Running in non-interactive shell - falling back to simple logging. You can override this using 'logging.config: false'")
+        _LOGGER.warning(
+            "Running in non-interactive shell - falling back to simple logging. You can override this using 'logging.config: false'"
+        )
 
 
 def get_logging_level(logging_level):

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -129,11 +129,16 @@ def configure_logging(config):
         file_handler.setFormatter(formatter)
         rootlogger.addHandler(file_handler)
 
-    # If we are running in a non-interactive shell then use simple logging
-    # If config value is specified then it always overrides this
-    if config.get("console") or (config.get("console") is None and not sys.stdout.isatty()):
+    # If we are running in a non-interactive shell (without a tty)
+    # then use simple logging instead of rich logging
+    # Config value always overrides
+    if config.get("console") is True:
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
+    else:
+        if config.get("console") is None and not sys.stdout.isatty():
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
 
     # If we still don't have the handler, we are assuming that
     # the user wants to switch off logging, let's log only

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -134,20 +134,21 @@ def configure_logging(config):
     # then use simple logging instead of rich logging
     # Config value always overrides
     running_in_non_interactive_shell = False
+    console = config.get("test_logging_console", sys.stderr)
     if config.get("console") is True:
-        handler = logging.StreamHandler()
+        handler = logging.StreamHandler(stream=console)
         handler.setFormatter(formatter)
     else:
-        if config.get("console") is None and not sys.stdout.isatty():
+        if config.get("console") is None and not console.isatty():
             running_in_non_interactive_shell = True
-            handler = logging.StreamHandler()
+            handler = logging.StreamHandler(stream=console)
             handler.setFormatter(formatter)
 
     # If we still don't have the handler, we are assuming that
     # the user wants to switch off logging, let's log only
     # Critical errors
     if not handler:
-        handler = logging.StreamHandler()
+        handler = logging.StreamHandler(stream=console)
         handler.setFormatter(formatter)
         log_level = get_logging_level("critical")
 

--- a/opsdroid/logging.py
+++ b/opsdroid/logging.py
@@ -132,11 +132,13 @@ def configure_logging(config):
     # If we are running in a non-interactive shell (without a tty)
     # then use simple logging instead of rich logging
     # Config value always overrides
+    running_in_non_interactive_shell = False;
     if config.get("console") is True:
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
     else:
         if config.get("console") is None and not sys.stdout.isatty():
+            running_in_non_interactive_shell = True
             handler = logging.StreamHandler()
             handler.setFormatter(formatter)
 
@@ -156,6 +158,8 @@ def configure_logging(config):
 
     _LOGGER.info("=" * 40)
     _LOGGER.info(_("Started opsdroid %s."), __version__)
+    if running_in_non_interactive_shell:
+        _LOGGER.warning("Running in non-interactive shell - falling back to simple logging. You can override this using 'logging.config: false'")
 
 
 def get_logging_level(logging_level):

--- a/opsdroid/tests/test_logging.py
+++ b/opsdroid/tests/test_logging.py
@@ -5,10 +5,13 @@ import re
 import sys
 import tempfile
 
+import rich.logging
+
 import opsdroid.logging as opsdroid
 import pytest
 from opsdroid.cli.start import configure_lang
 from rich.logging import RichHandler
+from io import StringIO
 
 configure_lang({})
 
@@ -179,9 +182,52 @@ def test_configure_default_logging(capsys):
     # StreamingHandler writes to stderr
     if not sys.stdout.isatty():
         assert "Started opsdroid" in captured.err
+        # Check if we log a warning message
+        assert "falling back to simple logging" in captured.err
     # RichHandler writes to stdout
     if sys.stdout.isatty():
         assert "Started opsdroid" in captured.out
+        # Check if we log a warning message
+        assert "falling back to simple logging" in captured.out
+
+
+def test_configure_logging_config_override(capsys):
+    # Test overriding the logging via config
+    config = {"console": True}
+    opsdroid.configure_logging(config)
+    rootlogger = logging.getLogger()
+    # Check that we have the correct logging handler
+    assert isinstance(rootlogger.handlers[1], logging.StreamHandler)
+    captured = capsys.readouterr()
+    # If overriding the console from the config the warning message should not be displayed
+    assert "falling back to simple logging" not in captured.err
+
+    config = {"console": False}
+    opsdroid.configure_logging(config)
+    rootlogger = logging.getLogger()
+    # Check that we have the correct logging handler
+    assert isinstance(rootlogger.handlers[1], RichHandler)
+    captured = capsys.readouterr()
+    assert "falling back to simple logging" not in captured.err
+
+
+def test_configure_logging_fallback_interactive(mocker):
+    # Testing interactive shell
+    stdout_mock = mocker.patch("sys.stdout")
+    stdout_mock.isatty.return_value = "istty"
+    config = {"test_logging_console": stdout_mock}
+    opsdroid.configure_logging(config)
+    rootlogger = logging.getLogger()
+    assert isinstance(rootlogger.handlers[1], rich.logging.RichHandler)
+
+
+def test_configure_logging_fallback_non_interactive():
+    # Testing non-interactive shell using StringIO
+    # Create a fake object to simulate a non-interactive console
+    config = {"test_logging_console": StringIO()}
+    opsdroid.configure_logging(config)
+    rootlogger = logging.getLogger()
+    assert isinstance(rootlogger.handlers[1].stream, StringIO)
 
 
 def test_configure_logging_formatter(capsys):


### PR DESCRIPTION
# Description

Switch to simple logging when running in a non-interactive shell (eg: Docker container).

## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?
- Tests on my local environment
  - Run with interactive shell (`docker run -ti`) without config options
    - Result: rich logging
  - Run without interactive shell (`docker run`) without config options
    - Result: simple logging
  - Run with interactive shell and config option `logging.console: false`
    - Result: simple logging
  - Run with non-interactive shell and config option `logging.console: true`
    - Result: rich logging

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
