### PR TITLE
Add middleware to aiohttp server to handle cors request

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,18 +9,18 @@
 For configuration, opsdroid uses a single YAML file named `configuration.yaml`. When you run opsdroid it will look for the file in the following places in order:
 
 - Local `./configuration.yaml`
--  The default user data location:
-    * Mac: `~/Library/Application Support/opsdroid`
-    * Linux: `~/.local/share/opsdroid`
-    * Windows: `C:\Documents and Settings\<User>\Application Data\Local Settings\opsdroid\opsdroid` or
-                `C:\Documents and Settings\<User>\Application Data\opsdroid\opsdroid`
-- System `/etc/opsdroid/configuration.yaml` (*nix only)
+- The default user data location:
+  - Mac: `~/Library/Application Support/opsdroid`
+  - Linux: `~/.local/share/opsdroid`
+  - Windows: `C:\Documents and Settings\<User>\Application Data\Local Settings\opsdroid\opsdroid` or
+    `C:\Documents and Settings\<User>\Application Data\opsdroid\opsdroid`
+- System `/etc/opsdroid/configuration.yaml` (\*nix only)
 
 _Note: If no file named `configuration.yaml` can be found on one of these folders, one will be created for you taken from the [example configuration file](https://github.com/opsdroid/opsdroid/blob/master/opsdroid/configuration/example_configuration.yaml)_
 
 Suppose you are using one of the default locations. In that case, you can run the command `opsdroid config edit` to open the configuration with your favourite editor (taken from the environment variable `EDITOR`) or the default editor vim.
 
-The opsdroid project itself is very simple and requires modules to give it functionality. You must specify the connector, skill, and database* modules you wish to use in your configuration file and any options they may require.
+The opsdroid project itself is very simple and requires modules to give it functionality. You must specify the connector, skill, and database\* modules you wish to use in your configuration file and any options they may require.
 
 **Connectors** are modules for connecting opsdroid to your specific chat service.
 
@@ -87,7 +87,6 @@ _Config options of the connectors themselves differ between connectors, see the 
 
 ```yaml
 connectors:
-
   slack:
     token: "mysecretslacktoken"
 
@@ -170,7 +169,7 @@ The default locations for the logs are:
 - Linux: `/home/<User>/.cache/opsdroid/log`
 - Windows: `C:\Users\<User>\AppData\Local\opsdroid\Logs\`
 
-If you are using one of the default paths for your log, you can run the command `opsdroid logs` to print the logs into the terminal. 
+If you are using one of the default paths for your log, you can run the command `opsdroid logs` to print the logs into the terminal.
 
 ```yaml
 logging:
@@ -199,6 +198,7 @@ When using rich logging, opsdroid will use the [RichHandler](https://rich.readth
 Opsdroid will fall back to simple console logging when running in a non-interactive shell (example: Docker container).
 
 If this is the case then you will see the following message in the log upon Opsdroid start:
+
 ```
 WARNING opsdroid.logging Running in non-interactive shell - falling back to simple logging. You can override this using 'logging.config: false'
 ```
@@ -219,11 +219,11 @@ logging:
   timestamp: true
 ```
 
-*example:*
+_example:_
 
 ```shell
-2020-12-02 10:39:51,255 INFO opsdroid.logging: ========================================                                 
-2020-12-02 10:39:51,255 INFO opsdroid.logging: Started opsdroid v0.19.0+66.g8b839bc.dirty.                             
+2020-12-02 10:39:51,255 INFO opsdroid.logging: ========================================
+2020-12-02 10:39:51,255 INFO opsdroid.logging: Started opsdroid v0.19.0+66.g8b839bc.dirty.
 2020-12-02 10:39:51,255 INFO opsdroid: ========================================
 ```
 
@@ -251,7 +251,7 @@ logging:
   extended: true
 ```
 
-*example:*
+_example:_
 
 ```shell
 INFO opsdroid.logging.configure_logging(): ========================================
@@ -273,7 +273,7 @@ logging:
       - "opsdroid.logging"
 ```
 
-*example:*
+_example:_
 
 ```shell
 DEBUG opsdroid.core: Loaded 5 skills
@@ -297,7 +297,7 @@ logging:
       - "aiosqlite"
 ```
 
-*example:*
+_example:_
 
 ```shell
 INFO opsdroid.logging: ========================================
@@ -363,7 +363,7 @@ INFO opsdroid.web: Started web server on http://0.0.0.0:8080
 
 ##### Logs formatter
 
-You can create your formatter string to pass to the logs. This option will give you more flexibility and get logs in your prefered format. Note that this option only works if you set `console: true` since rich logging will have its own 
+You can create your formatter string to pass to the logs. This option will give you more flexibility and get logs in your prefered format. Note that this option only works if you set `console: true` since rich logging will have its own
 formatter.
 
 ```yaml
@@ -416,7 +416,7 @@ parsers:
   regex:
     enabled: true
 
-# NLU parser
+  # NLU parser
   rasanlu:
     url: http://localhost:5000
     project: opsdroid
@@ -450,7 +450,7 @@ Configure the timezone.
 This timezone will be used in crontab skills if the timezone has not been set as a kwarg in the crontab decorator. All [timezone names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) from the [tz database](https://www.iana.org/time-zones) are valid here.
 
 ```yaml
-timezone: 'Europe/London'
+timezone: "Europe/London"
 ```
 
 ### Language
@@ -473,11 +473,25 @@ By default, opsdroid will start a web server on port `8080` (or `8443` if SSL de
 
 ```yaml
 web:
-  host: '0.0.0.0'
+  host: "0.0.0.0"
   port: 8080
   ssl:
     cert: /path/to/cert.pem
     key: /path/to/key.pem
+```
+
+#### CORS
+
+By default, opsdroid handles CORS requests insecurely. This means that every request will be accepted. You can configure CORS by using the following configuration:
+
+```yaml
+web:
+  cors:
+    allow-all: false
+    origins:
+      - http://localhost:3000
+    allow-headers:
+      - X-Token
 ```
 
 ## Module options
@@ -536,24 +550,24 @@ Notebooks are also supported.
 
 ```yaml
 skills:
- ping:
-   gist: https://gist.github.com/jacobtomlinson/6dd35e0f62d6b779d3d0d140f338d3e5
+  ping:
+    gist: https://gist.github.com/jacobtomlinson/6dd35e0f62d6b779d3d0d140f338d3e5
 ```
 
 Or you can specify the Gist ID without the full URL.
 
 ```yaml
 skills:
- ping:
-   gist: 6dd35e0f62d6b779d3d0d140f338d3e5
+  ping:
+    gist: 6dd35e0f62d6b779d3d0d140f338d3e5
 ```
 
 You can also directly specify the module name to import, which skips all of the opsdroid module generation.
 
 ```yaml
 skills:
- ping:
-   module: 'module.to.import'
+  ping:
+    module: "module.to.import"
 ```
 
 ### Disable Caching
@@ -645,7 +659,7 @@ Since version 0.17.0 came out we have migrated to a new configuration layout. We
 
 ### What changed
 
-We have dropped the pattern `- name:  <module name>`  and replaced it with the pattern `<module name>: {}` or `<module name>:` followed by a blank line underneath.
+We have dropped the pattern `- name: <module name>` and replaced it with the pattern `<module name>: {}` or `<module name>:` followed by a blank line underneath.
 
 This change makes sure we stop using lists containing dictionaries that carry the configuration for each module. In the new layout, we replace lists with a dictionary that uses the name of a module for a key and the additional configuration parameters inside a dictionary as a key.
 

--- a/opsdroid/configuration/example_configuration.yaml
+++ b/opsdroid/configuration/example_configuration.yaml
@@ -46,6 +46,13 @@ welcome-message: true
 #     cert: /path/to/cert.pem
 #     key: /path/to/key.pem
 #   webhook-token: "aabbccddee"
+#   cors:
+#     # If allow-all: true all requests will be accepted this is insecure
+#     allow-all: false
+#     origins:
+#       - http://localhost:8080
+#     allow-headers:
+#       - X-Token
 #   command-center:
 #     enabled: true
 #     token: secret-stuff
@@ -110,7 +117,7 @@ connectors:
     bot-name: "mybot" # default "opsdroid"
     max-connections: 10 # default is 10 users can be connected at once
     connection-timeout: 10 # default 10 seconds before requested socket times out
-    # Optional but recommended 
+    # Optional but recommended
     # token: "secret-token" # Used to validate request before assigning socket
   # Uncomment the connector(s) that you wish opsdroid to work on
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ test_suite = tests
 setup_requires = babel
 install_requires =
   aiohttp>=3.6.2
+  aiohttp-middlewares>=1.2.1
   appdirs>=1.4.4
   arrow>=0.15.8
   Babel>=2.8.0


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds  a new dependency `aiohttp-middlewares` to opsdroid so we can handle CORS. I've decided to use `aiohttp-middlewares` instead of `aiohttp-cors` because this library seems to be slightly more active than `aiohttp-cors` and its the one that seems to just work.

By using the work in this branch I was able to use the websocket token to connect to opsdroid successfully. I'm not entirely sure how to test this though 😞 

Fixes #1932


## Status
**READY** | ~~**UNDER DEVELOPMENT**~~ | ~~**ON HOLD**~~


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Use opsdroid-web and websocket token to test request 



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
