### PR TITLE
Add auto mode for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -121,7 +121,6 @@ database_matrix =
 test =
   pre-commit
   coveralls>=2.0.0
-  dialogflow>=0.8.0
   astroid>=2.4.1
   pytest>=5.4.2
   pytest-aiohttp==0.3.0
@@ -144,6 +143,7 @@ docs =
   docutils==0.16
 
 [tool:pytest]
+asyncio_mode = auto
 testpaths = opsdroid tests
 norecursedirs = .git testing_config
 addopts = -v


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
```
Starting from pytest-asyncio>=0.17, three modes are provided: auto,
strict, and legacy. Starting from pytest-asyncio>=0.19 the strict
mode is the default.
```
This is causing tests to fail when the latest version pytest-asyncio is installed

https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.19.0

Also removing the duplicate entry of dialogflow which is also making the tests fail

## Status
**READY**

- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Yes tests pass now

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
