### PR TITLE
Add py310 to envlist in tox.ini

### DIFF
--- a/opsdroid/connector/slack/tests/test_connector.py
+++ b/opsdroid/connector/slack/tests/test_connector.py
@@ -12,7 +12,6 @@ from opsdroid.connector.slack.events import (
     ModalPush,
     ModalUpdate,
 )
-
 from slack_sdk.socket_mode.request import SocketModeRequest
 
 from .conftest import get_path
@@ -85,6 +84,7 @@ async def test_connect_socket_mode(opsdroid, mock_api_obj, mock_api):
     connector.socket_mode_client.connect = amock.CoroutineMock()
     await connector.connect()
     assert connector.socket_mode_client.connect.called
+    await connector.disconnect()
 
 
 @pytest.mark.asyncio
@@ -99,12 +99,14 @@ async def test_connect_no_socket_mode_client(opsdroid, mock_api_obj, mock_api, c
     connector.slack_web_client.base_url = mock_api_obj.base_url
     await connector.connect()
     assert "RTM support has been dropped" in caplog.text
+    await connector.disconnect()
 
 
 @pytest.mark.asyncio
 async def test_connect_failure(connector, mock_api, caplog):
     await connector.connect()
     assert "The Slack Connector will not be available" in caplog.text
+    await connector.disconnect()
 
 
 @pytest.mark.asyncio
@@ -114,6 +116,7 @@ async def test_disconnect(opsdroid, mock_api_obj, mock_api):
     }
     await opsdroid.load()
     connector = opsdroid.get_connector("slack")
+    await connector.disconnect()
     connector.socket_mode_client.disconnect = amock.CoroutineMock()
     connector.socket_mode_client.close = amock.CoroutineMock()
     await connector.disconnect()
@@ -134,6 +137,7 @@ async def test_socket_event_handler(opsdroid, mock_api_obj, mock_api):
     connector.socket_mode_client.send_socket_mode_response = amock.CoroutineMock()
     await connector.socket_event_handler(connector.socket_mode_client, request)
     assert connector.socket_mode_client.send_socket_mode_response.called
+    await connector.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}{,-e2e,-noe2e}, lint, docker-{full,min}
+envlist = py{37,38,39,310}{,-e2e,-noe2e}, lint, docker-{full,min}
 skip_missing_interpreters = True
 
 [gh-actions]


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Tests for python 3.10 are throwing a false positive because nothing is showing on the logs.  I think this is because py310 was not added to the env list in tox.ini

Also tests for slack were not passing in 3.10. Adding fix for that as well 

## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Test A
- Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
