### PR TITLE
Resolve CI failures

### DIFF
--- a/opsdroid/cli/start.py
+++ b/opsdroid/cli/start.py
@@ -6,7 +6,6 @@ import logging
 
 import click
 from opsdroid.cli.utils import (
-    check_dependencies,
     configure_lang,
     path_option,
     welcome_message,
@@ -30,7 +29,6 @@ def start(path):
     configuration.
 
     """
-    check_dependencies()
 
     config_path = [path] if path else DEFAULT_CONFIG_LOCATIONS
     config = load_config_file(config_path)

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -5,7 +5,6 @@ import gettext
 import logging
 import os
 import subprocess
-import sys
 import time
 
 import click
@@ -104,19 +103,6 @@ def configure_lang(config):
     if lang_code != DEFAULT_LANGUAGE:
         lang = gettext.translation("opsdroid", LOCALE_DIR, (lang_code,), fallback=True)
         lang.install()
-
-
-def check_dependencies():
-    """Check for system dependencies required by opsdroid.
-
-    Returns:
-        int: the exit code. Returns 1 if the Python version installed is
-        below 3.7.
-
-    """
-    if sys.version_info.major < 3 or sys.version_info.minor < 7:
-        logging.critical(_("Whoops! opsdroid requires python 3.7 or above."))
-        sys.exit(1)
 
 
 def welcome_message(config):
@@ -222,7 +208,6 @@ def build_config(ctx, params):
     path = params.get("path")
 
     with contextlib.suppress(Exception):
-        check_dependencies()
 
         config = load_config_file([path] if path else DEFAULT_CONFIG_LOCATIONS)
 

--- a/opsdroid/connector/github/__init__.py
+++ b/opsdroid/connector/github/__init__.py
@@ -61,7 +61,7 @@ class ConnectorGitHub(Connector):
             private_key = open(self.private_key_file, "rt").read()
             installation_access_token = jwt.encode(
                 payload, private_key, algorithm="RS256"
-            ).decode("utf-8")
+            )
             headers = {"Authorization": f"Bearer {installation_access_token}"}
 
             async with aiohttp.ClientSession(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import unittest
 import unittest.mock as mock
 import os
-import sys
 import shutil
 import tempfile
 import gettext
@@ -71,53 +70,6 @@ class TestCLI(unittest.TestCase):
 
         response = welcome_message(config)
         self.assertIsNone(response)
-
-    def test_check_version_27(self):
-        with mock.patch.object(sys, "version_info") as version_info:
-            version_info.major = 2
-            version_info.minor = 7
-            with self.assertRaises(SystemExit):
-                from opsdroid.cli.utils import check_dependencies
-
-                check_dependencies()
-
-    def test_check_version_34(self):
-        with mock.patch.object(sys, "version_info") as version_info:
-            version_info.major = 3
-            version_info.minor = 4
-            with self.assertRaises(SystemExit):
-                from opsdroid.cli.utils import check_dependencies
-
-                check_dependencies()
-
-    def test_check_version_35(self):
-        with mock.patch.object(sys, "version_info") as version_info:
-            version_info.major = 3
-            version_info.minor = 5
-            with self.assertRaises(SystemExit):
-                from opsdroid.cli.utils import check_dependencies
-
-                check_dependencies()
-
-    def test_check_version_36(self):
-        with mock.patch.object(sys, "version_info") as version_info:
-            version_info.major = 3
-            version_info.minor = 6
-            with self.assertRaises(SystemExit):
-                from opsdroid.cli.utils import check_dependencies
-
-                check_dependencies()
-
-    def test_check_version_37(self):
-        with mock.patch.object(sys, "version_info") as version_info:
-            version_info.major = 3
-            version_info.minor = 7
-            try:
-                from opsdroid.cli.start import check_dependencies
-
-                check_dependencies()
-            except SystemExit:
-                self.fail("check_dependencies() exited unexpectedly!")
 
     def test_gen_config(self):
         with mock.patch.object(click, "echo") as click_echo, mock.patch(


### PR DESCRIPTION
CI seems to be failing in unrelated ways in #1953. Opening this PR to iterate and fix things.

- `jwt.encode` seems to return a string so removing the `.decode` call
- Removed version check because packaging shouldn't allow this to happen anyway in 99% of cases