### PR TITLE
improve environment var testing

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -74,16 +74,17 @@ class TestConfiguration(unittest.TestCase):
         self.assertIsNotNone(config)
 
     def test_load_config_file_with_env_vars(self):
-        os.environ["ENVVAR"] = "opsdroid"
+        ENVAR_VALUE = "opsdroid"
+        os.environ["ENVVAR"] = ENVAR_VALUE
         config = load_config_file(
             [os.path.abspath("tests/configs/minimal_with_envs.yaml")]
         )
-        assert config["connectors"]["shell"]["bot-name"] == os.environ["ENVVAR"]
+        assert config["connectors"]["shell"]["bot-name"] == ENVAR_VALUE
 
         config = load_config_file(
             [os.path.abspath("tests/configs/minimal_with_envs.json")]
         )
-        assert config["connectors"]["shell"]["bot-name"] == os.environ["ENVVAR"]
+        assert config["connectors"]["shell"]["bot-name"] == ENVAR_VALUE
 
     def test_create_default_config(self):
         test_config_path = os.path.join(


### PR DESCRIPTION
# Description
* check vs const rather than (unknown) os.environ
* (TODO) adds a test that loads env var that was set using `.bashrc`, `source`, or similar

Creates test for issue reported in [matrix chat](https://app.element.io/#/room/#opsdroid-general:matrix.org). Chat summary:

> 7yl4r: I need some clarification on how to use environment variables with connectors. I am trying to use them in the config. I am getting auth errors because the env vars are not being inserted into the config. I tried putting the environment vars into a `.env` file and `source`ing it. I also tried adding them to my `.bashrc`. Neither seems to have worked.

## Status
**UNDER DEVELOPMENT**

## Type of change
- Added tests
- (TODO) Bug fix (non-breaking change which fixes an issue)
- (TODO) Documentation (fix or adds documentation)

# How Has This Been Tested?
- I opened this PR so that I can test using GH-actions CI

# Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
