### PR TITLE
First ephemeral

### DIFF
--- a/opsdroid/connector/slack/connector.py
+++ b/opsdroid/connector/slack/connector.py
@@ -427,7 +427,7 @@ class ConnectorSlack(Connector):
         data = self._generate_base_data(message)
         data["text"] = message.text
 
-        if self.response_type == "in_channel":
+        if self.response_type == "in-channel":
             return await self.slack_web_client.api_call(
                 "chat.postMessage",
                 data=data,

--- a/opsdroid/connector/slack/tests/test_connector.py
+++ b/opsdroid/connector/slack/tests/test_connector.py
@@ -19,6 +19,7 @@ from .conftest import get_path
 USERS_INFO = ("/users.info", "GET", get_path("method_users.info.json"), 200)
 AUTH_TEST = ("/auth.test", "POST", get_path("method_auth.test.json"), 200)
 CHAT_POST_MESSAGE = ("/chat.postMessage", "POST", {"ok": True}, 200)
+CHAT_POST_EPHEMERAL = ("/chat.postEphemeral", "POST", {"ok": True}, 200)
 CHAT_UPDATE_MESSAGE = ("/chat.update", "POST", {"ok": True}, 200)
 VIEWS_OPEN = ("/views.open", "POST", {"ok": True}, 200)
 VIEWS_UPDATE = ("/views.update", "POST", {"ok": True}, 200)
@@ -236,6 +237,28 @@ async def test_send_message(send_event, connector):
         "channel": "room",
         "text": "test",
         "username": "opsdroid",
+        "icon_emoji": ":robot_face:",
+    }
+    assert response["ok"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.add_response(*CHAT_POST_EPHEMERAL)
+async def test_send_ephemeral(send_event, connector):
+    connector.response_type = "ephemeral"
+    event = events.Message(
+        text="Hey TEST USER",
+        user="Test User",
+        user_id="U01NK1K9L68",
+        target="room",
+        connector=connector,
+    )
+    payload, response = await send_event(CHAT_POST_EPHEMERAL, event)
+    assert payload == {
+        "channel": "room",
+        "text": "Hey TEST USER",
+        "username": "opsdroid",
+        "user": "U01NK1K9L68",
         "icon_emoji": ":robot_face:",
     }
     assert response["ok"]


### PR DESCRIPTION
# Description

The first ephemeral I got to send. Added another field to be configured in the configuration.yaml that will allow ephemerals to be sent instead of regular messages to the user that triggers the bot. 
Fixes #1941 


## Status
 **UNDER DEVELOPMENT** 


## Type of change
- New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

- So far I have set up an App I called mybot on slack, I used my local opsdroid exposing 8080 through ngrok.
![image](https://user-images.githubusercontent.com/77400826/204912621-8c2654bb-bfe2-4db4-8b96-700cb9f76d33.png)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
