### PR TITLE
Added retry timer for Slack API rate limit threshold + ability to reply to other bots & within a thread using Blocks

### DIFF
--- a/opsdroid/connector/slack/connector.py
+++ b/opsdroid/connector/slack/connector.py
@@ -217,7 +217,7 @@ class ConnectorSlack(Connector):
                 except SlackApiError as error:
                     if "ratelimited" in str(error):
                         wait_time = float(error.response.headers["Retry-After"])
-                        _LOGGER.warning(_(f"Rate limiting threshold reached. Retrying after {wait_time} seconds."))
+                        _LOGGER.warning(_(f"Rate limit threshold reached. Retrying after {wait_time} seconds."))
                         await asyncio.sleep(wait_time)
                         continue
                     else:

--- a/opsdroid/connector/slack/connector.py
+++ b/opsdroid/connector/slack/connector.py
@@ -211,9 +211,11 @@ class ConnectorSlack(Connector):
                     )
                     self.known_channels.update({c["name"]: c for c in channels["channels"]})
                     cursor = channels["response_metadata"].get("next_cursor")
-
                     if not cursor:
                         break
+                    channel_count = len(self.known_channels.keys())
+                    _LOGGER.info("Grabbed a total of %s channels from Slack", channel_count)
+                    await asyncio.sleep(self.refresh_interval - arrow.now().time().second)
                 except SlackApiError as error:
                     if "ratelimited" in str(error):
                         wait_time = float(error.response.headers["Retry-After"])
@@ -222,10 +224,6 @@ class ConnectorSlack(Connector):
                         continue
                     else:
                         raise
-
-            channel_count = len(self.known_channels.keys())
-            _LOGGER.info("Grabbed a total of %s channels from Slack", channel_count)
-            await asyncio.sleep(self.refresh_interval - arrow.now().time().second)
 
     async def event_handler(self, payload):
         """Handle different payload types and parse the resulting events"""

--- a/opsdroid/connector/slack/connector.py
+++ b/opsdroid/connector/slack/connector.py
@@ -209,17 +209,27 @@ class ConnectorSlack(Connector):
                     channels = await self.slack_web_client.conversations_list(
                         cursor=cursor, limit=self.channel_limit
                     )
-                    self.known_channels.update({c["name"]: c for c in channels["channels"]})
+                    self.known_channels.update(
+                        {c["name"]: c for c in channels["channels"]}
+                    )
                     cursor = channels["response_metadata"].get("next_cursor")
                     if not cursor:
                         break
                     channel_count = len(self.known_channels.keys())
-                    _LOGGER.info("Grabbed a total of %s channels from Slack", channel_count)
-                    await asyncio.sleep(self.refresh_interval - arrow.now().time().second)
+                    _LOGGER.info(
+                        "Grabbed a total of %s channels from Slack", channel_count
+                    )
+                    await asyncio.sleep(
+                        self.refresh_interval - arrow.now().time().second
+                    )
                 except SlackApiError as error:
                     if "ratelimited" in str(error):
                         wait_time = float(error.response.headers["Retry-After"])
-                        _LOGGER.warning(_(f"Rate limit threshold reached. Retrying after {wait_time} seconds."))
+                        _LOGGER.warning(
+                            _(
+                                f"Rate limit threshold reached. Retrying after {wait_time} seconds."
+                            )
+                        )
                         await asyncio.sleep(wait_time)
                         continue
                     else:
@@ -252,7 +262,7 @@ class ConnectorSlack(Connector):
             )
 
     async def socket_event_handler(
-            self, client: SocketModeClient, req: SocketModeRequest
+        self, client: SocketModeClient, req: SocketModeRequest
     ):
         payload = {}
 

--- a/opsdroid/connector/slack/connector.py
+++ b/opsdroid/connector/slack/connector.py
@@ -199,13 +199,15 @@ class ConnectorSlack(Connector):
         """Grab all the channels from the Slack API. This method runs while opsdroid
         is running at every refresh_interval.
         """
-
+        # By default, slack api asks us to wait 30 seconds if we hit the rate limit.
+        # We will retry 5 (2.5 mins) times before giving up.
+        max_retries = 5
         while self.opsdroid.eventloop.is_running():
             _LOGGER.info(_("Updating Channels from Slack API at %s."), time.asctime())
 
             cursor = None
 
-            while True:
+            while max_retries:
                 try:
                     channels = await self.slack_web_client.conversations_list(
                         cursor=cursor, limit=self.channel_limit
@@ -213,7 +215,7 @@ class ConnectorSlack(Connector):
                     self.known_channels.update(
                         {c["name"]: c for c in channels["channels"]}
                     )
-                    cursor = channels["response_metadata"].get("next_cursor")
+                    cursor = channels.get("response_metadata", {}).get("next_cursor")
                     if not cursor:
                         break
                     channel_count = len(self.known_channels.keys())
@@ -225,16 +227,20 @@ class ConnectorSlack(Connector):
                     )
                 except SlackApiError as error:
                     if "ratelimited" in str(error):
-                        wait_time = float(error.response.headers["Retry-After"])
+                        wait_time = float(error.response.headers.get("Retry-After", 30))
                         _LOGGER.warning(
                             _(
                                 f"Rate limit threshold reached. Retrying after {wait_time} seconds."
                             )
                         )
                         await asyncio.sleep(wait_time)
+                        max_retries -= 1
                         continue
                     else:
                         raise
+            # If we reach here, let's break from the loop
+            # (works for both cases: cursor is None or max_retries is 0)
+            break
 
     async def event_handler(self, payload):
         """Handle different payload types and parse the resulting events"""

--- a/opsdroid/connector/slack/events.py
+++ b/opsdroid/connector/slack/events.py
@@ -76,19 +76,19 @@ class InteractiveAction(events.Event):
                 async with aiohttp.ClientSession() as session:
                     headers = {"Content-Type": "application/json"}
                     response_data = {
-                                            "text": response_event,
-                                            "replace_original": False,
-                                            "delete_original": False,
-                                            "response_type": "in_channel",
-                                        }
-                    if 'message' in self.payload and self.connector.start_thread:
-                        if 'thread_ts' in self.payload['message']:
-                            response_data["thread_ts"] = self.payload["message"]["thread_ts"]
+                        "text": response_event,
+                        "replace_original": False,
+                        "delete_original": False,
+                        "response_type": "in_channel",
+                    }
+                    if "message" in self.payload and self.connector.start_thread:
+                        if "thread_ts" in self.payload["message"]:
+                            response_data["thread_ts"] = self.payload["message"][
+                                "thread_ts"
+                            ]
                     response = await session.post(
                         self.payload["response_url"],
-                        data=json.dumps(
-                            response_data
-                        ),
+                        data=json.dumps(response_data),
                         headers=headers,
                         ssl=self.ssl_context,
                     )

--- a/opsdroid/connector/slack/events.py
+++ b/opsdroid/connector/slack/events.py
@@ -81,8 +81,9 @@ class InteractiveAction(events.Event):
                                             "delete_original": False,
                                             "response_type": "in_channel",
                                         }
-                    if 'thread_ts' in self.payload['message']:
-                        response_data["thread_ts"] = self.payload["message"]["thread_ts"]
+                    if 'message' in self.payload:
+                        if 'thread_ts' in self.payload['message']:
+                            response_data["thread_ts"] = self.payload["message"]["thread_ts"]
                     response = await session.post(
                         self.payload["response_url"],
                         data=json.dumps(

--- a/opsdroid/connector/slack/events.py
+++ b/opsdroid/connector/slack/events.py
@@ -81,7 +81,7 @@ class InteractiveAction(events.Event):
                                             "delete_original": False,
                                             "response_type": "in_channel",
                                         }
-                    if 'message' in self.payload:
+                    if 'message' in self.payload and self.connector.start_thread:
                         if 'thread_ts' in self.payload['message']:
                             response_data["thread_ts"] = self.payload["message"]["thread_ts"]
                     response = await session.post(

--- a/opsdroid/connector/slack/events.py
+++ b/opsdroid/connector/slack/events.py
@@ -75,15 +75,18 @@ class InteractiveAction(events.Event):
             if "response_url" in self.payload:
                 async with aiohttp.ClientSession() as session:
                     headers = {"Content-Type": "application/json"}
+                    response_data = {
+                                            "text": response_event,
+                                            "replace_original": False,
+                                            "delete_original": False,
+                                            "response_type": "in_channel",
+                                        }
+                    if 'thread_ts' in self.payload['message']:
+                        response_data["thread_ts"] = self.payload["message"]["thread_ts"]
                     response = await session.post(
                         self.payload["response_url"],
                         data=json.dumps(
-                            {
-                                "text": response_event,
-                                "replace_original": False,
-                                "delete_original": False,
-                                "response_type": "in_channel",
-                            }
+                            response_data
                         ),
                         headers=headers,
                         ssl=self.ssl_context,


### PR DESCRIPTION
# Description

Issue 1  reported here: https://github.com/opsdroid/opsdroid/issues/1958
Issue 2 reported here: https://github.com/opsdroid/opsdroid/issues/1905

Issue 1:
The [_get_channels](https://github.com/opsdroid/opsdroid/blob/73da764ca72581a506f05117ec9690ca34b15400/opsdroid/connector/slack/connector.py#L197) method from Slack connector triggers a SlackAPIError exception when the rate limit threshold is reached in Slack API and throws an exception and Opsdroid stops its execution:

Here's the traceback thrown by Opsdroid currently:
```python
 File "/home/opsdroid_test/.local/lib/python3.10/site-packages/opsdroid/connector/slack/connector.py", line 208, in _get_channels
    channels = await self.slack_web_client.conversations_list(
  File "/home/opsdroid_test/.local/lib/python3.10/site-packages/slack_sdk/web/async_client.py", line 2463, in conversations_list
    return await self.api_call("conversations.list", http_verb="GET", params=kwargs)
  File "/home/opsdroid_test/.local/lib/python3.10/site-packages/slack_sdk/web/async_base_client.py", line 161, in api_call
    return await self._send(
  File "/home/opsdroid_test/.local/lib/python3.10/site-packages/slack_sdk/web/async_base_client.py", line 201, in _send
    return AsyncSlackResponse(**{**data, **res}).validate()
  File "/home/opsdroid_test/.local/lib/python3.10/site-packages/slack_sdk/web/async_slack_response.py", line 192, in validate
    raise e.SlackApiError(message=msg, response=self)
slack_sdk.errors.SlackApiError: The request to the Slack API failed. (url: https://www.slack.com/api/conversations.list)
The server responded with: {'ok': False, 'error': 'ratelimited'}
```

The solution for issue 1: The `ratelimited` error from Slack API gives us a retry timer back where instead of raising the exception and aborting the execution we can just back-off respecting the retry-timer which is exactly what I did.

Issue 2: When Opsdroid is replying to an InteractiveAction (within Blocks), it replies outside of a thread.

The solution for issue 2: I just added a small conditional to the payload that is sent back to the channel. If 'thread_ts' exists then Opsdroid should reply within the thread.

## Type of change

- Bug fix (for both issues)

I have caught the SlackAPIError exception, pulled the retry-timer from the error message and added a sleep function to wait for the specified amount of seconds advised by Slack API in the error message and continue afterwards.

# How Has This Been Tested?

After the code change, I left Opsdroid running for over an hour or so with no issues.

Here's a sample of the logs I see after the fix:

```shell
[12/06/22 22:37:00] INFO     Updating Channels from Slack API at Tue Dec  6 22:37:00 2022.                                                                                                                                                    connector.py:203
[12/06/22 22:37:15] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:37:49] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:38:25] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:38:56] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:39:28] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:40:00] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:40:35] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:41:08] WARNING  Rate limit threshold reached. Retrying after 30.0 seconds.                                                                                                                                                    connector.py:220
[12/06/22 22:41:38] INFO     Grabbed a total of 14427 channels from Slack
```

For issue 2: 

I tested by creating a hello world skill with a button for us to click on it so Opsdroid can respond:

```python
from opsdroid.skill import Skill
from opsdroid.matchers import match_regex
from opsdroid.matchers import match_event
from opsdroid.connector.slack.events import Blocks
from opsdroid.connector.slack.events import BlockActions

class HelloCatcher(Skill):
    @match_regex(r'hello man')
    async def my_first_reply(self, message):
        options = [
                {
                    "type": "section",
                    "text": {
                        "type": "mrkdwn",
                        "text": f"Please select your option:"
                    },
                },
            ]
        options.extend([
                    {
                        "type": "section",
                        "text": {
                            "type": "mrkdwn",
                            "text": f"Hey Rodrigo"
                        },
                        "accessory": {
                            "type": "button",
                            "text": {
                                "type": "plain_text",
                                "text": "Click here",
                                "emoji": True
                            },
                            "value": "test",
                            "action_id": "hoho"
                        },
                    },
                    {
                        "type": "divider"
                    },
                ])
        await message.respond(Blocks(options))

    @match_event(BlockActions, value="test")
    async def my_reply(self, event):
        await event.respond("Here's my reply.")
```

Without the fix, Opsdroid responds outside of a thread even when start_thread is set to False. 

With the fix added here, Opsdroid responds within a thread only when start_thread is set to False. 

Previously, it would take a couple of seconds to stop working.
