### PR TITLE
Support for Rasa entity extraction with roles

### DIFF
--- a/docs/skills/matchers/rasanlu.md
+++ b/docs/skills/matchers/rasanlu.md
@@ -171,3 +171,84 @@ The example skill will print the following .
   }
 }
 ```
+
+### Using entities with [roles](https://learning.rasa.com/conversational-ai-with-rasa/entities/#roles-and-groups) (Rasa 3.X)
+
+```eval_rst
+.. warning::
+   When using Rasa roles the entity name is used multiple times (for departure and for destination).
+   To be able to provided it via `message.entities` Opsdroid rasanlu matcher will create a new name `city` with both roles `departure` and `destination` appended (with `_`).
+
+   So the entities will be stored in `message.entities` with keys `city_departure` and `city_destination`.
+```
+
+Intents file (`intents.yml`).
+```YAML
+version: "3.1"
+
+intents:
+  - greetings
+  - bye
+  - travel
+
+entities:
+  - city:
+    roles:
+    - departure
+    - destination
+
+nlu:
+  - intent: greetings
+    examples: |
+      - Hey
+      - Hi
+      - hey there
+      - hello
+  - intent: bye
+    examples: |
+      - googbye
+      - bye
+      - ciao
+      - see you
+  - intent: travel
+    examples: |
+      - I want to fly from [Berlin]{"entity": "city","role":"departure"} to [San Francisco]{"entity": "city","role":"destination"}
+      - I want to go from [Berlin]{"entity": "city","role":"departure"} to [San Francisco]{"entity": "city","role":"destination"}
+      - I want to travel from [Berlin]{"entity": "city","role":"departure"} to [San Francisco]{"entity": "city","role":"destination"}
+```
+
+Skill file (`__init__.py`).
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_rasanlu
+
+class MySkill(Skill):
+    @match_rasanlu('travel')
+    async def hello(self, message):
+        if "city_departure" in message.entities and "city_destination" in message.entities:
+            source = message.entities['city_departure']['value']
+            destination = message.entities['city_destination']['value']
+            await message.respond("👌 Searching for routes from {} to {}".format(source, destination))
+        else:
+            await message.respond("😕 I couldn't understand you. Maybe try to rephrase your query.")
+```
+
+This skill will result the following structure in `message.entities`:
+
+* Input: `I want to travel from Berlin to San Francisco`
+* `message.entities`:
+
+```JSON
+{
+  "city_departure":
+  {
+    "value": "Berlin",
+    "confidence": 0.9992508292198181
+  },
+  "city_destination":
+  {
+    "value": "San Francisco",
+    "confidence": 0.9521082639694214
+  }
+}
+```

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -289,15 +289,18 @@ async def parse_rasanlu(opsdroid, skills, message, config):
                     if matcher["rasanlu_intent"] == result["intent"]["name"]:
                         message.rasanlu = result
                         for entity in result["entities"]:
+                            entity_name = entity["entity"]
+                            if "role" in entity:
+                                entity_name = entity["entity"]+"_"+entity["role"]
                             if "confidence_entity" in entity:
                                 message.update_entity(
-                                    entity["entity"],
+                                    entity_name,
                                     entity["value"],
                                     entity["confidence_entity"],
                                 )
                             elif "extractor" in entity:
                                 message.update_entity(
-                                    entity["entity"],
+                                    entity_name,
                                     entity["value"],
                                     entity["extractor"],
                                 )

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -294,7 +294,7 @@ async def parse_rasanlu(opsdroid, skills, message, config):
                         for entity in result["entities"]:
                             entity_name = entity["entity"]
                             if "role" in entity:
-                                entity_name = entity["entity"]+"_"+entity["role"]
+                                entity_name = entity["entity"] + "_" + entity["role"]
                             if "confidence_entity" in entity:
                                 message.update_entity(
                                     entity_name,

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -262,8 +262,11 @@ class TestParserRasaNLU(asynctest.TestCase):
                 opsdroid, opsdroid.skills, message, opsdroid.config["parsers"][0]
             )
 
-            print(skill["message"].entities.keys())
             self.assertEqual(len(skill["message"].entities.keys()), 2)
+            self.assertTrue("city_departure" in skill["message"].entities.keys())
+            self.assertTrue("city_destination" in skill["message"].entities.keys())
+            self.assertEqual(skill["message"].entities["city_departure"]["value"], "Berlin")
+            self.assertEqual(skill["message"].entities["city_destination"]["value"], "San Fransisco")
 
     async def test_parse_rasanlu_raises(self):
         with OpsDroid() as opsdroid:

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -242,7 +242,7 @@ class TestParserRasaNLU(asynctest.TestCase):
                         "role": "departure",
                         "confidence_role": 0.9610307812690735,
                         "value": "Berlin",
-                        "extractor": "DIETClassifier"
+                        "extractor": "DIETClassifier",
                     },
                     {
                         "entity": "city",
@@ -252,10 +252,20 @@ class TestParserRasaNLU(asynctest.TestCase):
                         "role": "destination",
                         "confidence_role": 0.8198645114898682,
                         "value": "San Fransisco",
-                        "extractor": "DIETClassifier"
-                    }
+                        "extractor": "DIETClassifier",
+                    },
                 ],
-                "text_tokens": [[0, 1], [2, 6], [7, 9], [10, 16], [17, 21], [22, 28], [29, 31], [32, 35], [36, 45]]
+                "text_tokens": [
+                    [0, 1],
+                    [2, 6],
+                    [7, 9],
+                    [10, 16],
+                    [17, 21],
+                    [22, 28],
+                    [29, 31],
+                    [32, 35],
+                    [36, 45],
+                ],
             }
 
             [skill] = await rasanlu.parse_rasanlu(
@@ -265,8 +275,12 @@ class TestParserRasaNLU(asynctest.TestCase):
             self.assertEqual(len(skill["message"].entities.keys()), 2)
             self.assertTrue("city_departure" in skill["message"].entities.keys())
             self.assertTrue("city_destination" in skill["message"].entities.keys())
-            self.assertEqual(skill["message"].entities["city_departure"]["value"], "Berlin")
-            self.assertEqual(skill["message"].entities["city_destination"]["value"], "San Fransisco")
+            self.assertEqual(
+                skill["message"].entities["city_departure"]["value"], "Berlin"
+            )
+            self.assertEqual(
+                skill["message"].entities["city_destination"]["value"], "San Fransisco"
+            )
 
     async def test_parse_rasanlu_raises(self):
         with OpsDroid() as opsdroid:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Rasa 3.x introduced a [new feature of entity grouping using roles and groups](https://learning.rasa.com/conversational-ai-with-rasa/entities/#roles-and-groups). Because the entity names are the same and the resulting structure is a dictionary it's not possible to create duplicated in the resulting structure. This PR is concatenating entity name and role to create a unique key for this dictionary. 

This PR is only addresses the entity grouping using roles (not groups).

Fixes #1959 


## Status

**READY**
<!-- | **ON HOLD** | **UNDER DEVELOPMENT**-->


## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Local test with Rasa 3.3.3-full Docker image
- Unit tests


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
