### PR TITLE
Fix CI: increase the timeout to allow MacOS test to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           PLATFORM: ${{ runner.os }}
         run: tox -vv
-        timeout-minutes: 20
+        timeout-minutes: 30
       - name: Upload coverage report
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Seem the the CI step for testing on the latest macos is always failing due to timeout (20min)


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Running the CI pipeline


# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
