### PR TITLE
rasanlu: Don't encode intents to ascii

### DIFF
--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -31,7 +31,7 @@ async def _get_all_intents(skills):
     if not intents:
         return None
     intents = "\n\n".join(intents)
-    return unicodedata.normalize("NFKD", intents).encode("ascii")
+    return unicodedata.normalize("NFKD", intents)
 
 
 async def _get_intents_fingerprint(intents):

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -411,8 +411,8 @@ class TestParserRasaNLU(asynctest.TestCase):
         skills[1] = {"intents": None}
         skills[2] = {"intents": "World"}
         intents = await rasanlu._get_all_intents(skills)
-        self.assertEqual(type(intents), type(b""))
-        self.assertEqual(intents, b"Hello\n\nWorld")
+        self.assertEqual(type(intents), type(""))
+        self.assertEqual(intents, "Hello\n\nWorld")
 
     async def test__get_all_intents_fails(self):
         skills = []


### PR DESCRIPTION
# Description

Seem that Rasa (< 2) didn't support models in unicode. Now it does.
This change enables multi language support for rasanlu parser.

Fixes #1968


## Status
**READY**
<!--| **UNDER DEVELOPMENT** | **ON HOLD**-->


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Local test using Rasa 3.3.3-full Docker container


# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
