### PR TITLE
rasanlu: return a proper error when Rasa is not reachable

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -361,7 +361,10 @@ class OpsDroid:
                     rasanlu
                 )
                 if rasa_version_is_compatible is False:
-                    self.critical("Rasa version is not compatible", 5)
+                    self.critical(
+                        "Cannot connect to Rasa or the Rasa version is not compatible",
+                        5,
+                    )
                 await train_rasanlu(rasanlu, skills)
 
     async def setup_connectors(self, connectors):

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -30,7 +30,7 @@ from opsdroid.parsers.parseformat import parse_format
 from opsdroid.parsers.rasanlu import (
     parse_rasanlu,
     train_rasanlu,
-    has_compatible_version_rasanlu,
+    rasa_usable,
 )
 from opsdroid.parsers.regex import parse_regex
 from opsdroid.parsers.sapcai import parse_sapcai
@@ -357,12 +357,9 @@ class OpsDroid:
             parsers = self.modules.get("parsers", {})
             rasanlu = get_parser_config("rasanlu", parsers)
             if rasanlu and rasanlu["enabled"]:
-                rasa_version_is_compatible = await has_compatible_version_rasanlu(
-                    rasanlu
-                )
-                if rasa_version_is_compatible is False:
+                if await rasa_usable(rasanlu) is False:
                     self.critical(
-                        "Cannot connect to Rasa or the Rasa version is not compatible",
+                        "Cannot connect to Rasa or the Rasa version is not compatible.",
                         5,
                     )
                 await train_rasanlu(rasanlu, skills)

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -98,6 +98,8 @@ async def has_compatible_version_rasanlu(config):
     """Check if Rasa NLU is compatible with the API we implement"""
     _LOGGER.debug(_("Checking Rasa NLU version."))
     json_object = await _get_rasa_nlu_version(config)
+    if json_object is None:
+        return False
     version = json_object["version"]
     minimum_compatible_version = json_object["minimum_compatible_version"]
     # Make sure we don't run against a 1.x.x Rasa NLU because it has a different API

--- a/opsdroid/parsers/rasanlu.py
+++ b/opsdroid/parsers/rasanlu.py
@@ -94,8 +94,8 @@ async def _get_rasa_nlu_version(config):
         return result
 
 
-async def has_compatible_version_rasanlu(config):
-    """Check if Rasa NLU is compatible with the API we implement"""
+async def rasa_usable(config):
+    """Check if can connect to Rasa NLU and the version is compatible with the API we implement"""
     _LOGGER.debug(_("Checking Rasa NLU version."))
     json_object = await _get_rasa_nlu_version(config)
     if json_object is None:

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -499,28 +499,28 @@ class TestParserRasaNLU(asynctest.TestCase):
                 await rasanlu._get_rasa_nlu_version({}), result.text.return_value
             )
 
-    async def test_has_compatible_version_rasanlu(self):
+    async def test_rasa_usable(self):
         with amock.patch.object(rasanlu, "_get_rasa_nlu_version") as mock_crc:
             mock_crc.return_value = {
                 "version": "1.0.0",
                 "minimum_compatible_version": "1.0.0",
             }
-            self.assertEqual(await rasanlu.has_compatible_version_rasanlu({}), False)
+            self.assertEqual(await rasanlu.rasa_usable({}), False)
 
             mock_crc.return_value = {
                 "version": "2.6.2",
                 "minimum_compatible_version": "2.6.0",
             }
-            self.assertEqual(await rasanlu.has_compatible_version_rasanlu({}), True)
+            self.assertEqual(await rasanlu.rasa_usable({}), True)
 
             mock_crc.return_value = {
                 "version": "3.1.2",
                 "minimum_compatible_version": "3.0.0",
             }
-            self.assertEqual(await rasanlu.has_compatible_version_rasanlu({}), True)
+            self.assertEqual(await rasanlu.rasa_usable({}), True)
 
             mock_crc.return_value = None
-            self.assertEqual(await rasanlu.has_compatible_version_rasanlu({}), False)
+            self.assertEqual(await rasanlu.rasa_usable({}), False)
 
     async def test__load_model(self):
         with amock.patch("aiohttp.ClientSession.put") as patched_request:
@@ -632,7 +632,7 @@ class TestParserRasaNLU(asynctest.TestCase):
         ) as mock_btu, amock.patch.object(
             rasanlu, "_get_intents_fingerprint"
         ) as mock_gif, amock.patch.object(
-            rasanlu, "has_compatible_version_rasanlu"
+            rasanlu, "rasa_usable"
         ) as mock_crc, amock.patch.object(
             rasanlu, "_load_model"
         ) as mock_lmo, amock.patch.object(
@@ -706,7 +706,7 @@ class TestParserRasaNLU(asynctest.TestCase):
         ) as mock_btu, amock.patch.object(
             rasanlu, "_get_intents_fingerprint"
         ) as mock_gif, amock.patch.object(
-            rasanlu, "has_compatible_version_rasanlu"
+            rasanlu, "rasa_usable"
         ) as mock_crc, amock.patch.object(
             rasanlu, "_load_model"
         ) as mock_lmo, amock.patch.object(

--- a/tests/test_parser_rasanlu.py
+++ b/tests/test_parser_rasanlu.py
@@ -519,6 +519,9 @@ class TestParserRasaNLU(asynctest.TestCase):
             }
             self.assertEqual(await rasanlu.has_compatible_version_rasanlu({}), True)
 
+            mock_crc.return_value = None
+            self.assertEqual(await rasanlu.has_compatible_version_rasanlu({}), False)
+
     async def test__load_model(self):
         with amock.patch("aiohttp.ClientSession.put") as patched_request:
             result = amock.Mock()


### PR DESCRIPTION
# Description

Adds a condition to check if Rasa version is returned.
This makes sure a user gets a proper error when Rasa is not reachable instead of a track trace.

Fixes #1970


## Status
**READY** 

<!--| **UNDER DEVELOPMENT** | **ON HOLD**-->


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Local machine
- Unit tests


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
