### PR TITLE
CI: fix Tox docker run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,53 +7,6 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install libolm
-        if: runner.os != 'Windows'
-        run: |
-          if [ $RUNNER_OS = Linux ]; then
-              sudo apt install libolm3 libolm-dev -y
-          else
-              brew install libolm
-          fi
-      - name: Install ffmpeg on Ubuntu
-        if: runner.os != 'Windows'
-        run: |
-          if [ $RUNNER_OS = Linux ]; then
-              sudo apt update || true
-              sudo apt install ffmpeg -y
-          fi
-      - name: Install ffmpeg on windows
-        if: runner.os == 'Windows'
-        run: |
-              choco feature enable -n=allowGlobalConfirmation
-              choco install ffmpeg
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -U tox tox-gh-actions
-      - name: Run tests
-        env:
-          PLATFORM: ${{ runner.os }}
-        run: tox -vv
-        timeout-minutes: 30
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./cov.xml
-
   check:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,53 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install libolm
+        if: runner.os != 'Windows'
+        run: |
+          if [ $RUNNER_OS = Linux ]; then
+              sudo apt install libolm3 libolm-dev -y
+          else
+              brew install libolm
+          fi
+      - name: Install ffmpeg on Ubuntu
+        if: runner.os != 'Windows'
+        run: |
+          if [ $RUNNER_OS = Linux ]; then
+              sudo apt update || true
+              sudo apt install ffmpeg -y
+          fi
+      - name: Install ffmpeg on windows
+        if: runner.os == 'Windows'
+        run: |
+              choco feature enable -n=allowGlobalConfirmation
+              choco install ffmpeg
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -U tox tox-gh-actions
+      - name: Run tests
+        env:
+          PLATFORM: ${{ runner.os }}
+        run: tox -vv
+        timeout-minutes: 30
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./cov.xml
+
   check:
     runs-on: ubuntu-20.04
     strategy:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docker-{full,min}
+envlist = py{37,38,39,310}{,-e2e,-noe2e}, lint, docker-{full,min}
 skip_missing_interpreters = True
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,7 @@ allowlist_externals =
 commands =
      min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
      full: docker build -t opsdroid-image:tmp .
-     bash -c 'echo "Running test Docker container..."'
-     docker run -it -d --name opsdroid-container opsdroid-image:tmp
+     bash -c 'docker run -it -d --name opsdroid-container opsdroid-image:tmp'
      sleep 10
      docker exec --user root opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"
      docker logs opsdroid-container

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ allowlist_externals =
 commands =
     min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
     full: docker build -t opsdroid-image:tmp .
-    docker container run -d --name opsdroid-container opsdroid-image:tmp
+    bash -c 'docker container run -d --name opsdroid-container opsdroid-image:tmp'
     bash -c 'echo "Waiting for the container to start..."; until eval "docker inspect -f {{.State.Running}} opsdroid-container"; do sleep 1; done'
     bash -c 'echo "Installing curl in the container..."; docker exec --user root opsdroid-container sh -c "apk add --no-cache curl"'
     bash -c 'echo "Waiting until curl is succesfull..."; until eval "docker exec --user root opsdroid-container sh -c \"curl -sSf http://localhost:8080/ || exit 1\""; do sleep 1; done'

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
     min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
     full: docker build -t opsdroid-image:tmp .
     bash -c 'docker container run -d --name opsdroid-container opsdroid-image:tmp'
-    bash -c 'echo "Waiting for the container to start..."; until eval "docker inspect -f {{.State.Running}} opsdroid-container"; do sleep 1; done'
+    bash -c 'echo "Waiting for the container to start..."; until eval "docker inspect -f \{\{.State.Running\}\} opsdroid-container"; do sleep 1; done'
     bash -c 'echo "Installing curl in the container..."; docker exec --user root opsdroid-container sh -c "apk add --no-cache curl"'
     bash -c 'echo "Waiting until curl is succesfull..."; until eval "docker exec --user root opsdroid-container sh -c \"curl -sSf http://localhost:8080/ || exit 1\""; do sleep 1; done'
     docker logs opsdroid-container

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ allowlist_externals =
 commands =
      min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
      full: docker build -t opsdroid-image:tmp .
+     echo "Running test Docker container..."
      docker run -it -d --name opsdroid-container opsdroid-image:tmp
      sleep 10
      docker exec --user root opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"

--- a/tox.ini
+++ b/tox.ini
@@ -32,11 +32,12 @@ skip_install = true
 ignore_errors = True
 allowlist_externals =
     docker
+    docker continer run
     bash
 commands =
     min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
     full: docker build -t opsdroid-image:tmp .
-    bash -c 'docker container run -d --name opsdroid-container opsdroid-image:tmp'
+    docker container run -d --name opsdroid-container opsdroid-image:tmp
     bash -c 'echo "Waiting for the container to start..."; until eval "docker inspect -f {{.State.Running}} opsdroid-container"; do sleep 1; done'
     bash -c 'echo "Installing curl in the container..."; docker exec --user root opsdroid-container sh -c "apk add --no-cache curl"'
     bash -c 'echo "Waiting until curl is succesfull..."; until eval "docker exec --user root opsdroid-container sh -c \"curl -sSf http://localhost:8080/ || exit 1\""; do sleep 1; done'

--- a/tox.ini
+++ b/tox.ini
@@ -32,12 +32,11 @@ skip_install = true
 ignore_errors = True
 allowlist_externals =
     docker
-    docker continer run
     bash
 commands =
     min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
     full: docker build -t opsdroid-image:tmp .
-    docker container run -d --name opsdroid-container opsdroid-image:tmp
+    bash -c 'docker container run -d --name opsdroid-container opsdroid-image:tmp'
     bash -c 'echo "Waiting for the container to start..."; until eval "docker inspect -f {{.State.Running}} opsdroid-container"; do sleep 1; done'
     bash -c 'echo "Installing curl in the container..."; docker exec --user root opsdroid-container sh -c "apk add --no-cache curl"'
     bash -c 'echo "Waiting until curl is succesfull..."; until eval "docker exec --user root opsdroid-container sh -c \"curl -sSf http://localhost:8080/ || exit 1\""; do sleep 1; done'

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ allowlist_externals =
 commands =
      min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
      full: docker build -t opsdroid-image:tmp .
-     echo "Running test Docker container..."
+     bash -c 'echo "Running test Docker container..."'
      docker run -it -d --name opsdroid-container opsdroid-image:tmp
      sleep 10
      docker exec --user root opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}{,-e2e,-noe2e}, lint, docker-{full,min}
+envlist = docker-{full,min}
 skip_missing_interpreters = True
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -33,17 +33,17 @@ ignore_errors = True
 allowlist_externals =
     docker
     bash
-    sleep
 commands =
-     min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
-     full: docker build -t opsdroid-image:tmp .
-     bash -c 'docker run -it -d --name opsdroid-container opsdroid-image:tmp'
-     sleep 10
-     docker exec --user root opsdroid-container sh -c "apk add --no-cache curl && curl -sSf http://localhost:8080/ || exit 1"
-     docker logs opsdroid-container
-     docker stop opsdroid-container
-     docker rm opsdroid-container
-     docker rmi opsdroid-image:tmp
+    min: docker build --build-arg EXTRAS= -t opsdroid-image:tmp .
+    full: docker build -t opsdroid-image:tmp .
+    docker container run -d --name opsdroid-container opsdroid-image:tmp
+    bash -c 'echo "Waiting for the container to start..."; until eval "docker inspect -f {{.State.Running}} opsdroid-container"; do sleep 1; done'
+    bash -c 'echo "Installing curl in the container..."; docker exec --user root opsdroid-container sh -c "apk add --no-cache curl"'
+    bash -c 'echo "Waiting until curl is succesfull..."; until eval "docker exec --user root opsdroid-container sh -c \"curl -sSf http://localhost:8080/ || exit 1\""; do sleep 1; done'
+    docker logs opsdroid-container
+    docker stop opsdroid-container
+    docker rm opsdroid-container
+    docker rmi opsdroid-image:tmp
 
 [testenv:docs]
 basepython = python3.8


### PR DESCRIPTION
# Description

Seem that Tox has a problem running `docker run` directly form the commands section. Unfortunately I didn't find the reason why. So I replaced it with a `bash -c ..` command.
Also I reworked the section after the `docker run`. Now the logic would wait until container is running instead. This will compensate if the container starts longer than 10 seconds.

## Status
**READY** <!--| **UNDER DEVELOPMENT** | **ON HOLD**-->


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- CI pipline is 🟢 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
