### PR TITLE
Update Python and Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-alpine3.14 as builder
+FROM python:3.9.16-alpine3.16 as builder
 LABEL maintainer="Jacob Tomlinson <jacob@tomlinson.email>"
 
 WORKDIR /usr/src/app


### PR DESCRIPTION

# Description

Fixes security holes in Python and Alpine base image and updates base before EOL.

- From Python 3.9.6 to 3.9.16, there are many security holes patched as well as bugfixes.
- Alpine 3.16 is the previous stable release (current is 3.17), but the latest stable release introduces some major changes, such as OpenSSL 3.0, so more testing is suggested. Using 3.16 patches some security holes, and moves up the timeline of support, as 3.14 will reach EOL later this year.

## Status
**READY**

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- Built container locally
- Ran opsdroid from new container (Slack connector, `ping` skill)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
