### PR TITLE
Fix configuration sample entry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -590,7 +590,7 @@ Set `no-dep` to true to skip the installation of dependencies on every start of 
 skills:
   myawesomeskill:
     no-cache: true
-    no-deps: true
+    no-dep: true
 ```
 
 _Note: This might be useful when developing a skill and already have the dependencies installed._


### PR DESCRIPTION
# Description

The documentation above (and the code https://github.com/opsdroid/opsdroid/blob/d7c754b285cf01d607fb5f0cf4456f51740c44cb/opsdroid/loader.py#L566-L572) say to use `no-dep`, but the example line shows `no-deps`.

Fixes example to say `no-dep` instead of `no-deps`


## Status
**READY** 


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested using `no-deps` option; still installed deps failed. Switched to `no-dep`: no deps installed.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
