### PR TITLE
Report unhandled exceptions as warnings

### DIFF
--- a/opsdroid/connector/matrix/tests/test_connector_connect.py
+++ b/opsdroid/connector/matrix/tests/test_connector_connect.py
@@ -22,6 +22,7 @@ async def test_connect_access_token(
     assert isinstance(connector, ConnectorMatrix)
     assert connector.access_token == "token"
     await connector.connect()
+    await connector.disconnect()
 
     assert mock_api.called("/_matrix/client/r0/account/whoami")
     assert (
@@ -47,6 +48,7 @@ async def test_connect_invalid_access_token(caplog, opsdroid, connector, mock_ap
     assert isinstance(connector, ConnectorMatrix)
     assert connector.access_token == "token"
     await connector.connect()
+    await connector.disconnect()
 
     assert mock_api.called("/_matrix/client/r0/account/whoami")
 
@@ -75,6 +77,7 @@ async def test_connect_login(
 ):
     assert isinstance(connector, ConnectorMatrix)
     await connector.connect()
+    await connector.disconnect()
 
     assert mock_api.called("/_matrix/client/r0/login")
     assert (
@@ -97,6 +100,7 @@ async def test_connect_login(
 async def test_connect_login_error(caplog, opsdroid, connector, mock_api):
     assert isinstance(connector, ConnectorMatrix)
     await connector.connect()
+    await connector.disconnect()
 
     assert mock_api.called("/_matrix/client/r0/login")
 
@@ -126,6 +130,7 @@ async def test_connect_join_fail(
     assert isinstance(connector, ConnectorMatrix)
     assert connector.access_token == "token"
     await connector.connect()
+    await connector.disconnect()
 
     assert caplog.record_tuples == [
         (
@@ -156,6 +161,7 @@ async def test_connect_set_nick_errors(
     caplog,
 ):
     await connector.connect()
+    await connector.disconnect()
 
     assert caplog.record_tuples == [
         (
@@ -194,6 +200,8 @@ async def test_connect_set_nick(
     mock_api,
 ):
     await connector.connect()
+    await connector.disconnect()
+
     assert mock_api.called(
         "/_matrix/client/r0/profile/@opsdroid:localhost/displayname", "GET"
     )

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -147,7 +147,9 @@ class OpsDroid:
             context (String): Describes the exception encountered.
 
         """
-        warnings.warn("ERROR: Unhandled exception in opsdroid, exiting...", stacklevel=2)
+        warnings.warn(
+            "ERROR: Unhandled exception in opsdroid, exiting...", stacklevel=2
+        )
         if "future" in context:
             try:  # pragma: nocover
                 context["future"].result()

--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -8,6 +8,7 @@ import logging
 import os
 import signal
 import sys
+import warnings
 import weakref
 
 from watchgod import PythonWatcher, awatch
@@ -146,14 +147,14 @@ class OpsDroid:
             context (String): Describes the exception encountered.
 
         """
-        print("ERROR: Unhandled exception in opsdroid, exiting...")
+        warnings.warn("ERROR: Unhandled exception in opsdroid, exiting...", stacklevel=2)
         if "future" in context:
             try:  # pragma: nocover
                 context["future"].result()
             # pylint: disable=broad-except
-            except Exception:  # pragma: nocover
-                print("Caught exception")
-        print(context)
+            except Exception as e:  # pragma: nocover
+                warnings.warn("Caught exception", stacklevel=2, source=e)
+        warnings.warn(context, stacklevel=2)
 
     def is_running(self):
         """Check whether opsdroid is running."""


### PR DESCRIPTION
# Description

I was debugging some test issues and discovered there are a number of exceptions being silently absorbed when pytest runs. It looks like some of these exceptions are interrupting expected cleanups and socket closures here and there.

This change reports them as warnings, so pytest will summarize them.

## Status
**READY** | **ON HOLD**


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

- I ran pytest and casually observed new warnings output.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
