### PR TITLE
Allow removal of Matrix messages

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -687,3 +687,10 @@ class ConnectorMatrix(Connector):
             event.content,
             ignore_unverified_devices=self._ignore_unverified,
         )
+
+    @register_event(events.DeleteMessage)
+    @ensure_room_id_and_send
+    async def _remove_messsage(self, event):
+        return await self.connection.room_redact(
+            event.target, event.linked_event.event_id, event.reason
+        )

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -284,6 +284,9 @@ class Message(Event):
 
         return await super().respond(response)
 
+    async def remove(self, reason):
+        return await super().respond(DeleteMessage(reason, linked_event=self))
+
 
 class EditedMessage(Message):
     """A  `opsdroid.events.Message` which has been edited.
@@ -546,6 +549,10 @@ class UnpinMessage(Event):
 
 class DeleteMessage(Event):
     """Event to represent deleting a message or other event."""
+
+    def __init__(self, reason, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reason = reason
 
 
 class BanUser(Event):

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -550,7 +550,7 @@ class UnpinMessage(Event):
 class DeleteMessage(Event):
     """Event to represent deleting a message or other event."""
 
-    def __init__(self, reason, *args, **kwargs):
+    def __init__(self, reason=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.reason = reason
 

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -285,7 +285,7 @@ class Message(Event):
         return await super().respond(response)
 
     async def remove(self, reason=None):
-        return await super().respond(DeleteMessage(reason, linked_event=self))
+        return await self.respond(DeleteMessage(reason, linked_event=self))
 
 
 class EditedMessage(Message):

--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -284,7 +284,7 @@ class Message(Event):
 
         return await super().respond(response)
 
-    async def remove(self, reason):
+    async def remove(self, reason=None):
         return await super().respond(DeleteMessage(reason, linked_event=self))
 
 


### PR DESCRIPTION

# Description

Added remove method to the Message event class, and function in the Matrix connector.py using this method.
Example use:

    class UnpongSkill(Skill):

    @match_regex(r"pong")
    async def unpong(self, event):
        await event.remove()

is a skill that automatically redacts any 'pong' message sent in the room.
For this to work the bot must have the privileges to remove the requested message.

Addresses #1899

## Status
**READY** 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update(?)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- manually tested in private Matrix room
- ran tox; only tests that failed were unrelated to changes.


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
