### PR TITLE
Handling Closed Connections

### DIFF
--- a/opsdroid/connector/websocket/__init__.py
+++ b/opsdroid/connector/websocket/__init__.py
@@ -180,7 +180,16 @@ class ConnectorWebsocket(Connector):
         """Respond with a message."""
         try:
             if message.target is None:
-                message.target = next(iter(self.active_connections))
+                #message.target = next(iter(self.active_connections))
+                open_connections = [conn for conn in self.active_connections.values() if not conn.closed]
+                if open_connections:
+                    message.target = open_connections[0]
+                else:
+                    # Handle the case where no open connections are available
+                    message.target = None  # or raise an appropriate exception
+                    # When a connection is closed, remove it from active_connections
+                if connection in self.active_connections:
+                    del self.active_connections[connection]
             _LOGGER.debug(
                 _("Responding with: '%s' in target %s"), message.text, message.target
             )


### PR DESCRIPTION
# Description

Instead of directly using next(iter(self.active_connections)), you should iterate through the active connections and remove any closed connections before selecting the target
This change will ensure that only open connections are considered for sending messages.
You should also make sure that when a connection is closed, it is properly removed from the active_connections dictionary. This should happen in the code where you handle connection closures.

Fixes #1933


## Status
 **UNDER DEVELOPMENT**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue
- 
# How Has This Been Tested?
Waiting for test result


# Checklist:
- [ ] I have performed a self-review of my own code

