### PR TITLE
Add support for multiple match regexs

### DIFF
--- a/opsdroid/events.py
+++ b/opsdroid/events.py
@@ -157,7 +157,7 @@ class Event(metaclass=EventMetaClass):
 
         return result
 
-    def update_entity(self, name, value, confidence=None):
+    def update_entity(self, name, value, confidence=None, append=False):
         """Add or update an entitiy.
 
         Adds or updates an entitiy entry for an event.
@@ -166,9 +166,27 @@ class Event(metaclass=EventMetaClass):
             name (string): Name of entity
             value (string): Value of entity
             confidence (float, optional): Confidence that entity is correct
+            append (bool, optional): Append the entity to a list with exisitng
+            entities of the same name. If False will replace the previous
+            entity.
 
         """
-        self.entities[name] = {"value": value, "confidence": confidence}
+        entity_dict = {"value": value, "confidence": confidence}
+        # Handle multiple matches:
+        if name in self.entities and append:
+            if isinstance(self.entities[name], dict):
+                new_entity = [self.entities[name], entity_dict]
+            elif isinstance(self.entities[name], list):
+                new_entity = self.entities[name] + [entity_dict]
+            else:
+                # We would only end up here if someone else has modified entities
+                raise ValueError(
+                    "Can't append a second entity to an existing entity"
+                    f" of type {type(self.entities[name])} with the same name."
+                )  # pragma: no cover
+        else:
+            new_entity = entity_dict
+        self.entities[name] = new_entity
 
     def get_entity(self, name):
         """Get the value of an entity by name.

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -26,7 +26,9 @@ async def match_regex(text, opts):
     elif opts["matching_condition"].lower() == "fullmatch":
         matched_regex = regex.fullmatch(opts["expression"], text, is_case_sensitive())
     elif opts["matching_condition"].lower() == "findall":
-        matched_regex = regex.finditer(opts["expression"], text, is_case_sensitive())
+        matched_regex = list(
+            regex.finditer(opts["expression"], text, is_case_sensitive())
+        )
     else:
         matched_regex = regex.match(opts["expression"], text, is_case_sensitive())
     return matched_regex

--- a/opsdroid/parsers/regex.py
+++ b/opsdroid/parsers/regex.py
@@ -25,6 +25,8 @@ async def match_regex(text, opts):
         matched_regex = regex.search(opts["expression"], text, is_case_sensitive())
     elif opts["matching_condition"].lower() == "fullmatch":
         matched_regex = regex.fullmatch(opts["expression"], text, is_case_sensitive())
+    elif opts["matching_condition"].lower() == "findall":
+        matched_regex = regex.finditer(opts["expression"], text, is_case_sensitive())
     else:
         matched_regex = regex.match(opts["expression"], text, is_case_sensitive())
     return matched_regex
@@ -40,8 +42,13 @@ async def parse_regex(opsdroid, skills, message):
                 matched_regex = await match_regex(message.text, opts)
                 if matched_regex:
                     message.regex = matched_regex
-                    for regroup, value in matched_regex.groupdict().items():
-                        message.update_entity(regroup, value, None)
+                    # If we have used findall then we have an iterable
+                    # if we haven't make it one so we can use the same codepath
+                    if opts["matching_condition"] != "findall":
+                        matched_regex = [matched_regex]
+                    for match in matched_regex:
+                        for regroup, value in match.groupdict().items():
+                            message.update_entity(regroup, value, None, append=True)
                     matched_skills.append(
                         {
                             "score": await calculate_score(

--- a/tests/test_parser_regex.py
+++ b/tests/test_parser_regex.py
@@ -164,3 +164,27 @@ class TestParserRegex(asynctest.TestCase):
             self.assertEqual(len(parsed_message.entities.keys()), 1)
             self.assertTrue("name" in parsed_message.entities.keys())
             self.assertEqual(parsed_message.entities["name"]["value"], "opsdroid")
+
+    async def test_parse_regex_findall(self):
+        with OpsDroid() as opsdroid:
+            regex = r"Hello (?P<name>\w+)|Hi (?P<name>\w+)"
+
+            mock_skill_named_groups = await self.getMockSkill()
+            opsdroid.skills.append(
+                match_regex(regex, matching_condition="findall")(
+                    mock_skill_named_groups
+                )
+            )
+
+            mock_connector = amock.CoroutineMock()
+            message = Message(
+                "Hi opsdroid, Hello world", "user", "default", mock_connector
+            )
+
+            [skill] = await opsdroid.get_ranked_skills(opsdroid.skills, message)
+            parsed_message = skill["message"]
+            self.assertEqual(len(parsed_message.entities.keys()), 1)
+            self.assertEqual(len(parsed_message.entities["name"]), 2)
+            self.assertTrue("name" in parsed_message.entities.keys())
+            self.assertEqual(parsed_message.entities["name"][0]["value"], "opsdroid")
+            self.assertEqual(parsed_message.entities["name"][1]["value"], "world")


### PR DESCRIPTION
# Description

This PR adds the option to use `regex.finditer` to find all matches in the message string.


## Status
**UNDER DEVELOPMENT**


## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
