### PR TITLE
configure web server to use TLS 1.2 protocol for ssl_context

### DIFF
--- a/opsdroid/web.py
+++ b/opsdroid/web.py
@@ -187,7 +187,7 @@ class Web:
         """
         try:
             ssl_config = self.config["ssl"]
-            sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
             sslcontext.load_cert_chain(ssl_config["cert"], ssl_config["key"])
             return sslcontext
         except FileNotFoundError:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Upgrades tls protocol for web server ssl_context from deprecated TLS v1.0 to TLS v1.2


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Created a web server instance using TLS v1.2 which correctly worked in opposition to tls v1.0 which was giving "curl: (35) error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol"


# Checklist:

- [/] I have performed a self-review of my own code
- [/] I have made corresponding changes to the documentation (if applicable)
- [/] I have added tests that prove my fix is effective or that my feature works
- [/] New and existing unit tests pass locally with my changes
