### PR TITLE
Relax coverage requirements

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,11 @@ ignore:
   - "opsdroid/_version.py"
   - "*/tests/*"
   - "opsdroid/testing/mockmodules/skills/broken_skill.py"
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90
+        threshold: 1%
+    patch: off

--- a/docs/maintaining/overview.md
+++ b/docs/maintaining/overview.md
@@ -21,7 +21,7 @@ As a maintainer one of the tasks that you have to take on will be reviewing pull
 **Criteria for merging a PR**
   - You didn't write it yourself
   - The [PR template](https://github.com/opsdroid/opsdroid/tree/master/.github/PULL_REQUEST_TEMPLATE.md) criteria are met (has tests, is documented, etc)
-  - The existing tests pass and coverage remains the same
+  - The existing tests pass and coverage remains roughly the same
   - It is related to an open issue
   - It moves us towards our [core aims](https://github.com/opsdroid/opsdroid/issues/1)
 


### PR DESCRIPTION
For a long time I insisted on maintaining 100% coverage here as a means of keeping things as maintainable as possible. My opinion on this has shifted in recent years and that last thing I want to encourage is bad tests for the sake of coverage.

This PR relaxes the CI checks a little to only insist on 90% coverage overall, and to allow for small drops in PRs.