### PR TITLE
Fix - matrix connector proxy config

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -3,6 +3,7 @@ import functools
 import json
 import logging
 import re
+import os
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -194,6 +195,7 @@ class ConnectorMatrix(Connector):
             config=config,
             store_path=self.store_path if self._allow_encryption else "",
             device_id=self.device_id,
+            proxy=os.environ.get('HTTPS_PROXY'),
         )
 
         if self.access_token is not None:

--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -195,7 +195,7 @@ class ConnectorMatrix(Connector):
             config=config,
             store_path=self.store_path if self._allow_encryption else "",
             device_id=self.device_id,
-            proxy=os.environ.get('HTTPS_PROXY'),
+            proxy=os.environ.get("HTTPS_PROXY"),
         )
 
         if self.access_token is not None:


### PR DESCRIPTION
# Description

Matrix connector doesn't support proxy config from ENV var like mattermost connector

Fixes n/a


## Status
**READY**


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Test matrix connection with proxy env var. Work as well


# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
