### PR TITLE
fixes #2005. Set notepad as default editor for windows

### DIFF
--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -44,10 +44,7 @@ def edit_config(ctx, path):
 
     """
     file = path or DEFAULT_CONFIG_PATH
-    if platform.system() == "Windows":
-        editor = os.environ.get("EDITOR", "notepad.exe")
-    else:
-        editor = os.environ.get("EDITOR", "vi")
+    editor = os.environ.get("EDITOR", "notepad.exe" if platform.system() == "Windows" else "vi")
 
     if editor == "vi":
         click.echo(

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import time
+import platform
 
 import click
 from opsdroid.configuration import load_config_file
@@ -43,7 +44,10 @@ def edit_config(ctx, path):
 
     """
     file = path or DEFAULT_CONFIG_PATH
-    editor = os.environ.get("EDITOR", "vi")
+    if platform.system() == "Windows":
+        editor = os.environ.get("EDITOR", "notepad.exe")
+    else:
+        editor = os.environ.get("EDITOR", "vi")
 
     if editor == "vi":
         click.echo(

--- a/opsdroid/cli/utils.py
+++ b/opsdroid/cli/utils.py
@@ -44,7 +44,9 @@ def edit_config(ctx, path):
 
     """
     file = path or DEFAULT_CONFIG_PATH
-    editor = os.environ.get("EDITOR", "notepad.exe" if platform.system() == "Windows" else "vi")
+    editor = os.environ.get(
+        "EDITOR", "notepad.exe" if platform.system() == "Windows" else "vi"
+    )
 
     if editor == "vi":
         click.echo(


### PR DESCRIPTION
# Description
Per @jacobtomlinson's recommendation in #2005 setting a default editor for windows instead defaulting to vim. Notepad was selected as default editor. 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2005 


## Status
**READY** 


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Tested by running on local environment. 



# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
