### PR TITLE
Mattermost bots can respond in a thread

### DIFF
--- a/docs/connectors/mattermost.md
+++ b/docs/connectors/mattermost.md
@@ -22,6 +22,9 @@ connectors:
     scheme: "http" # default: https
     port: 8065 # default: 8065
     connect-timeout: 30 # default: 30
+
+    # Mattermost should always respond in a thread:
+    use-threads: True # default: False
 ```
 
 ## Usage


### PR DESCRIPTION
Can be activated through the connector config; fixes #2052

# Description

If the Mattermost connector is configured with "use-threads" `True` (default is `False`, which is identical to the previous behavior), the bot will
1. create a new thread with the response if the message was a top level message
2. respond in the existing thread

## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

Unit Tests were extended. Is also running on our Mattermost test server and behaves as intended.


# Checklist:

- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
