### PR TITLE
Mattermost Connector: Optional setting to process messages that receive specific emoji reactions

### DIFF
--- a/docs/connectors/mattermost.md
+++ b/docs/connectors/mattermost.md
@@ -23,8 +23,11 @@ connectors:
     port: 8065 # default: 8065
     connect-timeout: 30 # default: 30
 
-    # Mattermost should always respond in a thread:
+    # OpsDroid should always respond in a thread:
     use-threads: True # default: False
+
+    # OpsDroid should parse messages that have received this emoji
+    emoji-trigger: "opsdroid-emoji" # default: None
 ```
 
 ## Usage

--- a/opsdroid/connector/mattermost/endpoints/base.py
+++ b/opsdroid/connector/mattermost/endpoints/base.py
@@ -1,10 +1,20 @@
-from aiohttp.client import ClientSession
+from aiohttp.client import ClientSession, ClientResponse
+from asyncio import Task
 
 
 class Base:
     def __init__(self, client: ClientSession, base_url: str):
         self._internal_client = client
         self._base_url = base_url
+
+    def create_future(self, func) -> Task[ClientResponse]:
+        """
+        Wraps a function to be called in the event loop.
+
+        :param func: Function to be called
+        :return: Future object
+        """
+        return self._internal_client.loop.create_task(func)
 
     def get(self, path, **kwargs):
         return self._internal_client.get(

--- a/opsdroid/connector/mattermost/endpoints/channels.py
+++ b/opsdroid/connector/mattermost/endpoints/channels.py
@@ -14,5 +14,10 @@ class Channels(Base):
         )
 
         return self.get(
-            Teams.endpoint + "/name/" + team_name + "/channels/name/" + channel_name
+            f"{Teams.endpoint}/name/{team_name}/channels/name/{channel_name}"
         )
+
+    def get_channel_by_id(self, channel_id):
+        _LOGGER.debug("Querying channel for ID '%s'", channel_id)
+
+        return self.get(f"{self.endpoint}/{channel_id}")

--- a/opsdroid/connector/mattermost/endpoints/posts.py
+++ b/opsdroid/connector/mattermost/endpoints/posts.py
@@ -10,3 +10,7 @@ class Posts(Base):
     def create_post(self, json):
         _LOGGER.debug("Sending post with payload '%s'", repr(json))
         return self.post(self.endpoint, json=json)
+
+    def get_post(self, post_id):
+        _LOGGER.debug("Getting post with id '%s'", repr(post_id))
+        return self.get(f"{self.endpoint}/{post_id}")

--- a/opsdroid/connector/mattermost/endpoints/users.py
+++ b/opsdroid/connector/mattermost/endpoints/users.py
@@ -5,4 +5,4 @@ class Users(Base):
     endpoint = "/users"
 
     def get_user(self, user_id):
-        return self.get(self.endpoint + "/" + user_id)
+        return self.get(f"{self.endpoint}/{user_id}")

--- a/opsdroid/connector/mattermost/tests/responses/channels.789.success.json
+++ b/opsdroid/connector/mattermost/tests/responses/channels.789.success.json
@@ -1,0 +1,3 @@
+{
+    "name": "unit_test_channel_789"  
+}

--- a/opsdroid/connector/mattermost/tests/responses/posts.456.success.json
+++ b/opsdroid/connector/mattermost/tests/responses/posts.456.success.json
@@ -1,0 +1,3 @@
+{
+    "message": "Unit Test Message"
+}

--- a/opsdroid/connector/mattermost/tests/responses/users.123.success.json
+++ b/opsdroid/connector/mattermost/tests/responses/users.123.success.json
@@ -1,0 +1,4 @@
+{
+    "id": "123",
+    "username": "Name for user 123"  
+}

--- a/opsdroid/connector/mattermost/tests/responses/websocket.reaction.success.json
+++ b/opsdroid/connector/mattermost/tests/responses/websocket.reaction.success.json
@@ -1,0 +1,9 @@
+{
+    "seq": 1,
+    "event": "reaction_added",
+    "data": {
+        "reaction": "{\"user_id\": \"123\", \"message\": \"Unit Test Message\", \"emoji_name\": \"emoji_test\", \"post_id\": \"456\", \"channel_id\": \"789\"}",
+        "sender_name": "Not the sender we want!",
+        "channel_name": "Unit Test Channel"
+    }
+}


### PR DESCRIPTION
# Description

It is a common pattern to have bots respond to messaged based on emoji reactions. For an example see issue:

fixes #2059


## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

Feature is running on our test server and reacts correctly to messages, mentions, and now emoji reactions.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
