### PR TITLE
docs: add example bye skill that responds to 'bye'

### DIFF
--- a/docs/examples/bye-skill.md
+++ b/docs/examples/bye-skill.md
@@ -1,0 +1,15 @@
+# Bye Skill
+
+This is a simple example showing how to build a skill in opsdroid that responds with "Goodbye!" when the user types "bye".
+
+## Skill Code
+
+```python
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
+
+class ByeSkill(Skill):
+
+    @match_regex(r'bye')
+    async def say_goodbye(self, message):
+        await message.respond("Goodbye!")

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -15,3 +15,5 @@ flip-a-coin
 stocks-portfolio
 contact-manager
 ```
+
+- [Bye Skill](bye-skill.md)

--- a/opsdroid-skills/skill-bye/__init__.py
+++ b/opsdroid-skills/skill-bye/__init__.py
@@ -1,0 +1,8 @@
+from opsdroid.skill import Skill
+from opsdroid.matchers import match_regex
+
+class ByeSkill(Skill):
+
+    @match_regex(r'bye')
+    async def say_goodbye(self, message):
+        await message.respond("Goodbye!")


### PR DESCRIPTION
Description
This PR adds a new example skill to the docs/examples section, showcasing how to create a simple skill that responds to the phrase "bye" with a goodbye message. This is intended to help beginners learn how to build basic skills with opsdroid using the @match_regex matcher.

No external dependencies are required.

Fixes #1198 (adds to it by contributing another example skill).

Status
READY

Type of change
 Bug fix (non-breaking change which fixes an issue)

 YES New feature (non-breaking change which adds functionality)

 Breaking change (fix or feature that would cause existing functionality to not work as expected)

 This change requires a documentation update

YES  Documentation (fix or adds documentation)

How Has This Been Tested?
This example is documentation-only and has not been tested via opsdroid start. It follows the same structure as existing examples and includes:

Skill implementation file in opsdroid-skills/skill-bye/__init__.py

Example walkthrough markdown file in docs/examples/bye-skill.md

Checklist:
 YES I have performed a self-review of my own code

 YES I have made corresponding changes to the documentation (if applicable)

 I have added tests that prove my fix is effective or that my feature works

 New and existing unit tests pass locally with my changes