### PR TITLE
Also catch LocalProtocolError for encryption errors

### DIFF
--- a/opsdroid/connector/matrix/connector.py
+++ b/opsdroid/connector/matrix/connector.py
@@ -313,7 +313,7 @@ class ConnectorMatrix(Connector):
                         if isinstance(event, nio.MegolmEvent):
                             try:  # pragma: no cover
                                 event = self.connection.decrypt_event(event)
-                            except nio.exceptions.EncryptionError:  # pragma: no cover
+                            except (nio.exceptions.EncryptionError, nio.exceptions.LocalProtocolError):  # pragma: no cover
                                 _LOGGER.exception(f"Failed to decrypt event {event}")
                         yield await self._event_creator.create_event(
                             event.source, roomid


### PR DESCRIPTION
# Description

It seems that nio has changed the error it reports if you don't have it setup to decrypt messages.


## Status
**READY**


## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

I tested it locally


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
